### PR TITLE
add doc comment support for function hover (JSDoc-style)

### DIFF
--- a/src/features/completion/tests.rs
+++ b/src/features/completion/tests.rs
@@ -45,6 +45,7 @@ fn create_test_symbols() -> SymbolTable {
         start_byte: 0,
         end_byte: 250,
         range: None,
+        doc_comment: None,
     };
     table.add_function(func);
 

--- a/src/features/hover/mod.rs
+++ b/src/features/hover/mod.rs
@@ -434,7 +434,15 @@ fn provide_index_hover(
 // ============================================================================
 
 fn format_function_hover(func: &Function) -> HoverResult {
-    HoverResult::new(format!("```wat\n{}\n```", format_function_signature(func)))
+    let mut content = format!("```wat\n{}\n```", format_function_signature(func));
+
+    // Add doc comment if present
+    if let Some(ref doc) = func.doc_comment {
+        content.push_str("\n\n---\n\n");
+        content.push_str(doc);
+    }
+
+    HoverResult::new(content)
 }
 
 fn format_global_hover(word: &str, global: &Global) -> HoverResult {

--- a/src/features/hover/tests.rs
+++ b/src/features/hover/tests.rs
@@ -51,6 +51,7 @@ fn create_test_symbols() -> SymbolTable {
         start_byte: 0,
         end_byte: 300,
         range: None,
+        doc_comment: None,
     };
     table.add_function(func);
 
@@ -411,6 +412,7 @@ fn test_format_function_signature() {
         start_byte: 0,
         end_byte: 150,
         range: None,
+        doc_comment: None,
     };
 
     let sig = format_function_signature(&func);
@@ -483,4 +485,50 @@ fn test_hover_outside_comment() {
     // Hover should work for instruction outside comment
     let hover = provide_hover(document, &symbols, &tree, position.into());
     assert!(hover.is_some());
+}
+
+#[test]
+fn test_hover_includes_doc_comment() {
+    use crate::parser;
+
+    // Hover over "call $add" - we need a call site
+    let doc_with_call = r#"(module
+  ;; Adds two 32-bit integers
+  (func $add (param $a i32) (param $b i32) (result i32)
+    (i32.add (local.get $a) (local.get $b)))
+  (func $main
+    (call $add (i32.const 1) (i32.const 2)))
+)"#;
+
+    let symbols_with_call = parser::parse_document(doc_with_call).unwrap();
+    let tree_with_call = create_test_tree(doc_with_call);
+
+    // Position on "$add" in the call instruction (line 5, around column 10)
+    let position = Position::new(5, 10);
+
+    let hover = provide_hover(
+        doc_with_call,
+        &symbols_with_call,
+        &tree_with_call,
+        position.into(),
+    );
+    assert!(hover.is_some(), "Expected hover for function call");
+
+    let content = match hover.unwrap().contents {
+        tower_lsp::lsp_types::HoverContents::Markup(m) => m.value,
+        _ => panic!("Expected Markup content"),
+    };
+
+    // Verify the hover contains the doc comment
+    assert!(
+        content.contains("Adds two 32-bit integers"),
+        "Hover should include doc comment. Got: {}",
+        content
+    );
+
+    // Also verify the function signature is present
+    assert!(
+        content.contains("func $add"),
+        "Hover should include function signature"
+    );
 }

--- a/src/features/signature/tests.rs
+++ b/src/features/signature/tests.rs
@@ -37,6 +37,7 @@ fn create_test_symbols() -> SymbolTable {
         start_byte: 0,
         end_byte: 200,
         range: None,
+        doc_comment: None,
     };
     table.add_function(func);
 
@@ -71,6 +72,7 @@ fn create_test_symbols() -> SymbolTable {
         start_byte: 0,
         end_byte: 300,
         range: None,
+        doc_comment: None,
     };
     table.add_function(multi_param_func);
 
@@ -268,6 +270,7 @@ fn test_format_function_signature_simple() {
         start_byte: 0,
         end_byte: 100,
         range: None,
+        doc_comment: None,
     };
 
     let sig = format_function_signature(&func);
@@ -293,6 +296,7 @@ fn test_format_function_signature_with_params() {
         start_byte: 0,
         end_byte: 100,
         range: None,
+        doc_comment: None,
     };
 
     let sig = format_function_signature(&func);
@@ -315,6 +319,7 @@ fn test_format_function_signature_with_results() {
         start_byte: 0,
         end_byte: 100,
         range: None,
+        doc_comment: None,
     };
 
     let sig = format_function_signature(&func);
@@ -342,6 +347,7 @@ fn test_format_function_signature_unnamed_params() {
         start_byte: 0,
         end_byte: 100,
         range: None,
+        doc_comment: None,
     };
 
     let sig = format_function_signature(&func);

--- a/src/features/symbols/mod.rs
+++ b/src/features/symbols/mod.rs
@@ -181,6 +181,8 @@ pub struct Function {
     pub end_byte: usize, // Byte offset where function ends
     #[allow(dead_code)] // Useful for go-to-definition
     pub range: Option<Range>,
+    /// Documentation comment extracted from comments preceding the function
+    pub doc_comment: Option<String>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/features/symbols/tests.rs
+++ b/src/features/symbols/tests.rs
@@ -25,6 +25,7 @@ fn test_add_function() {
         start_byte: 0,
         end_byte: 100,
         range: None,
+        doc_comment: None,
     };
 
     table.add_function(func);
@@ -134,6 +135,7 @@ fn test_get_function_by_index() {
             start_byte: 0,
             end_byte: 100,
             range: None,
+            doc_comment: None,
         };
         table.add_function(func);
     }
@@ -184,6 +186,7 @@ fn test_unnamed_symbols() {
         start_byte: 0,
         end_byte: 100,
         range: None,
+        doc_comment: None,
     };
     table.add_function(func);
 
@@ -210,6 +213,7 @@ fn test_multiple_symbols_same_type() {
             start_byte: 0,
             end_byte: 100,
             range: None,
+            doc_comment: None,
         };
         table.add_function(func);
     }
