### PR TITLE
add support for SIMD lane and zero-extension load/store instructions

### DIFF
--- a/docs/examples/simd.wat
+++ b/docs/examples/simd.wat
@@ -185,6 +185,60 @@
   (func $mul_f64x2 (param $a v128) (param $b v128) (result v128)
     (f64x2.mul (local.get $a) (local.get $b)))
 
+  ;; ============================================================
+  ;; Zero-extending loads
+  ;; Load partial data and zero the remaining lanes
+  ;; ============================================================
+
+  ;; Load 32 bits into lowest lane, zero upper 96 bits
+  (func $load32_zero (param $offset i32) (result v128)
+    (v128.load32_zero (local.get $offset)))
+
+  ;; Load 64 bits into lowest lane, zero upper 64 bits
+  (func $load64_zero (param $offset i32) (result v128)
+    (v128.load64_zero (local.get $offset)))
+
+  ;; ============================================================
+  ;; Lane memory operations
+  ;; Load/store individual lanes without affecting others
+  ;; ============================================================
+
+  ;; Load 8-bit value into specific lane of existing vector
+  (func $load8_into_lane (param $offset i32) (param $v v128) (result v128)
+    (v128.load8_lane 0 (local.get $offset) (local.get $v)))
+
+  ;; Load 16-bit value into specific lane
+  (func $load16_into_lane (param $offset i32) (param $v v128) (result v128)
+    (v128.load16_lane 0 (local.get $offset) (local.get $v)))
+
+  ;; Load 32-bit value into specific lane
+  (func $load32_into_lane (param $offset i32) (param $v v128) (result v128)
+    (v128.load32_lane 0 (local.get $offset) (local.get $v)))
+
+  ;; Load 64-bit value into specific lane
+  (func $load64_into_lane (param $offset i32) (param $v v128) (result v128)
+    (v128.load64_lane 0 (local.get $offset) (local.get $v)))
+
+  ;; Store 8-bit value from specific lane
+  (func $store8_from_lane (param $offset i32) (param $v v128)
+    (v128.store8_lane 0 (local.get $offset) (local.get $v)))
+
+  ;; Store 16-bit value from specific lane
+  (func $store16_from_lane (param $offset i32) (param $v v128)
+    (v128.store16_lane 0 (local.get $offset) (local.get $v)))
+
+  ;; Store 32-bit value from specific lane
+  (func $store32_from_lane (param $offset i32) (param $v v128)
+    (v128.store32_lane 0 (local.get $offset) (local.get $v)))
+
+  ;; Store 64-bit value from specific lane
+  (func $store64_from_lane (param $offset i32) (param $v v128)
+    (v128.store64_lane 0 (local.get $offset) (local.get $v)))
+
+  ;; Lane operations with offset
+  (func $load64_lane_with_offset (param $base i32) (param $v v128) (result v128)
+    (v128.load64_lane offset=8 1 (local.get $base) (local.get $v)))
+
   ;; Exports
   (export "add_i32x4" (func $add_i32x4))
   (export "mul_f32x4" (func $mul_f32x4))

