### PR TITLE
add wat-docs CLI for searching WAT instruction documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,11 @@ name = "wat-hover"
 path = "src/bin/wat-hover.rs"
 required-features = ["native"]
 
+[[bin]]
+name = "wat-docs"
+path = "src/bin/wat-docs.rs"
+required-features = ["native"]
+
 [features]
 default = ["native"]
 native = [

--- a/src/bin/wat-docs.rs
+++ b/src/bin/wat-docs.rs
@@ -1,0 +1,525 @@
+//! wat-docs: A CLI tool for searching and browsing WAT instruction documentation
+//!
+//! This tool provides access to WebAssembly instruction documentation and is designed
+//! to integrate with tools like fzf for interactive searching.
+//!
+//! # Examples
+//!
+//! List all instructions (pipe to fzf):
+//! ```sh
+//! wat-docs list | fzf --preview 'wat-docs show {}'
+//! ```
+//!
+//! Show documentation for a specific instruction:
+//! ```sh
+//! wat-docs show i32.add
+//! ```
+//!
+//! Search for instructions by name or content:
+//! ```sh
+//! wat-docs search memory
+//! ```
+
+use std::io::{self, IsTerminal, Write};
+use std::process::ExitCode;
+
+use clap::{Parser, Subcommand};
+
+use wat_lsp_rust::docs;
+use wat_lsp_rust::tree_sitter_bindings::create_parser;
+
+#[derive(Parser, Debug)]
+#[command(name = "wat-docs")]
+#[command(
+    author,
+    version,
+    about = "Search and browse WAT instruction documentation"
+)]
+#[command(
+    long_about = "A CLI tool for searching and browsing WebAssembly Text format instruction documentation.\n\n\
+    Designed to work with fzf for interactive searching:\n\n    \
+    wat-docs list | fzf --preview 'wat-docs show {}'"
+)]
+struct Args {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand, Debug)]
+enum Command {
+    /// List all instruction names (one per line, suitable for fzf)
+    List {
+        /// Filter instruction names containing this pattern
+        #[arg(short, long)]
+        filter: Option<String>,
+    },
+
+    /// Show documentation for a specific instruction
+    Show {
+        /// The instruction name (e.g., i32.add, memory.grow)
+        instruction: String,
+
+        /// Output raw markdown without formatting or highlighting
+        #[arg(short, long)]
+        raw: bool,
+
+        /// Disable syntax highlighting (use plain text)
+        #[arg(long)]
+        no_color: bool,
+
+        /// Force color output even when not a TTY (useful for piping to less -R)
+        #[arg(long)]
+        color: bool,
+    },
+
+    /// Search instructions by name or documentation content
+    Search {
+        /// Search pattern (case-insensitive substring match)
+        pattern: String,
+
+        /// Only search instruction names, not documentation content
+        #[arg(short, long)]
+        names_only: bool,
+
+        /// Show full documentation for each match
+        #[arg(short, long)]
+        full: bool,
+
+        /// Disable syntax highlighting
+        #[arg(long)]
+        no_color: bool,
+
+        /// Force color output even when not a TTY
+        #[arg(long)]
+        color: bool,
+    },
+
+    /// Output commands for shell integration (fzf aliases, etc.)
+    #[command(name = "shell-setup")]
+    ShellSetup {
+        /// Shell type
+        #[arg(value_enum)]
+        shell: ShellType,
+    },
+}
+
+#[derive(Debug, Clone, Copy, clap::ValueEnum)]
+enum ShellType {
+    Bash,
+    Zsh,
+    Fish,
+}
+
+/// ANSI escape codes for formatting
+mod ansi {
+    pub const RESET: &str = "\x1b[0m";
+    pub const BOLD: &str = "\x1b[1m";
+    pub const DIM: &str = "\x1b[2m";
+
+    // Colors
+    pub const GREEN: &str = "\x1b[32m";
+    pub const YELLOW: &str = "\x1b[33m";
+    pub const BLUE: &str = "\x1b[34m";
+    pub const MAGENTA: &str = "\x1b[35m";
+    pub const CYAN: &str = "\x1b[36m";
+
+    // Bright colors
+    pub const BRIGHT_RED: &str = "\x1b[91m";
+    pub const BRIGHT_CYAN: &str = "\x1b[96m";
+}
+
+struct Highlighter {
+    use_color: bool,
+}
+
+impl Highlighter {
+    fn new(use_color: bool) -> Self {
+        Self { use_color }
+    }
+
+    /// Render markdown documentation with syntax highlighting
+    fn render_doc(&self, title: &str, content: &str) -> String {
+        if !self.use_color {
+            return format!("## {}\n\n{}", title, content);
+        }
+
+        let mut output = String::new();
+
+        // Render title
+        output.push_str(&format!(
+            "{}{}## {}{}",
+            ansi::BOLD,
+            ansi::CYAN,
+            title,
+            ansi::RESET
+        ));
+        output.push_str("\n\n");
+
+        // Process content line by line, handling code blocks
+        let mut in_code_block = false;
+        let mut code_block_content = String::new();
+
+        for line in content.lines() {
+            let trimmed = line.trim();
+
+            if trimmed.starts_with("```") {
+                if in_code_block {
+                    // End of code block - highlight and output
+                    output.push_str(&self.highlight_wat_code(&code_block_content));
+                    output.push_str(&format!("{}{}{}\n", ansi::DIM, "```", ansi::RESET));
+                    code_block_content.clear();
+                    in_code_block = false;
+                } else {
+                    // Start of code block
+                    in_code_block = true;
+                    output.push_str(&format!("{}{}{}\n", ansi::DIM, trimmed, ansi::RESET));
+                }
+            } else if in_code_block {
+                code_block_content.push_str(line);
+                code_block_content.push('\n');
+            } else if let Some(rest) = trimmed.strip_prefix("Signature:") {
+                // Highlight signature line
+                output.push_str(&format!(
+                    "{}{}Signature:{}{}",
+                    ansi::BOLD,
+                    ansi::YELLOW,
+                    ansi::RESET,
+                    rest
+                ));
+                output.push('\n');
+            } else if trimmed.starts_with("Example:") {
+                output.push_str(&format!(
+                    "{}{}Example:{}",
+                    ansi::BOLD,
+                    ansi::GREEN,
+                    ansi::RESET
+                ));
+                output.push('\n');
+            } else {
+                output.push_str(line);
+                output.push('\n');
+            }
+        }
+
+        output
+    }
+
+    /// Highlight WAT code using tree-sitter for accurate parsing
+    fn highlight_wat_code(&self, code: &str) -> String {
+        let mut parser = create_parser();
+
+        let tree = match parser.parse(code, None) {
+            Some(t) => t,
+            None => return code.to_string(), // Fallback to plain text
+        };
+
+        let root = tree.root_node();
+
+        // Collect colored spans
+        let mut spans: Vec<(usize, usize, &str, &str)> = Vec::new(); // (start, end, color, reset)
+
+        self.collect_highlight_spans(&root, &mut spans);
+
+        // Sort spans by start position
+        spans.sort_by_key(|s| s.0);
+
+        // Build output with colors
+        let mut output = String::new();
+        let mut last_end = 0;
+
+        for (start, end, color, _) in &spans {
+            // Add any unhighlighted text before this span
+            if *start > last_end {
+                output.push_str(&code[last_end..*start]);
+            }
+
+            // Add highlighted text
+            if *start < code.len() && *end <= code.len() {
+                output.push_str(color);
+                output.push_str(&code[*start..*end]);
+                output.push_str(ansi::RESET);
+            }
+
+            last_end = *end;
+        }
+
+        // Add any remaining text
+        if last_end < code.len() {
+            output.push_str(&code[last_end..]);
+        }
+
+        output
+    }
+
+    fn collect_highlight_spans<'a>(
+        &self,
+        node: &tree_sitter::Node,
+        spans: &mut Vec<(usize, usize, &'a str, &'a str)>,
+    ) {
+        let kind = node.kind();
+        let start = node.start_byte();
+        let end = node.end_byte();
+
+        // Determine color based on node type
+        let color: Option<&str> = match kind {
+            // Comments - dim gray/italic
+            "comment_line" | "comment_block" => Some(ansi::DIM),
+
+            // Keywords - bold magenta
+            "module" | "func" | "param" | "result" | "local" | "global" | "memory" | "table"
+            | "export" | "import" | "type" | "elem" | "data" | "start" | "mut" | "offset"
+            | "item" => Some(ansi::MAGENTA),
+
+            // Control flow keywords - bold blue
+            "block" | "loop" | "if" | "then" | "else" | "end" | "br" | "br_if" | "br_table"
+            | "return" | "call" | "call_indirect" | "unreachable" | "nop" | "drop" | "select"
+            | "try" | "catch" | "catch_all" | "throw" | "rethrow" | "delegate" => Some(ansi::BLUE),
+
+            // Value types - cyan
+            "value_type" | "value_type_num_type" | "value_type_ref_type" => Some(ansi::CYAN),
+
+            // Numeric types - cyan
+            "num_type_i32" | "num_type_i64" | "num_type_f32" | "num_type_f64" | "num_type_v128" => {
+                Some(ansi::CYAN)
+            }
+
+            // Reference types
+            "ref_type" | "heap_type" => Some(ansi::CYAN),
+
+            // Identifiers/variables ($name) - yellow
+            "identifier" => Some(ansi::YELLOW),
+
+            // Numbers - bright red
+            "nat" | "int" | "float" | "dec_nat" | "hex_nat" | "dec_float" | "hex_float"
+            | "align_offset_value" => Some(ansi::BRIGHT_RED),
+
+            // Strings - green
+            "string" => Some(ansi::GREEN),
+
+            // Instructions - bright cyan for the instruction name
+            "instr_plain" | "op" => {
+                // For instructions, we want to color just the opcode
+                if node.child_count() == 0 {
+                    Some(ansi::BRIGHT_CYAN)
+                } else {
+                    None // Let children be colored
+                }
+            }
+
+            // Plain instruction names (opcodes)
+            s if s.starts_with("op_") => Some(ansi::BRIGHT_CYAN),
+
+            // Type names
+            "i32" | "i64" | "f32" | "f64" | "v128" | "funcref" | "externref" | "anyref"
+            | "eqref" | "i31ref" | "structref" | "arrayref" | "nullref" | "nullfuncref"
+            | "nullexternref" => Some(ansi::CYAN),
+
+            _ => None,
+        };
+
+        if let Some(c) = color {
+            // Only add leaf nodes or specific parent nodes
+            if node.child_count() == 0
+                || matches!(
+                    kind,
+                    "comment_line" | "comment_block" | "string" | "identifier"
+                )
+            {
+                spans.push((start, end, c, ansi::RESET));
+            }
+        }
+
+        // Recurse into children
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            self.collect_highlight_spans(&child, spans);
+        }
+    }
+
+    /// Render a separator line
+    fn render_separator(&self) -> String {
+        if self.use_color {
+            format!("\n{}---{}\n\n", ansi::DIM, ansi::RESET)
+        } else {
+            "\n---\n\n".to_string()
+        }
+    }
+}
+
+fn main() -> ExitCode {
+    let args = Args::parse();
+
+    match args.command {
+        Command::List { filter } => cmd_list(filter),
+        Command::Show {
+            instruction,
+            raw,
+            no_color,
+            color,
+        } => cmd_show(&instruction, raw, no_color, color),
+        Command::Search {
+            pattern,
+            names_only,
+            full,
+            no_color,
+            color,
+        } => cmd_search(&pattern, names_only, full, no_color, color),
+        Command::ShellSetup { shell } => cmd_shell_setup(shell),
+    }
+}
+
+fn cmd_list(filter: Option<String>) -> ExitCode {
+    let names = match &filter {
+        Some(pattern) => docs::search_instruction_names(pattern),
+        None => docs::instruction_names(),
+    };
+
+    for name in names {
+        println!("{}", name);
+    }
+
+    ExitCode::SUCCESS
+}
+
+fn should_use_color(no_color_flag: bool, force_color: bool) -> bool {
+    // --color forces color on
+    if force_color {
+        return true;
+    }
+    // --no-color forces color off
+    if no_color_flag {
+        return false;
+    }
+    // Check NO_COLOR env var (https://no-color.org/)
+    if std::env::var("NO_COLOR").is_ok() {
+        return false;
+    }
+    // Check if stdout is a terminal
+    io::stdout().is_terminal()
+}
+
+fn cmd_show(instruction: &str, raw: bool, no_color: bool, force_color: bool) -> ExitCode {
+    match docs::get_instruction_doc(instruction) {
+        Some(doc) => {
+            if raw {
+                println!("{}", doc);
+            } else {
+                let highlighter = Highlighter::new(should_use_color(no_color, force_color));
+                print!("{}", highlighter.render_doc(instruction, doc));
+                io::stdout().flush().ok();
+            }
+            ExitCode::SUCCESS
+        }
+        None => {
+            eprintln!("Unknown instruction: {}", instruction);
+            eprintln!();
+
+            // Suggest similar instructions
+            let suggestions = docs::search_instruction_names(instruction);
+            if !suggestions.is_empty() {
+                eprintln!("Did you mean one of these?");
+                for name in suggestions.iter().take(5) {
+                    eprintln!("  {}", name);
+                }
+            }
+
+            ExitCode::from(1)
+        }
+    }
+}
+
+fn cmd_search(
+    pattern: &str,
+    names_only: bool,
+    full: bool,
+    no_color: bool,
+    force_color: bool,
+) -> ExitCode {
+    if names_only {
+        let names = docs::search_instruction_names(pattern);
+        if names.is_empty() {
+            eprintln!("No instructions found matching '{}'", pattern);
+            return ExitCode::from(1);
+        }
+
+        for name in names {
+            println!("{}", name);
+        }
+    } else {
+        let results = docs::search_instructions(pattern);
+        if results.is_empty() {
+            eprintln!("No instructions found matching '{}'", pattern);
+            return ExitCode::from(1);
+        }
+
+        let highlighter = Highlighter::new(should_use_color(no_color, force_color));
+
+        for (name, doc) in results {
+            if full {
+                print!("{}", highlighter.render_doc(name, doc));
+                print!("{}", highlighter.render_separator());
+            } else {
+                // Show just the first line of documentation as a summary
+                let summary = doc.lines().next().unwrap_or("");
+                if highlighter.use_color {
+                    println!("{}{}{}: {}", ansi::BOLD, name, ansi::RESET, summary);
+                } else {
+                    println!("{}: {}", name, summary);
+                }
+            }
+        }
+        io::stdout().flush().ok();
+    }
+
+    ExitCode::SUCCESS
+}
+
+fn cmd_shell_setup(shell: ShellType) -> ExitCode {
+    match shell {
+        ShellType::Bash | ShellType::Zsh => {
+            println!(
+                r#"# WAT documentation browser with fzf
+# Add this to your .bashrc or .zshrc
+
+wat-browse() {{
+    local instruction
+    instruction=$(wat-docs list | fzf --preview 'wat-docs show {{}} --color' --preview-window=right:60%:wrap --ansi)
+    if [ -n "$instruction" ]; then
+        wat-docs show "$instruction"
+    fi
+}}
+
+# Search and browse
+wat-search() {{
+    local instruction
+    instruction=$(wat-docs search "$1" --names-only | fzf --preview 'wat-docs show {{}} --color' --preview-window=right:60%:wrap --ansi)
+    if [ -n "$instruction" ]; then
+        wat-docs show "$instruction"
+    fi
+}}"#
+            );
+        }
+        ShellType::Fish => {
+            println!(
+                r#"# WAT documentation browser with fzf
+# Add this to your config.fish
+
+function wat-browse
+    set instruction (wat-docs list | fzf --preview 'wat-docs show {{}} --color' --preview-window=right:60%:wrap --ansi)
+    if test -n "$instruction"
+        wat-docs show "$instruction"
+    end
+end
+
+function wat-search
+    set instruction (wat-docs search $argv[1] --names-only | fzf --preview 'wat-docs show {{}} --color' --preview-window=right:60%:wrap --ansi)
+    if test -n "$instruction"
+        wat-docs show "$instruction"
+    end
+end"#
+            );
+        }
+    }
+
+    ExitCode::SUCCESS
+}