@@ -314,6 +318,7 @@ fn test_complex_function() {
         start_byte: 0,
         end_byte: 500,
         range: None,
+        doc_comment: None,
     };
 
     assert_eq!(func.parameters.len(), 2);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -243,6 +243,7 @@ fn extract_imported_function(desc_node: &Node, source: &str, index: usize) -> Op
         start_byte: desc_node.start_byte(),
         end_byte: desc_node.end_byte(),
         range: name_range,
+        doc_comment: None, // Imported functions don't have doc comments
     })
 }
 
@@ -578,6 +579,115 @@ fn extract_functions_with_offset(
     }
 }
 
+/// Extract doc comment from comments immediately preceding a node.
+/// Looks for comment nodes that appear on lines immediately before the target node,
+/// similar to how JSDoc works.
+///
+/// Tree structure: module_field_func's parent is module_field, whose parent is module.
+/// Comments appear as siblings of module_field under the module node.
+fn extract_doc_comment(node: &Node, source: &str) -> Option<String> {
+    let node_start_line = node.range().start_point.row;
+    if node_start_line == 0 {
+        return None;
+    }
+
+    // module_field_func -> module_field -> module
+    // We need to find comments that are siblings of module_field (our grandparent)
+    let parent = node.parent()?; // module_field
+    let grandparent = parent.parent()?; // module
+
+    let parent_start_byte = parent.start_byte();
+
+    let mut comments = Vec::new();
+    let mut cursor = grandparent.walk();
+
+    // Collect all comment nodes that appear before the module_field
+    for sibling in grandparent.children(&mut cursor) {
+        // Stop when we reach or pass our target node's parent
+        if sibling.start_byte() >= parent_start_byte {
+            break;
+        }
+
+        let kind = sibling.kind();
+        #[cfg(all(feature = "wasm", not(feature = "native")))]
+        let kind = kind.as_str();
+
+        if kind == "comment_line" || kind == "comment_block" {
+            let comment_end_line = sibling.range().end_point.row;
+            comments.push((comment_end_line, node_text(&sibling, source)));
+        }
+    }
+
+    if comments.is_empty() {
+        return None;
+    }
+
+    // Filter to only include comments that form a contiguous block ending at the line before the function
+    let mut relevant_comments = Vec::new();
+    let mut expected_line = node_start_line - 1;
+
+    // Process comments in reverse order (from closest to function to furthest)
+    for (end_line, text) in comments.into_iter().rev() {
+        // Allow for blank lines between comments (up to 1 blank line)
+        if end_line <= expected_line && expected_line - end_line <= 1 {
+            relevant_comments.push(text);
+            // Update expected line to look for comments before this one
+            expected_line = end_line.saturating_sub(1);
+        } else if relevant_comments.is_empty() {
+            // If we haven't found any comments yet and this one isn't adjacent, skip
+            continue;
+        } else {
+            // Stop if there's a gap
+            break;
+        }
+    }
+
+    if relevant_comments.is_empty() {
+        return None;
+    }
+
+    // Reverse to get comments in original order (top to bottom)
+    relevant_comments.reverse();
+
+    // Process comment text: remove comment delimiters and clean up
+    let processed: Vec<String> = relevant_comments
+        .iter()
+        .map(|c| {
+            let trimmed = c.trim();
+            if let Some(stripped) = trimmed.strip_prefix(";;") {
+                // Line comment: remove ;; prefix
+                stripped.trim().to_string()
+            } else if let Some(inner) = trimmed
+                .strip_prefix("(;")
+                .and_then(|s| s.strip_suffix(";)"))
+            {
+                // Block comment: remove (; and ;) delimiters
+                // Handle multi-line block comments by preserving line structure
+                inner
+                    .lines()
+                    .map(|line| {
+                        let l = line.trim();
+                        // Remove leading * if present (common doc comment style)
+                        l.strip_prefix('*').map(|s| s.trim()).unwrap_or(l)
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n")
+                    .trim()
+                    .to_string()
+            } else {
+                trimmed.to_string()
+            }
+        })
+        .filter(|s| !s.is_empty())
+        .collect();
+
+    if processed.is_empty() {
+        None
+    } else {
+        Some(processed.join("\n"))
+    }
+}
+
 /// Extract a single function from a func node
 fn extract_function(func_node: &Node, source: &str, index: usize) -> Option<Function> {
     let range = func_node.range();
@@ -598,6 +708,9 @@ fn extract_function(func_node: &Node, source: &str, index: usize) -> Option<Func
     let locals = extract_locals(func_node, source);
     let blocks = extract_blocks(func_node, source);
 
+    // Extract doc comment from preceding comments
+    let doc_comment = extract_doc_comment(func_node, source);
+
     Some(Function {
         name,
         index,
@@ -610,6 +723,7 @@ fn extract_function(func_node: &Node, source: &str, index: usize) -> Option<Func
         start_byte: func_node.start_byte(),
         end_byte: func_node.end_byte(),
         range: name_range,
+        doc_comment,
     })
 }
 

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -492,3 +492,120 @@ fn test_parse_011_host_watlings() {
         "$log_some_numbers should be found"
     );
 }
+
+#[test]
+fn test_parse_function_with_line_comment_doc() {
+    // Test that line comments before a function are extracted as doc comments
+    let wat = r#"(module
+  ;; Adds two numbers together
+  (func $add (param $a i32) (param $b i32) (result i32)
+    (i32.add (local.get $a) (local.get $b)))
+)"#;
+
+    let symbols = parse_document(wat).unwrap();
+    let func = &symbols.functions[0];
+
+    assert_eq!(func.name, Some("$add".to_string()));
+    assert!(
+        func.doc_comment.is_some(),
+        "Expected doc_comment, got {:?}",
+        func.doc_comment
+    );
+    assert!(func
+        .doc_comment
+        .as_ref()
+        .unwrap()
+        .contains("Adds two numbers"));
+}
+
+#[test]
+fn test_parse_function_with_block_comment_doc() {
+    // Test that block comments before a function are extracted as doc comments
+    let wat = r#"
+(module
+  (; Multiplies two numbers together ;)
+  (func $mul (param $a i32) (param $b i32) (result i32)
+    (i32.mul (local.get $a) (local.get $b)))
+)
+"#;
+
+    let symbols = parse_document(wat).unwrap();
+    let func = &symbols.functions[0];
+
+    assert_eq!(func.name, Some("$mul".to_string()));
+    assert!(func.doc_comment.is_some());
+    assert!(func
+        .doc_comment
+        .as_ref()
+        .unwrap()
+        .contains("Multiplies two numbers"));
+}
+
+#[test]
+fn test_parse_function_with_multiline_doc_comment() {
+    // Test multiple line comments form a single doc comment
+    let wat = r#"
+(module
+  ;; Calculates the factorial of n
+  ;; Uses recursive algorithm
+  (func $factorial (param $n i32) (result i32)
+    (if (result i32) (i32.le_s (local.get $n) (i32.const 1))
+      (then (i32.const 1))
+      (else (i32.mul (local.get $n)
+        (call $factorial (i32.sub (local.get $n) (i32.const 1)))))))
+)
+"#;
+
+    let symbols = parse_document(wat).unwrap();
+    let func = &symbols.functions[0];
+
+    assert_eq!(func.name, Some("$factorial".to_string()));
+    assert!(func.doc_comment.is_some());
+    let doc = func.doc_comment.as_ref().unwrap();
+    assert!(doc.contains("factorial"));
+    assert!(doc.contains("recursive"));
+}
+
+#[test]
+fn test_parse_function_without_doc_comment() {
+    // Test that functions without preceding comments have no doc comment
+    let wat = r#"
+(module
+  (func $simple (result i32)
+    (i32.const 42))
+)
+"#;
+
+    let symbols = parse_document(wat).unwrap();
+    let func = &symbols.functions[0];
+
+    assert_eq!(func.name, Some("$simple".to_string()));
+    assert!(func.doc_comment.is_none());
+}
+
+#[test]
+fn test_parse_function_comment_with_one_blank_line() {
+    // Test that comments with one blank line between them and function are still captured
+    let wat = r#"(module
+  ;; This comment has one blank line before function
+
+  (func $spaced (result i32)
+    (i32.const 0))
+)"#;
+
+    let symbols = parse_document(wat).unwrap();
+    let func = &symbols.functions[0];
+
+    assert_eq!(func.name, Some("$spaced".to_string()));
+    // The comment should be captured because we allow up to 1 blank line
+    assert!(
+        func.doc_comment.is_some(),
+        "Expected doc_comment with 1 blank line gap, got {:?}",
+        func.doc_comment
+    );
+    assert!(func
+        .doc_comment
+        .as_ref()
+        .unwrap()
+        .contains("one blank line"));
+}