--- a/docs/instructions.md
+++ b/docs/instructions.md
@@ -3469,6 +3469,119 @@ Example:
 ```
 ---
 
+## v128.load32_zero
+Load 32-bit value into the lowest lane and zero all other lanes.
+
+Signature: `(param i32) (result v128)`
+
+Example:
+```wat
+(v128.load32_zero (i32.const 0))  ;; Loads i32 into lane 0, zeros lanes 1-3
+```
+---
+
+## v128.load64_zero
+Load 64-bit value into the lowest lane and zero all other lanes.
+
+Signature: `(param i32) (result v128)`
+
+Example:
+```wat
+(v128.load64_zero (i32.const 0))  ;; Loads i64 into lane 0, zeros lane 1
+```
+---
+
+## v128.load8_lane
+Load 8-bit value into a specific lane of an existing vector.
+
+Signature: `(param i32 v128) (result v128)`
+
+Example:
+```wat
+(v128.load8_lane 0 (i32.const 0) (local.get $vec))  ;; Load byte into lane 0
+(v128.load8_lane offset=4 5 (i32.const 0) (local.get $vec))  ;; With offset, lane 5
+```
+---
+
+## v128.load16_lane
+Load 16-bit value into a specific lane of an existing vector.
+
+Signature: `(param i32 v128) (result v128)`
+
+Example:
+```wat
+(v128.load16_lane 0 (i32.const 0) (local.get $vec))  ;; Load i16 into lane 0
+```
+---
+
+## v128.load32_lane
+Load 32-bit value into a specific lane of an existing vector.
+
+Signature: `(param i32 v128) (result v128)`
+
+Example:
+```wat
+(v128.load32_lane 0 (i32.const 0) (local.get $vec))  ;; Load i32 into lane 0
+```
+---
+
+## v128.load64_lane
+Load 64-bit value into a specific lane of an existing vector.
+
+Signature: `(param i32 v128) (result v128)`
+
+Example:
+```wat
+(v128.load64_lane 0 (i32.const 0) (local.get $vec))  ;; Load i64 into lane 0
+(v128.load64_lane offset=8 1 (i32.const 0) (local.get $vec))  ;; With offset, lane 1
+```
+---
+
+## v128.store8_lane
+Store 8-bit value from a specific lane to memory.
+
+Signature: `(param i32 v128)`
+
+Example:
+```wat
+(v128.store8_lane 0 (i32.const 0) (local.get $vec))  ;; Store lane 0 as byte
+```
+---
+
+## v128.store16_lane
+Store 16-bit value from a specific lane to memory.
+
+Signature: `(param i32 v128)`
+
+Example:
+```wat
+(v128.store16_lane 0 (i32.const 0) (local.get $vec))  ;; Store lane 0 as i16
+```
+---
+
+## v128.store32_lane
+Store 32-bit value from a specific lane to memory.
+
+Signature: `(param i32 v128)`
+
+Example:
+```wat
+(v128.store32_lane 0 (i32.const 0) (local.get $vec))  ;; Store lane 0 as i32
+```
+---
+
+## v128.store64_lane
+Store 64-bit value from a specific lane to memory.
+
+Signature: `(param i32 v128)`
+
+Example:
+```wat
+(v128.store64_lane 0 (i32.const 0) (local.get $vec))  ;; Store lane 0 as i64
+(v128.store64_lane offset=8 1 (i32.const 0) (local.get $vec))  ;; With offset, lane 1
+```
+---
+
 ## v128.any_true
 Check if any bit in the vector is non-zero.
 

--- a/grammars/tree-sitter-wat/grammar.js
+++ b/grammars/tree-sitter-wat/grammar.js
@@ -284,6 +284,7 @@ module.exports = grammar({
         seq($.op_simd_offset_opt_align_opt, optional($.offset_value), optional($.align_value)),
         $.op_simd_const,
         $.op_simd_lane,
+        seq($.op_simd_lane_memarg, optional($.offset_value), optional($.align_value), $.int),
       ),
 
     _instruction_relaxed_simd: $ =>
@@ -643,7 +644,7 @@ module.exports = grammar({
             "v",
             choice(
               imm(/(8x16|16x8|32x4|64x2)\.load_splat/),
-              imm(/128\.(load((8|16|32|64)_splat|(8x8|16x4|32x2)_[su])?|store)/),
+              imm(/128\.(load((8|16|32|64)_splat|(8x8|16x4|32x2)_[su]|(32|64)_zero)?|store)/),
             ),
           ),
         ),
@@ -688,6 +689,10 @@ module.exports = grammar({
         seq(alias(seq(choice("f32x4", "f64x2", "i32x4", "i64x2"), imm("."), imm("extract_lane")), $.instr_name), $.int),
         seq(alias(seq(choice("f32x4", "f64x2", "i8x16", "i16x8", "i32x4", "i64x2"), imm("."), imm("replace_lane")), $.instr_name), $.int),
       ),
+
+    // proposal: simd - memory lane operations (load/store with lane index)
+    op_simd_lane_memarg: $ =>
+      token(seq("v128.", choice("load", "store"), imm(/(8|16|32|64)_lane/))),
 
     // proposal: bulk-memory-operations
     op_table_copy: $ => seq("table.copy", optional(seq($.index, $.index))),

--- a/packages/playground/examples.js
+++ b/packages/playground/examples.js
@@ -261,5 +261,84 @@ export const watExamples = {
     (local.set $result (i32.add (local.get $a) (local.get $b)))
     (call $log (local.get $result))
     (local.get $result)))
+`,
+
+  simd: `(module
+  ;; SIMD (Single Instruction Multiple Data) Example
+  ;; Demonstrates v128 operations for parallel computation
+
+  (memory (export "memory") 1)
+
+  ;; Basic v128 operations
+  (func (export "add_vectors") (param $a v128) (param $b v128) (result v128)
+    (i32x4.add (local.get $a) (local.get $b)))
+
+  ;; Create a constant vector
+  (func (export "make_vector") (result v128)
+    (v128.const i32x4 1 2 3 4))
+
+  ;; Splat a single value to all lanes
+  (func (export "splat") (param $val i32) (result v128)
+    (i32x4.splat (local.get $val)))
+
+  ;; Extract a lane from a vector
+  (func (export "get_lane_0") (param $v v128) (result i32)
+    (i32x4.extract_lane 0 (local.get $v)))
+
+  ;; Replace a lane in a vector
+  (func (export "set_lane_0") (param $v v128) (param $val i32) (result v128)
+    (i32x4.replace_lane 0 (local.get $v) (local.get $val)))
+
+  ;; ============================================================
+  ;; Lane load/store operations (load/store individual lanes)
+  ;; These were recently added to the grammar!
+  ;; ============================================================
+
+  ;; Load a 64-bit value into a specific lane
+  (func (export "load_into_lane") (param $v v128) (param $addr i32) (result v128)
+    (v128.load64_lane 0 (local.get $addr) (local.get $v)))
+
+  ;; Store a 64-bit value from a specific lane
+  (func (export "store_from_lane") (param $v v128) (param $addr i32)
+    (v128.store64_lane 0 (local.get $addr) (local.get $v)))
+
+  ;; Load 32-bit lanes
+  (func (export "load32_into_lane") (param $v v128) (param $addr i32) (result v128)
+    (v128.load32_lane 0 (local.get $addr) (local.get $v)))
+
+  ;; Store 32-bit lanes
+  (func (export "store32_from_lane") (param $v v128) (param $addr i32)
+    (v128.store32_lane 0 (local.get $addr) (local.get $v)))
+
+  ;; ============================================================
+  ;; Zero-extending loads (load partial and zero the rest)
+  ;; These were also recently added!
+  ;; ============================================================
+
+  ;; Load 64 bits and zero-extend to v128 (upper 64 bits = 0)
+  (func (export "load64_zero") (param $addr i32) (result v128)
+    (v128.load64_zero (local.get $addr)))
+
+  ;; Load 32 bits and zero-extend to v128 (upper 96 bits = 0)
+  (func (export "load32_zero") (param $addr i32) (result v128)
+    (v128.load32_zero (local.get $addr)))
+
+  ;; ============================================================
+  ;; Practical example: Sum array elements using SIMD
+  ;; ============================================================
+
+  ;; Sum 4 i32 values in parallel from memory
+  (func (export "sum_simd") (param $addr i32) (result i32)
+    (local $vec v128)
+    ;; Load 4 i32 values
+    (local.set $vec (v128.load (local.get $addr)))
+    ;; Sum all lanes
+    (i32.add
+      (i32.add
+        (i32x4.extract_lane 0 (local.get $vec))
+        (i32x4.extract_lane 1 (local.get $vec)))
+      (i32.add
+        (i32x4.extract_lane 2 (local.get $vec))
+        (i32x4.extract_lane 3 (local.get $vec))))))
 `
 };