--- a/src/docs.rs
+++ b/src/docs.rs
@@ -1,0 +1,212 @@
+//! Documentation access module for WAT instruction documentation
+//!
+//! This module provides programmatic access to the instruction documentation
+//! that is generated at build time from `docs/instructions.md`.
+
+use std::collections::HashMap;
+
+mod generated {
+    // Include the auto-generated instruction documentation
+    // This brings in: use std::collections::HashMap; use once_cell::sync::Lazy;
+    // and INSTRUCTION_DOCS: Lazy<HashMap<&'static str, &'static str>>
+    include!(concat!(env!("OUT_DIR"), "/instruction_docs.rs"));
+}
+
+use generated::INSTRUCTION_DOCS;
+
+/// Get documentation for a specific instruction
+pub fn get_instruction_doc(name: &str) -> Option<&'static str> {
+    INSTRUCTION_DOCS.get(name).copied()
+}
+
+/// Get all instruction names
+pub fn instruction_names() -> Vec<&'static str> {
+    let mut names: Vec<_> = INSTRUCTION_DOCS.keys().copied().collect();
+    names.sort();
+    names
+}
+
+/// Get all instruction documentation as a reference to the underlying HashMap
+pub fn all_instructions() -> &'static HashMap<&'static str, &'static str> {
+    &INSTRUCTION_DOCS
+}
+
+/// Search for instructions matching a pattern (case-insensitive substring match)
+pub fn search_instructions(pattern: &str) -> Vec<(&'static str, &'static str)> {
+    let pattern_lower = pattern.to_lowercase();
+    let mut results: Vec<_> = INSTRUCTION_DOCS
+        .iter()
+        .filter(|(name, doc)| {
+            name.to_lowercase().contains(&pattern_lower)
+                || doc.to_lowercase().contains(&pattern_lower)
+        })
+        .map(|(k, v)| (*k, *v))
+        .collect();
+    results.sort_by(|a, b| a.0.cmp(b.0));
+    results
+}
+
+/// Search for instructions where the name matches a pattern
+pub fn search_instruction_names(pattern: &str) -> Vec<&'static str> {
+    let pattern_lower = pattern.to_lowercase();
+    let mut results: Vec<_> = INSTRUCTION_DOCS
+        .keys()
+        .filter(|name| name.to_lowercase().contains(&pattern_lower))
+        .copied()
+        .collect();
+    results.sort();
+    results
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_instruction_doc_exists() {
+        // Test that common instructions have documentation
+        assert!(get_instruction_doc("i32.add").is_some());
+        assert!(get_instruction_doc("i32.const").is_some());
+        assert!(get_instruction_doc("local.get").is_some());
+        assert!(get_instruction_doc("call").is_some());
+        assert!(get_instruction_doc("block").is_some());
+    }
+
+    #[test]
+    fn test_get_instruction_doc_not_exists() {
+        // Test that non-existent instructions return None
+        assert!(get_instruction_doc("not.an.instruction").is_none());
+        assert!(get_instruction_doc("").is_none());
+        assert!(get_instruction_doc("foobar").is_none());
+    }
+
+    #[test]
+    fn test_get_instruction_doc_content() {
+        // Test that documentation contains expected content
+        let doc = get_instruction_doc("i32.add").unwrap();
+        assert!(doc.to_lowercase().contains("add"));
+        assert!(doc.contains("i32"));
+    }
+
+    #[test]
+    fn test_instruction_names_not_empty() {
+        let names = instruction_names();
+        assert!(!names.is_empty());
+        // Should have many instructions
+        assert!(names.len() > 100);
+    }
+
+    #[test]
+    fn test_instruction_names_sorted() {
+        let names = instruction_names();
+        let mut sorted = names.clone();
+        sorted.sort();
+        assert_eq!(names, sorted);
+    }
+
+    #[test]
+    fn test_instruction_names_contains_common() {
+        let names = instruction_names();
+        assert!(names.contains(&"i32.add"));
+        assert!(names.contains(&"i64.mul"));
+        assert!(names.contains(&"f32.neg"));
+        assert!(names.contains(&"memory.grow"));
+    }
+
+    #[test]
+    fn test_all_instructions_not_empty() {
+        let all = all_instructions();
+        assert!(!all.is_empty());
+        assert!(all.len() > 100);
+    }
+
+    #[test]
+    fn test_all_instructions_matches_names() {
+        let all = all_instructions();
+        let names = instruction_names();
+        assert_eq!(all.len(), names.len());
+    }
+
+    #[test]
+    fn test_search_instructions_by_name() {
+        let results = search_instructions("i32.add");
+        assert!(!results.is_empty());
+        // Should find i32.add
+        assert!(results.iter().any(|(name, _)| *name == "i32.add"));
+    }
+
+    #[test]
+    fn test_search_instructions_by_content() {
+        // Search for something that appears in documentation but not instruction names
+        let results = search_instructions("memory");
+        assert!(!results.is_empty());
+        // Should find memory-related instructions
+        assert!(results.iter().any(|(name, _)| name.contains("memory")));
+    }
+
+    #[test]
+    fn test_search_instructions_case_insensitive() {
+        let results_lower = search_instructions("memory");
+        let results_upper = search_instructions("MEMORY");
+        let results_mixed = search_instructions("MeMoRy");
+
+        assert_eq!(results_lower.len(), results_upper.len());
+        assert_eq!(results_lower.len(), results_mixed.len());
+    }
+
+    #[test]
+    fn test_search_instructions_sorted() {
+        let results = search_instructions("i32");
+        let names: Vec<_> = results.iter().map(|(n, _)| *n).collect();
+        let mut sorted = names.clone();
+        sorted.sort();
+        assert_eq!(names, sorted);
+    }
+
+    #[test]
+    fn test_search_instructions_no_match() {
+        let results = search_instructions("xyznotfound123");
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_search_instruction_names_basic() {
+        let results = search_instruction_names("i32");
+        assert!(!results.is_empty());
+        // All results should contain "i32"
+        for name in &results {
+            assert!(name.to_lowercase().contains("i32"));
+        }
+    }
+
+    #[test]
+    fn test_search_instruction_names_case_insensitive() {
+        let results_lower = search_instruction_names("add");
+        let results_upper = search_instruction_names("ADD");
+        assert_eq!(results_lower, results_upper);
+    }
+
+    #[test]
+    fn test_search_instruction_names_sorted() {
+        let results = search_instruction_names("load");
+        let mut sorted = results.clone();
+        sorted.sort();
+        assert_eq!(results, sorted);
+    }
+
+    #[test]
+    fn test_search_instruction_names_no_match() {
+        let results = search_instruction_names("xyznotfound123");
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_search_instruction_names_partial() {
+        // Search for partial instruction names
+        let results = search_instruction_names(".add");
+        assert!(results.contains(&"i32.add"));
+        assert!(results.contains(&"i64.add"));
+        assert!(results.contains(&"f32.add"));
+        assert!(results.contains(&"f64.add"));
+    }
+}

--- a/src/features/hover/mod.rs
+++ b/src/features/hover/mod.rs
@@ -541,8 +541,5 @@ fn format_elem_hover(word: &str, elem: &ElemSegment) -> HoverResult {
 }
 
 fn get_instruction_doc(word: &str) -> Option<String> {
-    INSTRUCTION_DOCS.get(word).map(|s| s.to_string())
+    crate::docs::get_instruction_doc(word).map(|s| s.to_string())
 }
-
-// Include the auto-generated instruction documentation
-include!(concat!(env!("OUT_DIR"), "/instruction_docs.rs"));

--- a/src/features/hover/tests.rs
+++ b/src/features/hover/tests.rs
@@ -327,11 +327,11 @@ fn test_is_word_char() {
 #[test]
 fn test_instruction_docs_available() {
     // Test that some basic instruction docs are available
-    assert!(INSTRUCTION_DOCS.contains_key("i32.add"));
-    assert!(INSTRUCTION_DOCS.contains_key("f32.mul")); // Changed from f64.mul
-    assert!(INSTRUCTION_DOCS.contains_key("local.get"));
-    assert!(INSTRUCTION_DOCS.contains_key("block"));
-    assert!(INSTRUCTION_DOCS.contains_key("call"));
+    assert!(crate::docs::get_instruction_doc("i32.add").is_some());
+    assert!(crate::docs::get_instruction_doc("f32.mul").is_some()); // Changed from f64.mul
+    assert!(crate::docs::get_instruction_doc("local.get").is_some());
+    assert!(crate::docs::get_instruction_doc("block").is_some());
+    assert!(crate::docs::get_instruction_doc("call").is_some());
 }
 
 #[test]
@@ -339,47 +339,47 @@ fn test_new_instruction_docs_available() {
     // Test that the new WASM 3.0 instruction docs are available
     // Typed function references
     assert!(
-        INSTRUCTION_DOCS.contains_key("call_ref"),
+        crate::docs::get_instruction_doc("call_ref").is_some(),
         "call_ref should be documented"
     );
     assert!(
-        INSTRUCTION_DOCS.contains_key("return_call_ref"),
+        crate::docs::get_instruction_doc("return_call_ref").is_some(),
         "return_call_ref should be documented"
     );
 
     // Null-checking branches
     assert!(
-        INSTRUCTION_DOCS.contains_key("br_on_null"),
+        crate::docs::get_instruction_doc("br_on_null").is_some(),
         "br_on_null should be documented"
     );
     assert!(
-        INSTRUCTION_DOCS.contains_key("br_on_non_null"),
+        crate::docs::get_instruction_doc("br_on_non_null").is_some(),
         "br_on_non_null should be documented"
     );
 
     // Reference equality
     assert!(
-        INSTRUCTION_DOCS.contains_key("ref.eq"),
+        crate::docs::get_instruction_doc("ref.eq").is_some(),
         "ref.eq should be documented"
     );
 
     // Reference conversions
     assert!(
-        INSTRUCTION_DOCS.contains_key("any.convert_extern"),
+        crate::docs::get_instruction_doc("any.convert_extern").is_some(),
         "any.convert_extern should be documented"
     );
     assert!(
-        INSTRUCTION_DOCS.contains_key("extern.convert_any"),
+        crate::docs::get_instruction_doc("extern.convert_any").is_some(),
         "extern.convert_any should be documented"
     );
 
     // Array initialization
     assert!(
-        INSTRUCTION_DOCS.contains_key("array.init_data"),
+        crate::docs::get_instruction_doc("array.init_data").is_some(),
         "array.init_data should be documented"
     );
     assert!(
-        INSTRUCTION_DOCS.contains_key("array.init_elem"),
+        crate::docs::get_instruction_doc("array.init_elem").is_some(),
         "array.init_elem should be documented"
     );
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,9 @@
 // Core types (protocol-independent) - must be first as other modules depend on it
 pub mod core;
 
+// Documentation access (instruction docs generated at build time)
+pub mod docs;
+
 // Wast-based parser (works in WASM, always available)
 pub mod wast_parser;
 

--- a/tests/wat_docs_cli.rs
+++ b/tests/wat_docs_cli.rs
@@ -1,0 +1,399 @@
+//! Integration tests for the wat-docs CLI binary
+//!
+//! These tests verify the CLI behavior including output formatting and colorization.
+
+use std::process::Command;
+
+/// Get the path to the wat-docs binary
+fn wat_docs_bin() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_wat-docs"))
+}
+
+// ANSI escape code constants for verification
+mod ansi {
+    pub const RESET: &str = "\x1b[0m";
+    pub const BOLD: &str = "\x1b[1m";
+    pub const DIM: &str = "\x1b[2m";
+    pub const GREEN: &str = "\x1b[32m";
+    pub const YELLOW: &str = "\x1b[33m";
+    pub const MAGENTA: &str = "\x1b[35m";
+    pub const CYAN: &str = "\x1b[36m";
+    pub const BRIGHT_RED: &str = "\x1b[91m";
+}
+
+#[test]
+fn test_list_command() {
+    let output = wat_docs_bin()
+        .args(["list"])
+        .output()
+        .expect("Failed to execute wat-docs");
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+
+    // Should have many instructions
+    assert!(
+        lines.len() > 100,
+        "Expected many instructions, got {}",
+        lines.len()
+    );
+
+    // Should include common instructions
+    assert!(lines.contains(&"i32.add"));
+    assert!(lines.contains(&"memory.grow"));
+    assert!(lines.contains(&"call"));
+}
+
+#[test]
+fn test_list_with_filter() {
+    let output = wat_docs_bin()
+        .args(["list", "--filter", "i32.a"])
+        .output()
+        .expect("Failed to execute wat-docs");
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+
+    // All results should contain "i32.a"
+    for line in &lines {
+        assert!(
+            line.contains("i32.a"),
+            "Expected all results to contain 'i32.a', got '{}'",
+            line
+        );
+    }
+
+    // Should include i32.add
+    assert!(lines.contains(&"i32.add"));
+}
+
+#[test]
+fn test_show_command_raw() {
+    let output = wat_docs_bin()
+        .args(["show", "i32.add", "--raw"])
+        .output()
+        .expect("Failed to execute wat-docs");
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Should contain documentation content
+    assert!(stdout.to_lowercase().contains("add"));
+    assert!(stdout.contains("i32"));
+
+    // Raw mode should NOT contain ANSI codes
+    assert!(
+        !stdout.contains("\x1b["),
+        "Raw mode should not contain ANSI escape codes"
+    );
+}
+
+#[test]
+fn test_show_command_no_color() {
+    let output = wat_docs_bin()
+        .args(["show", "i32.add", "--no-color"])
+        .output()
+        .expect("Failed to execute wat-docs");
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Should contain header
+    assert!(stdout.contains("## i32.add"));
+
+    // No-color mode should NOT contain ANSI codes
+    assert!(
+        !stdout.contains("\x1b["),
+        "No-color mode should not contain ANSI escape codes"
+    );
+}
+
+#[test]
+fn test_show_command_with_color() {
+    let output = wat_docs_bin()
+        .args(["show", "i32.add", "--color"])
+        .output()
+        .expect("Failed to execute wat-docs");
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Color mode SHOULD contain ANSI codes
+    assert!(
+        stdout.contains("\x1b["),
+        "Color mode should contain ANSI escape codes"
+    );
+
+    // Should have reset codes
+    assert!(stdout.contains(ansi::RESET), "Should contain RESET codes");
+
+    // Header should be cyan and bold
+    assert!(stdout.contains(ansi::CYAN), "Header should be cyan");
+    assert!(stdout.contains(ansi::BOLD), "Header should be bold");
+}
+
+#[test]
+fn test_show_command_colorizes_code_blocks() {
+    let output = wat_docs_bin()
+        .args(["show", "func", "--color"])
+        .output()
+        .expect("Failed to execute wat-docs");
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Code blocks should have syntax highlighting
+    // Keywords like "func", "param", "result" should be magenta
+    assert!(
+        stdout.contains(ansi::MAGENTA),
+        "Keywords should be highlighted in magenta"
+    );
+
+    // Identifiers like $add should be yellow
+    assert!(
+        stdout.contains(ansi::YELLOW),
+        "Identifiers should be highlighted in yellow"
+    );
+
+    // Types should be cyan
+    assert!(
+        stdout.contains(ansi::CYAN),
+        "Types should be highlighted in cyan"
+    );
+
+    // Code fence should be dimmed
+    assert!(stdout.contains(ansi::DIM), "Code fences should be dimmed");
+}
+
+#[test]
+fn test_show_command_colorizes_numbers() {
+    let output = wat_docs_bin()
+        .args(["show", "i32.const", "--color"])
+        .output()
+        .expect("Failed to execute wat-docs");
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Numbers should be bright red
+    assert!(
+        stdout.contains(ansi::BRIGHT_RED),
+        "Numbers should be highlighted in bright red"
+    );
+}
+
+#[test]
+fn test_show_command_colorizes_comments() {
+    let output = wat_docs_bin()
+        .args(["show", "i32.add", "--color"])
+        .output()
+        .expect("Failed to execute wat-docs");
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Comments should be dimmed (the example has ";; Returns 8")
+    assert!(stdout.contains(ansi::DIM), "Comments should be dimmed");
+}
+
+#[test]
+fn test_show_unknown_instruction() {
+    let output = wat_docs_bin()
+        .args(["show", "not.an.instruction"])
+        .output()
+        .expect("Failed to execute wat-docs");
+
+    // Should fail
+    assert!(!output.status.success());
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Unknown instruction"));
+}
+
+#[test]
+fn test_show_suggests_similar() {
+    let output = wat_docs_bin()
+        .args(["show", "i32.ad"]) // Typo - missing 'd'
+        .output()
+        .expect("Failed to execute wat-docs");
+
+    // Should fail but suggest alternatives
+    assert!(!output.status.success());
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Did you mean"));
+    assert!(stderr.contains("i32.add"));
+}
+
+#[test]
+fn test_search_command() {
+    let output = wat_docs_bin()
+        .args(["search", "memory"])
+        .output()
+        .expect("Failed to execute wat-docs");
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Should find memory-related instructions
+    assert!(stdout.contains("memory"));
+}
+
+#[test]
+fn test_search_names_only() {
+    let output = wat_docs_bin()
+        .args(["search", "i32", "--names-only"])
+        .output()
+        .expect("Failed to execute wat-docs");
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+
+    // All lines should be instruction names containing "i32"
+    for line in &lines {
+        assert!(
+            line.contains("i32"),
+            "All results should contain 'i32', got '{}'",
+            line
+        );
+        // Names-only should not have ": " separator (no description)
+        assert!(
+            !line.contains(": "),
+            "Names-only should not include descriptions"
+        );
+    }
+}
+
+#[test]
+fn test_search_no_results() {
+    let output = wat_docs_bin()
+        .args(["search", "xyznotfound123"])
+        .output()
+        .expect("Failed to execute wat-docs");
+
+    // Should fail when no results
+    assert!(!output.status.success());
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("No instructions found"));
+}
+
+#[test]
+fn test_search_case_insensitive() {
+    let output_lower = wat_docs_bin()
+        .args(["search", "memory", "--names-only"])
+        .output()
+        .expect("Failed to execute wat-docs");
+
+    let output_upper = wat_docs_bin()
+        .args(["search", "MEMORY", "--names-only"])
+        .output()
+        .expect("Failed to execute wat-docs");
+
+    assert!(output_lower.status.success());
+    assert!(output_upper.status.success());
+
+    // Results should be identical
+    assert_eq!(output_lower.stdout, output_upper.stdout);
+}
+
+#[test]
+fn test_shell_setup_bash() {
+    let output = wat_docs_bin()
+        .args(["shell-setup", "bash"])
+        .output()
+        .expect("Failed to execute wat-docs");
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Should contain bash function definitions
+    assert!(stdout.contains("wat-browse()"));
+    assert!(stdout.contains("wat-search()"));
+    assert!(stdout.contains("fzf"));
+}
+
+#[test]
+fn test_shell_setup_fish() {
+    let output = wat_docs_bin()
+        .args(["shell-setup", "fish"])
+        .output()
+        .expect("Failed to execute wat-docs");
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Should contain fish function definitions
+    assert!(stdout.contains("function wat-browse"));
+    assert!(stdout.contains("function wat-search"));
+    assert!(stdout.contains("fzf"));
+}
+
+#[test]
+fn test_help_output() {
+    let output = wat_docs_bin()
+        .args(["--help"])
+        .output()
+        .expect("Failed to execute wat-docs");
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Should show usage information
+    assert!(stdout.contains("wat-docs"));
+    assert!(stdout.contains("list"));
+    assert!(stdout.contains("show"));
+    assert!(stdout.contains("search"));
+}
+
+#[test]
+fn test_signature_highlighted() {
+    let output = wat_docs_bin()
+        .args(["show", "i32.add", "--color"])
+        .output()
+        .expect("Failed to execute wat-docs");
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Signature line should be yellow and bold
+    assert!(
+        stdout.contains(&format!("{}{}Signature:", ansi::BOLD, ansi::YELLOW)),
+        "Signature should be bold yellow"
+    );
+}
+
+#[test]
+fn test_example_highlighted() {
+    let output = wat_docs_bin()
+        .args(["show", "i32.add", "--color"])
+        .output()
+        .expect("Failed to execute wat-docs");
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Example line should be green and bold
+    assert!(
+        stdout.contains(&format!("{}{}Example:", ansi::BOLD, ansi::GREEN)),
+        "Example should be bold green"
+    );
+}


### PR DESCRIPTION
Adds a new `wat-docs` CLI tool for browsing and searching WAT instruction documentation.

**Features:**
- `wat-docs list` - List all 388 instructions (pipeable to fzf)
- `wat-docs show <instruction>` - Show documentation with syntax highlighting
- `wat-docs search <pattern>` - Search by name or content
- `wat-docs shell-setup` - Generate shell integration for fzf

Syntax highlighting uses tree-sitter for accurate WAT parsing.