--- a/src/symbol_lookup.rs
+++ b/src/symbol_lookup.rs
@@ -229,6 +229,7 @@ mod tests {
             start_byte: 0,
             end_byte: 100,
             range: Some(Range::from_coords(1, 6, 1, 10)),
+            doc_comment: None,
         });
         symbols.add_global(Global {
             name: Some("$counter".to_string()),

--- a/src/wast_parser.rs
+++ b/src/wast_parser.rs
@@ -62,6 +62,7 @@ fn extract_symbols(wat: &wast::Wat, source: &str) -> Result<SymbolTable, String>
                             start_byte: import.span.offset(),
                             end_byte: import.span.offset(),
                             range,
+                            doc_comment: None, // Imported functions don't have doc comments
                         });
                         func_index += 1;
                     }
@@ -136,6 +137,7 @@ fn extract_symbols(wat: &wast::Wat, source: &str) -> Result<SymbolTable, String>
                     start_byte: func.span.offset(),
                     end_byte: func.span.offset(),
                     range: func.id.map(|id| id_to_range(id, source)),
+                    doc_comment: None, // wast parser doesn't extract comments
                 });
                 func_index += 1;
             }


### PR DESCRIPTION
Adds JSDoc-style documentation comment support for functions. Comments placed directly above a function definition are now extracted and displayed in hover information.

- Added `doc_comment` field to Function struct
- Extracts line comments (;;) and block comments (; ... ;) preceding functions
- Supports multi-line doc comments
- Allows up to 1 blank line between comment and function
- Added comprehensive tests