--- a/tests/fixtures/simd_comprehensive.wat
+++ b/tests/fixtures/simd_comprehensive.wat
@@ -1,0 +1,334 @@
+;; Comprehensive SIMD instruction test file
+;; This file tests all SIMD instructions to catch grammar regressions
+;; Run with: cargo run --bin wat-check -- tests/fixtures/simd_comprehensive.wat
+
+(module
+  (memory 1)
+
+  ;; ============================================================================
+  ;; v128 load/store basic
+  ;; ============================================================================
+  (func $test_v128_load_store (local $v v128)
+    ;; Basic load/store
+    (local.set $v (v128.load (i32.const 0)))
+    (v128.store (i32.const 0) (local.get $v))
+
+    ;; With offset and align
+    (local.set $v (v128.load offset=16 align=16 (i32.const 0)))
+    (v128.store offset=32 align=16 (i32.const 0) (local.get $v))
+  )
+
+  ;; ============================================================================
+  ;; v128 extending loads (8x8, 16x4, 32x2)
+  ;; ============================================================================
+  (func $test_v128_extending_loads (result v128)
+    (v128.load8x8_s (i32.const 0))
+  )
+  (func $test_v128_extending_loads_u (result v128)
+    (v128.load8x8_u (i32.const 0))
+  )
+  (func $test_v128_load16x4_s (result v128)
+    (v128.load16x4_s (i32.const 0))
+  )
+  (func $test_v128_load16x4_u (result v128)
+    (v128.load16x4_u (i32.const 0))
+  )
+  (func $test_v128_load32x2_s (result v128)
+    (v128.load32x2_s (i32.const 0))
+  )
+  (func $test_v128_load32x2_u (result v128)
+    (v128.load32x2_u (i32.const 0))
+  )
+
+  ;; ============================================================================
+  ;; v128 splat loads
+  ;; ============================================================================
+  (func $test_v128_splat_loads (result v128)
+    (v128.load8_splat (i32.const 0))
+  )
+  (func $test_v128_load16_splat (result v128)
+    (v128.load16_splat (i32.const 0))
+  )
+  (func $test_v128_load32_splat (result v128)
+    (v128.load32_splat (i32.const 0))
+  )
+  (func $test_v128_load64_splat (result v128)
+    (v128.load64_splat (i32.const 0))
+  )
+
+  ;; ============================================================================
+  ;; v128 zero-extending loads (IMPORTANT: these were previously missing!)
+  ;; ============================================================================
+  (func $test_v128_load32_zero (result v128)
+    (v128.load32_zero (i32.const 0))
+  )
+  (func $test_v128_load64_zero (result v128)
+    (v128.load64_zero (i32.const 0))
+  )
+  (func $test_v128_load64_zero_with_offset (result v128)
+    (v128.load64_zero offset=8 (i32.const 0))
+  )
+  (func $test_v128_load32_zero_with_align (result v128)
+    (v128.load32_zero align=4 (i32.const 0))
+  )
+
+  ;; ============================================================================
+  ;; v128 lane loads (IMPORTANT: these were previously missing!)
+  ;; ============================================================================
+  (func $test_v128_load8_lane (param $v v128) (result v128)
+    (v128.load8_lane 0 (i32.const 0) (local.get $v))
+  )
+  (func $test_v128_load16_lane (param $v v128) (result v128)
+    (v128.load16_lane 0 (i32.const 0) (local.get $v))
+  )
+  (func $test_v128_load32_lane (param $v v128) (result v128)
+    (v128.load32_lane 0 (i32.const 0) (local.get $v))
+  )
+  (func $test_v128_load64_lane (param $v v128) (result v128)
+    (v128.load64_lane 0 (i32.const 0) (local.get $v))
+  )
+  (func $test_v128_load64_lane_with_offset (param $v v128) (result v128)
+    (v128.load64_lane offset=8 1 (i32.const 0) (local.get $v))
+  )
+
+  ;; ============================================================================
+  ;; v128 lane stores (IMPORTANT: these were previously missing!)
+  ;; ============================================================================
+  (func $test_v128_store8_lane (param $v v128)
+    (v128.store8_lane 0 (i32.const 0) (local.get $v))
+  )
+  (func $test_v128_store16_lane (param $v v128)
+    (v128.store16_lane 0 (i32.const 0) (local.get $v))
+  )
+  (func $test_v128_store32_lane (param $v v128)
+    (v128.store32_lane 0 (i32.const 0) (local.get $v))
+  )
+  (func $test_v128_store64_lane (param $v v128)
+    (v128.store64_lane 0 (i32.const 0) (local.get $v))
+  )
+  (func $test_v128_store64_lane_with_offset (param $v v128)
+    (v128.store64_lane offset=8 1 (i32.const 0) (local.get $v))
+  )
+
+  ;; ============================================================================
+  ;; v128.const
+  ;; ============================================================================
+  (func $test_v128_const (result v128)
+    (v128.const i32x4 1 2 3 4)
+  )
+  (func $test_v128_const_f32x4 (result v128)
+    (v128.const f32x4 1.0 2.0 3.0 4.0)
+  )
+  (func $test_v128_const_i8x16 (result v128)
+    (v128.const i8x16 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15)
+  )
+  (func $test_v128_const_i64x2 (result v128)
+    (v128.const i64x2 100 200)
+  )
+  (func $test_v128_const_f64x2 (result v128)
+    (v128.const f64x2 1.5 2.5)
+  )
+
+  ;; ============================================================================
+  ;; i8x16 shuffle
+  ;; ============================================================================
+  (func $test_i8x16_shuffle (param $a v128) (param $b v128) (result v128)
+    (i8x16.shuffle 0 1 2 3 4 5 6 7 16 17 18 19 20 21 22 23
+                   (local.get $a) (local.get $b))
+  )
+
+  ;; ============================================================================
+  ;; extract_lane / replace_lane
+  ;; ============================================================================
+  (func $test_i8x16_extract_lane_s (param $v v128) (result i32)
+    (i8x16.extract_lane_s 0 (local.get $v))
+  )
+  (func $test_i8x16_extract_lane_u (param $v v128) (result i32)
+    (i8x16.extract_lane_u 15 (local.get $v))
+  )
+  (func $test_i16x8_extract_lane_s (param $v v128) (result i32)
+    (i16x8.extract_lane_s 0 (local.get $v))
+  )
+  (func $test_i16x8_extract_lane_u (param $v v128) (result i32)
+    (i16x8.extract_lane_u 7 (local.get $v))
+  )
+  (func $test_i32x4_extract_lane (param $v v128) (result i32)
+    (i32x4.extract_lane 0 (local.get $v))
+  )
+  (func $test_i64x2_extract_lane (param $v v128) (result i64)
+    (i64x2.extract_lane 1 (local.get $v))
+  )
+  (func $test_f32x4_extract_lane (param $v v128) (result f32)
+    (f32x4.extract_lane 2 (local.get $v))
+  )
+  (func $test_f64x2_extract_lane (param $v v128) (result f64)
+    (f64x2.extract_lane 0 (local.get $v))
+  )
+
+  (func $test_i8x16_replace_lane (param $v v128) (param $val i32) (result v128)
+    (i8x16.replace_lane 5 (local.get $v) (local.get $val))
+  )
+  (func $test_i32x4_replace_lane (param $v v128) (param $val i32) (result v128)
+    (i32x4.replace_lane 3 (local.get $v) (local.get $val))
+  )
+  (func $test_f32x4_replace_lane (param $v v128) (param $val f32) (result v128)
+    (f32x4.replace_lane 1 (local.get $v) (local.get $val))
+  )
+
+  ;; ============================================================================
+  ;; Splat operations
+  ;; ============================================================================
+  (func $test_i8x16_splat (param $val i32) (result v128)
+    (i8x16.splat (local.get $val))
+  )
+  (func $test_i16x8_splat (param $val i32) (result v128)
+    (i16x8.splat (local.get $val))
+  )
+  (func $test_i32x4_splat (param $val i32) (result v128)
+    (i32x4.splat (local.get $val))
+  )
+  (func $test_i64x2_splat (param $val i64) (result v128)
+    (i64x2.splat (local.get $val))
+  )
+  (func $test_f32x4_splat (param $val f32) (result v128)
+    (f32x4.splat (local.get $val))
+  )
+  (func $test_f64x2_splat (param $val f64) (result v128)
+    (f64x2.splat (local.get $val))
+  )
+
+  ;; ============================================================================
+  ;; i32x4 arithmetic
+  ;; ============================================================================
+  (func $test_i32x4_add (param $a v128) (param $b v128) (result v128)
+    (i32x4.add (local.get $a) (local.get $b))
+  )
+  (func $test_i32x4_sub (param $a v128) (param $b v128) (result v128)
+    (i32x4.sub (local.get $a) (local.get $b))
+  )
+  (func $test_i32x4_mul (param $a v128) (param $b v128) (result v128)
+    (i32x4.mul (local.get $a) (local.get $b))
+  )
+
+  ;; ============================================================================
+  ;; f32x4 arithmetic
+  ;; ============================================================================
+  (func $test_f32x4_add (param $a v128) (param $b v128) (result v128)
+    (f32x4.add (local.get $a) (local.get $b))
+  )
+  (func $test_f32x4_sub (param $a v128) (param $b v128) (result v128)
+    (f32x4.sub (local.get $a) (local.get $b))
+  )
+  (func $test_f32x4_mul (param $a v128) (param $b v128) (result v128)
+    (f32x4.mul (local.get $a) (local.get $b))
+  )
+  (func $test_f32x4_div (param $a v128) (param $b v128) (result v128)
+    (f32x4.div (local.get $a) (local.get $b))
+  )
+  (func $test_f32x4_sqrt (param $v v128) (result v128)
+    (f32x4.sqrt (local.get $v))
+  )
+  (func $test_f32x4_neg (param $v v128) (result v128)
+    (f32x4.neg (local.get $v))
+  )
+  (func $test_f32x4_abs (param $v v128) (result v128)
+    (f32x4.abs (local.get $v))
+  )
+
+  ;; ============================================================================
+  ;; v128 bitwise operations
+  ;; ============================================================================
+  (func $test_v128_and (param $a v128) (param $b v128) (result v128)
+    (v128.and (local.get $a) (local.get $b))
+  )
+  (func $test_v128_or (param $a v128) (param $b v128) (result v128)
+    (v128.or (local.get $a) (local.get $b))
+  )
+  (func $test_v128_xor (param $a v128) (param $b v128) (result v128)
+    (v128.xor (local.get $a) (local.get $b))
+  )
+  (func $test_v128_not (param $v v128) (result v128)
+    (v128.not (local.get $v))
+  )
+  (func $test_v128_andnot (param $a v128) (param $b v128) (result v128)
+    (v128.andnot (local.get $a) (local.get $b))
+  )
+  (func $test_v128_bitselect (param $a v128) (param $b v128) (param $c v128) (result v128)
+    (v128.bitselect (local.get $a) (local.get $b) (local.get $c))
+  )
+  (func $test_v128_any_true (param $v v128) (result i32)
+    (v128.any_true (local.get $v))
+  )
+
+  ;; ============================================================================
+  ;; Comparison operations
+  ;; ============================================================================
+  (func $test_i32x4_eq (param $a v128) (param $b v128) (result v128)
+    (i32x4.eq (local.get $a) (local.get $b))
+  )
+  (func $test_i32x4_ne (param $a v128) (param $b v128) (result v128)
+    (i32x4.ne (local.get $a) (local.get $b))
+  )
+  (func $test_i32x4_lt_s (param $a v128) (param $b v128) (result v128)
+    (i32x4.lt_s (local.get $a) (local.get $b))
+  )
+  (func $test_f32x4_eq (param $a v128) (param $b v128) (result v128)
+    (f32x4.eq (local.get $a) (local.get $b))
+  )
+  (func $test_f32x4_lt (param $a v128) (param $b v128) (result v128)
+    (f32x4.lt (local.get $a) (local.get $b))
+  )
+
+  ;; ============================================================================
+  ;; Shift operations
+  ;; ============================================================================
+  (func $test_i32x4_shl (param $v v128) (param $shift i32) (result v128)
+    (i32x4.shl (local.get $v) (local.get $shift))
+  )
+  (func $test_i32x4_shr_s (param $v v128) (param $shift i32) (result v128)
+    (i32x4.shr_s (local.get $v) (local.get $shift))
+  )
+  (func $test_i32x4_shr_u (param $v v128) (param $shift i32) (result v128)
+    (i32x4.shr_u (local.get $v) (local.get $shift))
+  )
+
+  ;; ============================================================================
+  ;; Bitmask operations
+  ;; ============================================================================
+  (func $test_i8x16_bitmask (param $v v128) (result i32)
+    (i8x16.bitmask (local.get $v))
+  )
+  (func $test_i32x4_bitmask (param $v v128) (result i32)
+    (i32x4.bitmask (local.get $v))
+  )
+
+  ;; ============================================================================
+  ;; All true operations
+  ;; ============================================================================
+  (func $test_i8x16_all_true (param $v v128) (result i32)
+    (i8x16.all_true (local.get $v))
+  )
+  (func $test_i32x4_all_true (param $v v128) (result i32)
+    (i32x4.all_true (local.get $v))
+  )
+
+  ;; ============================================================================
+  ;; Swizzle
+  ;; ============================================================================
+  (func $test_i8x16_swizzle (param $v v128) (param $idx v128) (result v128)
+    (i8x16.swizzle (local.get $v) (local.get $idx))
+  )
+
+  ;; ============================================================================
+  ;; Relaxed SIMD (proposal)
+  ;; ============================================================================
+  (func $test_i8x16_relaxed_swizzle (param $v v128) (param $idx v128) (result v128)
+    (i8x16.relaxed_swizzle (local.get $v) (local.get $idx))
+  )
+  (func $test_f32x4_relaxed_min (param $a v128) (param $b v128) (result v128)
+    (f32x4.relaxed_min (local.get $a) (local.get $b))
+  )
+  (func $test_f32x4_relaxed_max (param $a v128) (param $b v128) (result v128)
+    (f32x4.relaxed_max (local.get $a) (local.get $b))
+  )
+)

--- a/tests/grammar_tests.rs
+++ b/tests/grammar_tests.rs
@@ -1,0 +1,334 @@
+//! Integration tests for the WAT grammar
+//!
+//! These tests verify that the tree-sitter grammar correctly parses all standard
+//! WebAssembly instructions without syntax errors. This catches grammar regressions
+//! when new WASM instructions are added to the specification.
+
+#[cfg(feature = "native")]
+mod grammar_tests {
+    use std::fs;
+    use std::path::Path;
+    use tower_lsp::lsp_types::DiagnosticSeverity;
+    use wat_lsp_rust::diagnostics::provide_tree_sitter_diagnostics;
+    use wat_lsp_rust::tree_sitter_bindings::create_parser;
+
+    /// Check a WAT file for syntax errors only (tree-sitter level)
+    fn check_syntax(source: &str) -> Vec<String> {
+        let mut parser = create_parser();
+        let tree = parser.parse(source, None).expect("Failed to parse");
+        let diagnostics = provide_tree_sitter_diagnostics(&tree, source);
+
+        diagnostics
+            .iter()
+            .filter(|d| d.severity == Some(DiagnosticSeverity::ERROR))
+            .map(|d| format!("Line {}: {}", d.range.start.line + 1, d.message))
+            .collect()
+    }
+
+    /// Load and check a fixture file
+    fn check_fixture(filename: &str) -> Vec<String> {
+        let fixture_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("fixtures")
+            .join(filename);
+
+        let source = fs::read_to_string(&fixture_path)
+            .unwrap_or_else(|e| panic!("Failed to read {}: {}", fixture_path.display(), e));
+
+        check_syntax(&source)
+    }
+
+    #[test]
+    fn test_simd_comprehensive_parses_without_errors() {
+        let errors = check_fixture("simd_comprehensive.wat");
+        assert!(
+            errors.is_empty(),
+            "SIMD comprehensive test file had syntax errors:\n{}",
+            errors.join("\n")
+        );
+    }
+
+    // ========================================================================
+    // Individual instruction tests - useful for debugging specific failures
+    // ========================================================================
+
+    #[test]
+    fn test_v128_load64_zero() {
+        let source = r#"
+            (module
+                (memory 1)
+                (func (result v128)
+                    (v128.load64_zero (i32.const 0))
+                )
+            )
+        "#;
+        let errors = check_syntax(source);
+        assert!(errors.is_empty(), "v128.load64_zero failed: {:?}", errors);
+    }
+
+    #[test]
+    fn test_v128_load32_zero() {
+        let source = r#"
+            (module
+                (memory 1)
+                (func (result v128)
+                    (v128.load32_zero (i32.const 0))
+                )
+            )
+        "#;
+        let errors = check_syntax(source);
+        assert!(errors.is_empty(), "v128.load32_zero failed: {:?}", errors);
+    }
+
+    #[test]
+    fn test_v128_load64_lane() {
+        let source = r#"
+            (module
+                (memory 1)
+                (func (param $v v128) (result v128)
+                    (v128.load64_lane 0 (i32.const 0) (local.get $v))
+                )
+            )
+        "#;
+        let errors = check_syntax(source);
+        assert!(errors.is_empty(), "v128.load64_lane failed: {:?}", errors);
+    }
+
+    #[test]
+    fn test_v128_load32_lane() {
+        let source = r#"
+            (module
+                (memory 1)
+                (func (param $v v128) (result v128)
+                    (v128.load32_lane 0 (i32.const 0) (local.get $v))
+                )
+            )
+        "#;
+        let errors = check_syntax(source);
+        assert!(errors.is_empty(), "v128.load32_lane failed: {:?}", errors);
+    }
+
+    #[test]
+    fn test_v128_load16_lane() {
+        let source = r#"
+            (module
+                (memory 1)
+                (func (param $v v128) (result v128)
+                    (v128.load16_lane 0 (i32.const 0) (local.get $v))
+                )
+            )
+        "#;
+        let errors = check_syntax(source);
+        assert!(errors.is_empty(), "v128.load16_lane failed: {:?}", errors);
+    }
+
+    #[test]
+    fn test_v128_load8_lane() {
+        let source = r#"
+            (module
+                (memory 1)
+                (func (param $v v128) (result v128)
+                    (v128.load8_lane 0 (i32.const 0) (local.get $v))
+                )
+            )
+        "#;
+        let errors = check_syntax(source);
+        assert!(errors.is_empty(), "v128.load8_lane failed: {:?}", errors);
+    }
+
+    #[test]
+    fn test_v128_store64_lane() {
+        let source = r#"
+            (module
+                (memory 1)
+                (func (param $v v128)
+                    (v128.store64_lane 0 (i32.const 0) (local.get $v))
+                )
+            )
+        "#;
+        let errors = check_syntax(source);
+        assert!(errors.is_empty(), "v128.store64_lane failed: {:?}", errors);
+    }
+
+    #[test]
+    fn test_v128_store32_lane() {
+        let source = r#"
+            (module
+                (memory 1)
+                (func (param $v v128)
+                    (v128.store32_lane 0 (i32.const 0) (local.get $v))
+                )
+            )
+        "#;
+        let errors = check_syntax(source);
+        assert!(errors.is_empty(), "v128.store32_lane failed: {:?}", errors);
+    }
+
+    #[test]
+    fn test_v128_store16_lane() {
+        let source = r#"
+            (module
+                (memory 1)
+                (func (param $v v128)
+                    (v128.store16_lane 0 (i32.const 0) (local.get $v))
+                )
+            )
+        "#;
+        let errors = check_syntax(source);
+        assert!(errors.is_empty(), "v128.store16_lane failed: {:?}", errors);
+    }
+
+    #[test]
+    fn test_v128_store8_lane() {
+        let source = r#"
+            (module
+                (memory 1)
+                (func (param $v v128)
+                    (v128.store8_lane 0 (i32.const 0) (local.get $v))
+                )
+            )
+        "#;
+        let errors = check_syntax(source);
+        assert!(errors.is_empty(), "v128.store8_lane failed: {:?}", errors);
+    }
+
+    #[test]
+    fn test_v128_lane_with_offset() {
+        let source = r#"
+            (module
+                (memory 1)
+                (func (param $v v128) (result v128)
+                    (v128.load64_lane offset=8 1 (i32.const 0) (local.get $v))
+                )
+            )
+        "#;
+        let errors = check_syntax(source);
+        assert!(
+            errors.is_empty(),
+            "v128.load64_lane with offset failed: {:?}",
+            errors
+        );
+    }
+
+    #[test]
+    fn test_v128_lane_with_align() {
+        let source = r#"
+            (module
+                (memory 1)
+                (func (param $v v128)
+                    (v128.store64_lane align=8 0 (i32.const 0) (local.get $v))
+                )
+            )
+        "#;
+        let errors = check_syntax(source);
+        assert!(
+            errors.is_empty(),
+            "v128.store64_lane with align failed: {:?}",
+            errors
+        );
+    }
+
+    // ========================================================================
+    // Tests for other SIMD instructions that should continue to work
+    // ========================================================================
+
+    #[test]
+    fn test_v128_basic_load_store() {
+        let source = r#"
+            (module
+                (memory 1)
+                (func (local $v v128)
+                    (local.set $v (v128.load (i32.const 0)))
+                    (v128.store (i32.const 0) (local.get $v))
+                )
+            )
+        "#;
+        let errors = check_syntax(source);
+        assert!(
+            errors.is_empty(),
+            "v128 basic load/store failed: {:?}",
+            errors
+        );
+    }
+
+    #[test]
+    fn test_v128_const() {
+        let source = r#"
+            (module
+                (func (result v128)
+                    (v128.const i32x4 1 2 3 4)
+                )
+            )
+        "#;
+        let errors = check_syntax(source);
+        assert!(errors.is_empty(), "v128.const failed: {:?}", errors);
+    }
+
+    #[test]
+    fn test_i8x16_shuffle() {
+        let source = r#"
+            (module
+                (func (param $a v128) (param $b v128) (result v128)
+                    (i8x16.shuffle 0 1 2 3 4 5 6 7 16 17 18 19 20 21 22 23
+                                   (local.get $a) (local.get $b))
+                )
+            )
+        "#;
+        let errors = check_syntax(source);
+        assert!(errors.is_empty(), "i8x16.shuffle failed: {:?}", errors);
+    }
+
+    #[test]
+    fn test_extract_lane() {
+        let source = r#"
+            (module
+                (func (param $v v128) (result i32)
+                    (i32x4.extract_lane 0 (local.get $v))
+                )
+            )
+        "#;
+        let errors = check_syntax(source);
+        assert!(errors.is_empty(), "extract_lane failed: {:?}", errors);
+    }
+
+    #[test]
+    fn test_replace_lane() {
+        let source = r#"
+            (module
+                (func (param $v v128) (param $val i32) (result v128)
+                    (i32x4.replace_lane 0 (local.get $v) (local.get $val))
+                )
+            )
+        "#;
+        let errors = check_syntax(source);
+        assert!(errors.is_empty(), "replace_lane failed: {:?}", errors);
+    }
+
+    #[test]
+    fn test_splat_loads() {
+        let source = r#"
+            (module
+                (memory 1)
+                (func (result v128)
+                    (v128.load64_splat (i32.const 0))
+                )
+            )
+        "#;
+        let errors = check_syntax(source);
+        assert!(errors.is_empty(), "splat loads failed: {:?}", errors);
+    }
+
+    #[test]
+    fn test_extending_loads() {
+        let source = r#"
+            (module
+                (memory 1)
+                (func (result v128)
+                    (v128.load8x8_s (i32.const 0))
+                )
+            )
+        "#;
+        let errors = check_syntax(source);
+        assert!(errors.is_empty(), "extending loads failed: {:?}", errors);
+    }
+}

--- a/tests/run_fixture_tests.sh
+++ b/tests/run_fixture_tests.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Run all fixture tests through wat-check to verify they parse without errors
+# Usage: ./tests/run_fixture_tests.sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+echo "Building wat-check..."
+cargo build --release --bin wat-check
+
+echo ""
+echo "Running fixture tests..."
+echo "========================"
+
+FAILED=0
+PASSED=0
+
+for file in "$SCRIPT_DIR"/fixtures/*.wat; do
+    if [ -f "$file" ]; then
+        filename=$(basename "$file")
+        if "$PROJECT_DIR/target/release/wat-check" "$file" 2>&1; then
+            echo "PASS: $filename"
+            ((PASSED++))
+        else
+            echo "FAIL: $filename"
+            ((FAILED++))
+        fi
+    fi
+done
+
+echo ""
+echo "========================"
+echo "Results: $PASSED passed, $FAILED failed"
+
+if [ $FAILED -gt 0 ]; then
+    exit 1
+fi
+
+echo "All fixture tests passed!"


### PR DESCRIPTION
- Add v128.load32_zero and v128.load64_zero to grammar
- Add v128.{load,store}{8,16,32,64}_lane with memarg support
- Create comprehensive SIMD grammar tests (20 tests)
- Add test fixtures for regression testing