### PR TITLE
add relaxed SIMD docs, memory64 support, and multi-memory improvements

### DIFF
--- a/docs/instructions.md
+++ b/docs/instructions.md
@@ -5424,3 +5424,291 @@ Example:
   (i32.const 10))      ;; number of elements to copy
 ```
 ---
+
+## f32x4.relaxed_madd
+Relaxed fused multiply-add: `a * b + c` for each f32 lane. The result may be computed with or without intermediate rounding, depending on the host platform. This allows efficient use of native FMA instructions where available.
+
+Signature: `(param v128 v128 v128) (result v128)`
+
+Example:
+```wat
+;; Compute a * b + c with relaxed precision
+(f32x4.relaxed_madd
+  (local.get $a)   ;; multiplicand
+  (local.get $b)   ;; multiplier
+  (local.get $c))  ;; addend
+```
+---
+
+## f32x4.relaxed_nmadd
+Relaxed fused negative multiply-add: `-a * b + c` for each f32 lane. The result may be computed with or without intermediate rounding, depending on the host platform.
+
+Signature: `(param v128 v128 v128) (result v128)`
+
+Example:
+```wat
+;; Compute -a * b + c with relaxed precision
+(f32x4.relaxed_nmadd
+  (local.get $a)   ;; multiplicand (negated)
+  (local.get $b)   ;; multiplier
+  (local.get $c))  ;; addend
+```
+---
+
+## f64x2.relaxed_madd
+Relaxed fused multiply-add: `a * b + c` for each f64 lane. The result may be computed with or without intermediate rounding, depending on the host platform. This allows efficient use of native FMA instructions where available.
+
+Signature: `(param v128 v128 v128) (result v128)`
+
+Example:
+```wat
+;; Compute a * b + c with relaxed precision (64-bit floats)
+(f64x2.relaxed_madd
+  (local.get $a)   ;; multiplicand
+  (local.get $b)   ;; multiplier
+  (local.get $c))  ;; addend
+```
+---
+
+## f64x2.relaxed_nmadd
+Relaxed fused negative multiply-add: `-a * b + c` for each f64 lane. The result may be computed with or without intermediate rounding, depending on the host platform.
+
+Signature: `(param v128 v128 v128) (result v128)`
+
+Example:
+```wat
+;; Compute -a * b + c with relaxed precision (64-bit floats)
+(f64x2.relaxed_nmadd
+  (local.get $a)   ;; multiplicand (negated)
+  (local.get $b)   ;; multiplier
+  (local.get $c))  ;; addend
+```
+---
+
+## i8x16.relaxed_swizzle
+Relaxed byte swizzle operation. Selects bytes from the first vector using indices from the second vector. Unlike i8x16.swizzle, the behavior for out-of-range indices (>= 16) is implementation-defined rather than returning 0.
+
+Signature: `(param v128 v128) (result v128)`
+
+Example:
+```wat
+;; Swizzle bytes with relaxed out-of-range behavior
+(i8x16.relaxed_swizzle
+  (local.get $data)     ;; source bytes
+  (local.get $indices)) ;; lane indices (0-15 for defined behavior)
+```
+---
+
+## i32x4.relaxed_trunc_f32x4_s
+Relaxed truncation of f32x4 to signed i32x4. Unlike i32x4.trunc_sat_f32x4_s, the behavior for NaN and out-of-range values is implementation-defined, allowing more efficient code generation.
+
+Signature: `(param v128) (result v128)`
+
+Example:
+```wat
+;; Truncate f32 lanes to signed i32 with relaxed semantics
+(i32x4.relaxed_trunc_f32x4_s (local.get $floats))
+```
+---
+
+## i32x4.relaxed_trunc_f32x4_u
+Relaxed truncation of f32x4 to unsigned i32x4. Unlike i32x4.trunc_sat_f32x4_u, the behavior for NaN and out-of-range values is implementation-defined, allowing more efficient code generation.
+
+Signature: `(param v128) (result v128)`
+
+Example:
+```wat
+;; Truncate f32 lanes to unsigned i32 with relaxed semantics
+(i32x4.relaxed_trunc_f32x4_u (local.get $floats))
+```
+---
+
+## i32x4.relaxed_trunc_f64x2_s_zero
+Relaxed truncation of f64x2 to signed i32x4 with zero extension. Converts two f64 lanes to i32 and sets the upper two i32 lanes to zero. Behavior for NaN and out-of-range values is implementation-defined.
+
+Signature: `(param v128) (result v128)`
+
+Example:
+```wat
+;; Truncate two f64 lanes to signed i32, upper lanes zeroed
+(i32x4.relaxed_trunc_f64x2_s_zero (local.get $doubles))
+```
+---
+
+## i32x4.relaxed_trunc_f64x2_u_zero
+Relaxed truncation of f64x2 to unsigned i32x4 with zero extension. Converts two f64 lanes to u32 and sets the upper two i32 lanes to zero. Behavior for NaN and out-of-range values is implementation-defined.
+
+Signature: `(param v128) (result v128)`
+
+Example:
+```wat
+;; Truncate two f64 lanes to unsigned i32, upper lanes zeroed
+(i32x4.relaxed_trunc_f64x2_u_zero (local.get $doubles))
+```
+---
+
+## f32x4.relaxed_min
+Relaxed lane-wise minimum of two f32x4 vectors. Unlike f32x4.min, the behavior for NaN inputs is implementation-defined, allowing use of efficient native min instructions.
+
+Signature: `(param v128 v128) (result v128)`
+
+Example:
+```wat
+;; Relaxed minimum with implementation-defined NaN handling
+(f32x4.relaxed_min (local.get $a) (local.get $b))
+```
+---
+
+## f32x4.relaxed_max
+Relaxed lane-wise maximum of two f32x4 vectors. Unlike f32x4.max, the behavior for NaN inputs is implementation-defined, allowing use of efficient native max instructions.
+
+Signature: `(param v128 v128) (result v128)`
+
+Example:
+```wat
+;; Relaxed maximum with implementation-defined NaN handling
+(f32x4.relaxed_max (local.get $a) (local.get $b))
+```
+---
+
+## f64x2.relaxed_min
+Relaxed lane-wise minimum of two f64x2 vectors. Unlike f64x2.min, the behavior for NaN inputs is implementation-defined, allowing use of efficient native min instructions.
+
+Signature: `(param v128 v128) (result v128)`
+
+Example:
+```wat
+;; Relaxed minimum with implementation-defined NaN handling (64-bit)
+(f64x2.relaxed_min (local.get $a) (local.get $b))
+```
+---
+
+## f64x2.relaxed_max
+Relaxed lane-wise maximum of two f64x2 vectors. Unlike f64x2.max, the behavior for NaN inputs is implementation-defined, allowing use of efficient native max instructions.
+
+Signature: `(param v128 v128) (result v128)`
+
+Example:
+```wat
+;; Relaxed maximum with implementation-defined NaN handling (64-bit)
+(f64x2.relaxed_max (local.get $a) (local.get $b))
+```
+---
+
+## i8x16.relaxed_laneselect
+Relaxed lane select for i8x16 vectors. Selects bytes from the first or second vector based on the mask. The exact selection semantics (whether it uses the high bit or all bits of each mask byte) is implementation-defined.
+
+Signature: `(param v128 v128 v128) (result v128)`
+
+Example:
+```wat
+;; Select bytes based on mask with relaxed semantics
+(i8x16.relaxed_laneselect
+  (local.get $a)      ;; selected when mask bit is set
+  (local.get $b)      ;; selected when mask bit is clear
+  (local.get $mask))  ;; selection mask
+```
+---
+
+## i16x8.relaxed_laneselect
+Relaxed lane select for i16x8 vectors. Selects 16-bit lanes from the first or second vector based on the mask. The exact selection semantics is implementation-defined.
+
+Signature: `(param v128 v128 v128) (result v128)`
+
+Example:
+```wat
+;; Select 16-bit lanes based on mask with relaxed semantics
+(i16x8.relaxed_laneselect
+  (local.get $a)      ;; selected when mask bit is set
+  (local.get $b)      ;; selected when mask bit is clear
+  (local.get $mask))  ;; selection mask
+```
+---
+
+## i32x4.relaxed_laneselect
+Relaxed lane select for i32x4 vectors. Selects 32-bit lanes from the first or second vector based on the mask. The exact selection semantics is implementation-defined.
+
+Signature: `(param v128 v128 v128) (result v128)`
+
+Example:
+```wat
+;; Select 32-bit lanes based on mask with relaxed semantics
+(i32x4.relaxed_laneselect
+  (local.get $a)      ;; selected when mask bit is set
+  (local.get $b)      ;; selected when mask bit is clear
+  (local.get $mask))  ;; selection mask
+```
+---
+
+## i64x2.relaxed_laneselect
+Relaxed lane select for i64x2 vectors. Selects 64-bit lanes from the first or second vector based on the mask. The exact selection semantics is implementation-defined.
+
+Signature: `(param v128 v128 v128) (result v128)`
+
+Example:
+```wat
+;; Select 64-bit lanes based on mask with relaxed semantics
+(i64x2.relaxed_laneselect
+  (local.get $a)      ;; selected when mask bit is set
+  (local.get $b)      ;; selected when mask bit is clear
+  (local.get $mask))  ;; selection mask
+```
+---
+
+## i16x8.relaxed_q15mulr_s
+Relaxed Q15 rounding multiply returning high half for signed i16x8 lanes. Computes `(a * b + 0x4000) >> 15` with implementation-defined overflow behavior. Useful for fixed-point DSP operations.
+
+Signature: `(param v128 v128) (result v128)`
+
+Example:
+```wat
+;; Q15 fixed-point multiply with relaxed overflow
+(i16x8.relaxed_q15mulr_s (local.get $a) (local.get $b))
+```
+---
+
+## i16x8.relaxed_dot_i8x16_i7x16_s
+Relaxed dot product of i8x16 and i7x16 (7-bit unsigned) vectors, producing i16x8 results. Multiplies pairs of 8-bit values and sums adjacent products. The behavior when the second operand has the high bit set is implementation-defined.
+
+Signature: `(param v128 v128) (result v128)`
+
+Example:
+```wat
+;; Dot product: sum of pairwise products of 8-bit lanes
+(i16x8.relaxed_dot_i8x16_i7x16_s
+  (local.get $a)   ;; signed 8-bit values
+  (local.get $b))  ;; 7-bit unsigned values (high bit behavior undefined)
+```
+---
+
+## i32x4.relaxed_dot_i8x16_i7x16_add_s
+Relaxed dot product of i8x16 and i7x16 vectors with i32x4 accumulation. Multiplies pairs of 8-bit values, sums groups of four products, and adds to the accumulator. The behavior when the second operand has the high bit set is implementation-defined.
+
+Signature: `(param v128 v128 v128) (result v128)`
+
+Example:
+```wat
+;; Dot product with accumulation: useful for neural network inference
+(i32x4.relaxed_dot_i8x16_i7x16_add_s
+  (local.get $a)     ;; signed 8-bit values
+  (local.get $b)     ;; 7-bit unsigned values
+  (local.get $acc))  ;; i32x4 accumulator
+```
+---
+
+## func.bind
+Partially apply a function, binding some arguments to produce a new function reference with a reduced signature. This is part of the typed function references proposal and allows creating closures over function arguments.
+
+Signature: `(param funcref args...) (result funcref)`
+
+Example:
+```wat
+(type $binary (func (param i32 i32) (result i32)))
+(type $unary (func (param i32) (result i32)))
+
+;; Bind the first argument of an add function to create an "add 5" function
+(func.bind (type $unary)
+  (ref.func $add)      ;; function to partially apply
+  (i32.const 5))       ;; bound first argument
+```
+---

--- a/grammars/tree-sitter-wat/grammar.js
+++ b/grammars/tree-sitter-wat/grammar.js
@@ -714,7 +714,12 @@ module.exports = grammar({
 
     memory_fields_type: $ => seq(optional($.import), $.memory_type),
 
-    memory_type: $ => $.limits,
+    // proposal: memory64
+    // Memory type can optionally include 'i64' keyword for 64-bit addressing
+    memory_type: $ => seq(optional($.memory64_type), $.limits),
+
+    // proposal: memory64
+    memory64_type: $ => "i64",
 
     memory_use: $ => seq("(", "memory", $.index, ")"),
 

--- a/src/diagnostics/instruction_metadata.rs
+++ b/src/diagnostics/instruction_metadata.rs
@@ -331,9 +331,25 @@ pub fn get_instruction_arity_map() -> HashMap<&'static str, InstructionArity> {
     map.insert("i64.store16", InstructionArity::mem_store());
     map.insert("i64.store32", InstructionArity::mem_store());
 
-    // Memory management (nullary in linear, but memory.grow consumes 1 in folded)
-    map.insert("memory.size", InstructionArity::nullary());
-    map.insert("memory.grow", InstructionArity::unary_op());
+    // Memory management - support optional memory index (multi-memory proposal)
+    map.insert(
+        "memory.size",
+        InstructionArity {
+            min_params: 0,
+            max_params: 1,
+            param_description: "optional memory index",
+            operand_mode: OperandMode::Fixed(0), // produces i32 (current size)
+        },
+    );
+    map.insert(
+        "memory.grow",
+        InstructionArity {
+            min_params: 0,
+            max_params: 1,
+            param_description: "optional memory index",
+            operand_mode: OperandMode::Fixed(1), // consumes delta, produces i32 (previous size or -1)
+        },
+    );
 
     // WasmGC Instructions
     // Structs
@@ -442,10 +458,34 @@ pub fn get_instruction_arity_map() -> HashMap<&'static str, InstructionArity> {
         InstructionArity::exact(2, "type and elem index", 4),
     ); // array, dst, src, len
 
-    // Bulk memory operations
-    map.insert("memory.copy", InstructionArity::exact(0, "", 3)); // dest, src, len
-    map.insert("memory.fill", InstructionArity::exact(0, "", 3)); // dest, val, len
-    map.insert("memory.init", InstructionArity::exact(1, "data index", 3)); // dest, offset, len
+    // Bulk memory operations - support optional memory indices (multi-memory proposal)
+    map.insert(
+        "memory.copy",
+        InstructionArity {
+            min_params: 0,
+            max_params: 2,
+            param_description: "optional dest and src memory indices",
+            operand_mode: OperandMode::Fixed(3), // dest offset, src offset, len
+        },
+    );
+    map.insert(
+        "memory.fill",
+        InstructionArity {
+            min_params: 0,
+            max_params: 1,
+            param_description: "optional memory index",
+            operand_mode: OperandMode::Fixed(3), // dest, val, len
+        },
+    );
+    map.insert(
+        "memory.init",
+        InstructionArity {
+            min_params: 1,
+            max_params: 2,
+            param_description: "data index and optional memory index",
+            operand_mode: OperandMode::Fixed(3), // dest, offset, len
+        },
+    );
     map.insert("data.drop", InstructionArity::exact(1, "data index", 0));
 
     // Table operations

--- a/src/diagnostics/semantic_diagnostics.rs
+++ b/src/diagnostics/semantic_diagnostics.rs
@@ -18,6 +18,7 @@ pub fn provide_semantic_diagnostics(
     walk_tree_for_undefined_references(tree.root_node(), source, symbols, &mut diagnostics);
     walk_tree_for_parameter_counts(tree.root_node(), source, symbols, &mut diagnostics);
     check_atomic_operations_shared_memory(tree.root_node(), source, symbols, &mut diagnostics);
+    check_memory64_operations(tree.root_node(), source, symbols, &mut diagnostics);
     diagnostics
 }
 
@@ -822,6 +823,176 @@ fn create_operand_count_diagnostic(
         tags: None,
         data: None,
     }
+}
+
+/// Check for memory64-specific semantic issues
+/// When a memory is declared with i64 address space (memory64), operations on it
+/// should use i64 addresses instead of i32
+fn check_memory64_operations(
+    node: Node,
+    source: &str,
+    symbols: &SymbolTable,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    // Skip if there are no memory64 memories
+    let memory64_memories: Vec<_> = symbols.memories.iter().filter(|m| m.is_memory64).collect();
+
+    if memory64_memories.is_empty() {
+        return;
+    }
+
+    // Walk the tree looking for memory operations
+    walk_tree_for_memory64_ops(node, source, symbols, diagnostics);
+}
+
+/// Recursively find memory operations and validate memory64 usage
+fn walk_tree_for_memory64_ops(
+    node: Node,
+    source: &str,
+    symbols: &SymbolTable,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    if node.kind() == "instr_plain" || node.kind() == "expr1_plain" {
+        let text = &source[node.byte_range()];
+        let first_token = text.split_whitespace().next().unwrap_or("");
+
+        // Check memory.size and memory.grow - these have different return/param types for memory64
+        if first_token == "memory.size" || first_token == "memory.grow" {
+            if let Some(memory) = get_memory_for_instruction(&node, source, symbols) {
+                if memory.is_memory64 {
+                    let range = node_to_lsp_range(&node);
+                    let (return_type, param_info) = if first_token == "memory.size" {
+                        ("i64", "")
+                    } else {
+                        ("i64", " and takes i64 delta parameter")
+                    };
+                    diagnostics.push(Diagnostic {
+                        range,
+                        severity: Some(DiagnosticSeverity::HINT),
+                        code: Some(NumberOrString::String("memory64-type".to_string())),
+                        code_description: None,
+                        source: Some("wat-lsp".to_string()),
+                        message: format!(
+                            "'{}' on memory64 returns {}{}",
+                            first_token, return_type, param_info
+                        ),
+                        related_information: None,
+                        tags: None,
+                        data: None,
+                    });
+                }
+            }
+        }
+
+        // Check load/store operations
+        if is_memory_load_store(first_token) {
+            if let Some(memory) = get_memory_for_instruction(&node, source, symbols) {
+                if memory.is_memory64 {
+                    let range = node_to_lsp_range(&node);
+                    diagnostics.push(Diagnostic {
+                        range,
+                        severity: Some(DiagnosticSeverity::HINT),
+                        code: Some(NumberOrString::String("memory64-address".to_string())),
+                        code_description: None,
+                        source: Some("wat-lsp".to_string()),
+                        message: format!(
+                            "'{}' on memory64 requires i64 address operand",
+                            first_token
+                        ),
+                        related_information: None,
+                        tags: None,
+                        data: None,
+                    });
+                }
+            }
+        }
+
+        // Check bulk memory operations
+        if first_token == "memory.copy" || first_token == "memory.fill" {
+            // For memory.copy, check both source and dest memories
+            // For memory.fill, check the target memory
+            if let Some(memory) = get_memory_for_instruction(&node, source, symbols) {
+                if memory.is_memory64 {
+                    let range = node_to_lsp_range(&node);
+                    diagnostics.push(Diagnostic {
+                        range,
+                        severity: Some(DiagnosticSeverity::HINT),
+                        code: Some(NumberOrString::String("memory64-bulk".to_string())),
+                        code_description: None,
+                        source: Some("wat-lsp".to_string()),
+                        message: format!(
+                            "'{}' on memory64 requires i64 address operands",
+                            first_token
+                        ),
+                        related_information: None,
+                        tags: None,
+                        data: None,
+                    });
+                }
+            }
+        }
+    }
+
+    // Recursively check children
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        walk_tree_for_memory64_ops(child, source, symbols, diagnostics);
+    }
+}
+
+/// Get the memory referenced by an instruction
+/// Returns the memory at index 0 if no explicit memory index is specified
+fn get_memory_for_instruction<'a>(
+    node: &Node,
+    source: &str,
+    symbols: &'a SymbolTable,
+) -> Option<&'a crate::symbols::Memory> {
+    // Try to find an explicit memory index in the instruction
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "index" {
+            let index_text = &source[child.byte_range()];
+            // Check if it's a named memory reference
+            if index_text.starts_with('$') {
+                return symbols.get_memory_by_name(index_text);
+            }
+            // Check if it's a numeric index
+            if let Ok(idx) = index_text.parse::<usize>() {
+                return symbols.memories.get(idx);
+            }
+        }
+    }
+
+    // Default to memory 0
+    symbols.memories.first()
+}
+
+/// Check if an instruction is a memory load or store operation
+fn is_memory_load_store(instr: &str) -> bool {
+    // Load operations
+    if instr.ends_with(".load")
+        || instr.contains(".load8_")
+        || instr.contains(".load16_")
+        || instr.contains(".load32_")
+    {
+        return true;
+    }
+
+    // Store operations
+    if instr.ends_with(".store")
+        || instr.contains(".store8")
+        || instr.contains(".store16")
+        || instr.contains(".store32")
+    {
+        return true;
+    }
+
+    // SIMD load/store operations
+    if instr.starts_with("v128.load") || instr.starts_with("v128.store") {
+        return true;
+    }
+
+    false
 }
 
 #[cfg(test)]
@@ -1785,5 +1956,149 @@ mod tests {
         assert!(!is_atomic_memory_operation("i32.load"));
         assert!(!is_atomic_memory_operation("i64.store"));
         assert!(!is_atomic_memory_operation("memory.grow"));
+    }
+
+    // Memory64 tests
+
+    #[test]
+    fn test_memory64_no_hints_for_regular_memory() {
+        // Regular memory should not produce memory64 hints
+        let document = r#"(module
+  (memory 1)
+
+  (func $test (result i32)
+    (memory.size)
+  )
+)"#;
+
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        let memory64_hints: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.code == Some(NumberOrString::String("memory64-type".to_string())))
+            .collect();
+        assert_eq!(
+            memory64_hints.len(),
+            0,
+            "Regular memory should not produce memory64 hints"
+        );
+    }
+
+    #[test]
+    fn test_memory64_hints_for_memory_size() {
+        // memory64 memory should produce hints for memory.size
+        let document = r#"(module
+  (memory i64 1)
+
+  (func $test (result i64)
+    (memory.size)
+  )
+)"#;
+
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+
+        // Verify memory64 was detected
+        assert!(
+            symbols
+                .memories
+                .first()
+                .map(|m| m.is_memory64)
+                .unwrap_or(false),
+            "Memory should be detected as memory64"
+        );
+
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        let memory64_hints: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.message.contains("memory64"))
+            .collect();
+        assert!(
+            !memory64_hints.is_empty(),
+            "memory64 should produce hints for memory.size"
+        );
+    }
+
+    #[test]
+    fn test_memory64_hints_for_memory_grow() {
+        // memory64 memory should produce hints for memory.grow
+        let document = r#"(module
+  (memory i64 1)
+
+  (func $test (result i64)
+    (memory.grow (i64.const 1))
+  )
+)"#;
+
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        let memory64_hints: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.message.contains("memory64") && d.message.contains("memory.grow"))
+            .collect();
+        assert!(
+            !memory64_hints.is_empty(),
+            "memory64 should produce hints for memory.grow"
+        );
+    }
+
+    #[test]
+    fn test_memory64_hints_for_load_store() {
+        // memory64 memory should produce hints for load/store
+        let document = r#"(module
+  (memory i64 1)
+
+  (func $test (result i32)
+    (i32.load (i64.const 0))
+  )
+)"#;
+
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        let memory64_hints: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.message.contains("i64 address"))
+            .collect();
+        assert!(
+            !memory64_hints.is_empty(),
+            "memory64 should produce hints about i64 address for load"
+        );
+    }
+
+    #[test]
+    fn test_is_memory_load_store() {
+        // Test the helper function
+        assert!(is_memory_load_store("i32.load"));
+        assert!(is_memory_load_store("i64.load"));
+        assert!(is_memory_load_store("f32.load"));
+        assert!(is_memory_load_store("f64.load"));
+        assert!(is_memory_load_store("i32.load8_s"));
+        assert!(is_memory_load_store("i32.load8_u"));
+        assert!(is_memory_load_store("i32.load16_s"));
+        assert!(is_memory_load_store("i64.load32_u"));
+
+        assert!(is_memory_load_store("i32.store"));
+        assert!(is_memory_load_store("i64.store"));
+        assert!(is_memory_load_store("f32.store"));
+        assert!(is_memory_load_store("i32.store8"));
+        assert!(is_memory_load_store("i64.store32"));
+
+        assert!(is_memory_load_store("v128.load"));
+        assert!(is_memory_load_store("v128.store"));
+
+        // Non-memory operations should not match
+        assert!(!is_memory_load_store("i32.add"));
+        assert!(!is_memory_load_store("memory.size"));
+        assert!(!is_memory_load_store("local.get"));
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -370,12 +370,9 @@ fn extract_imported_memory(desc_node: &Node, source: &str, index: usize) -> Opti
         if child.kind() == "memory_type" {
             let mut type_cursor = child.walk();
             for type_child in child.children(&mut type_cursor) {
-                // Check for i64 keyword indicating memory64
-                if type_child.kind() == "value_type" {
-                    let type_text = node_text(&type_child, source);
-                    if type_text == "i64" {
-                        is_memory64 = true;
-                    }
+                // Check for memory64_type (i64 keyword) indicating memory64
+                if type_child.kind() == "memory64_type" {
+                    is_memory64 = true;
                 }
                 if type_child.kind() == "limits" {
                     let mut limits_cursor = type_child.walk();
@@ -1697,32 +1694,23 @@ fn extract_memory(memory_node: &Node, source: &str, index: usize) -> Option<Memo
 
     let mut cursor = memory_node.walk();
     for child in memory_node.children(&mut cursor) {
-        // Check for i64 keyword at memory node level indicating memory64
-        if child.kind() == "value_type" {
-            let type_text = node_text(&child, source);
-            if type_text == "i64" {
-                is_memory64 = true;
-            }
+        // Check for memory64_type (i64 keyword) at memory node level
+        if child.kind() == "memory64_type" {
+            is_memory64 = true;
         }
         if child.kind() == "memory_fields_type" {
             let mut fields_cursor = child.walk();
             for fields_child in child.children(&mut fields_cursor) {
-                // Check for i64 keyword in memory_fields_type
-                if fields_child.kind() == "value_type" {
-                    let type_text = node_text(&fields_child, source);
-                    if type_text == "i64" {
-                        is_memory64 = true;
-                    }
+                // Check for memory64_type in memory_fields_type
+                if fields_child.kind() == "memory64_type" {
+                    is_memory64 = true;
                 }
                 if fields_child.kind() == "memory_type" {
                     let mut type_cursor = fields_child.walk();
                     for type_child in fields_child.children(&mut type_cursor) {
-                        // Check for i64 keyword in memory_type
-                        if type_child.kind() == "value_type" {
-                            let type_text = node_text(&type_child, source);
-                            if type_text == "i64" {
-                                is_memory64 = true;
-                            }
+                        // Check for memory64_type in memory_type
+                        if type_child.kind() == "memory64_type" {
+                            is_memory64 = true;
                         }
                         if type_child.kind() == "limits" {
                             extract_limits(
@@ -1739,12 +1727,9 @@ fn extract_memory(memory_node: &Node, source: &str, index: usize) -> Option<Memo
             // Handle direct memory_type (without wrapper)
             let mut type_cursor = child.walk();
             for type_child in child.children(&mut type_cursor) {
-                // Check for i64 keyword in memory_type
-                if type_child.kind() == "value_type" {
-                    let type_text = node_text(&type_child, source);
-                    if type_text == "i64" {
-                        is_memory64 = true;
-                    }
+                // Check for memory64_type in memory_type
+                if type_child.kind() == "memory64_type" {
+                    is_memory64 = true;
                 }
                 if type_child.kind() == "limits" {
                     extract_limits(&type_child, &mut min_limit, &mut max_limit, &mut shared);

--- a/tests/fixtures/multi_memory.wat
+++ b/tests/fixtures/multi_memory.wat
@@ -1,0 +1,81 @@
+;; Multi-memory test fixture
+;; Tests the multi-memory proposal features
+
+(module
+  ;; Multiple memory definitions
+  (memory $mem0 1)
+  (memory $mem1 2 4)
+  (memory $mem2 1 1)
+
+  ;; Import a memory
+  (import "env" "external_mem" (memory $imported 1))
+
+  ;; Export memories
+  (export "memory0" (memory $mem0))
+  (export "memory1" (memory $mem1))
+
+  ;; Data segments targeting different memories
+  (data $d0 (memory $mem0) (i32.const 0) "hello")
+  (data $d1 (memory $mem1) (i32.const 0) "world")
+  (data $d2 (memory 2) (i32.const 0) "test")
+
+  ;; Function using multi-memory instructions
+  (func $multi_memory_ops (export "multi_memory_ops")
+    ;; memory.size with explicit indices
+    (drop (memory.size $mem0))
+    (drop (memory.size $mem1))
+    (drop (memory.size 0))
+    (drop (memory.size 1))
+
+    ;; memory.grow with explicit indices
+    (drop (memory.grow $mem0 (i32.const 1)))
+    (drop (memory.grow $mem1 (i32.const 1)))
+    (drop (memory.grow 0 (i32.const 1)))
+    (drop (memory.grow 1 (i32.const 1)))
+
+    ;; memory.fill with explicit indices
+    (memory.fill $mem0
+      (i32.const 0)    ;; destination
+      (i32.const 0)    ;; value
+      (i32.const 10))  ;; count
+    (memory.fill 1
+      (i32.const 0)
+      (i32.const 0)
+      (i32.const 10))
+
+    ;; memory.copy between memories
+    (memory.copy $mem0 $mem1
+      (i32.const 0)    ;; dest offset
+      (i32.const 0)    ;; src offset
+      (i32.const 10))  ;; length
+    (memory.copy 0 1
+      (i32.const 0)
+      (i32.const 0)
+      (i32.const 10))
+
+    ;; memory.init with memory index
+    (memory.init $mem0 $d0
+      (i32.const 0)
+      (i32.const 0)
+      (i32.const 5))
+    (memory.init 1 $d1
+      (i32.const 0)
+      (i32.const 0)
+      (i32.const 5))
+  )
+
+  ;; Function with load/store to different memories
+  (func $load_store_multi (param $addr i32) (result i32)
+    ;; Load from memory 0
+    (i32.store $mem0 (local.get $addr) (i32.const 42))
+    ;; Load from memory 1
+    (i32.store $mem1 (local.get $addr) (i32.const 43))
+    ;; Load from memory 0
+    (i32.load $mem0 (local.get $addr))
+  )
+
+  ;; Function with offset and align on different memories
+  (func $load_with_offset (param $addr i32) (result i32)
+    (i32.load $mem0 offset=4 align=4 (local.get $addr))
+  )
+)

--- a/tests/phase5_grammar_test.rs
+++ b/tests/phase5_grammar_test.rs
@@ -196,8 +196,7 @@ fn test_parse_shared_memory() {
 
 #[test]
 fn test_parse_memory64() {
-    // Note: The tree-sitter grammar may parse this differently
-    // This test verifies the parser handles the syntax
+    // Test that memory64 (i64-addressed memory) is properly detected
     let wat = r#"
 (module
   (memory $mem64 i64 1)
@@ -205,9 +204,14 @@ fn test_parse_memory64() {
 "#;
 
     let symbols = parse_document(wat).unwrap();
-    // Just verify parsing doesn't fail
-    // Memory64 detection depends on grammar support
-    let _ = symbols.memories.len(); // Parsing succeeded
+    assert_eq!(symbols.memories.len(), 1, "Should have 1 memory");
+
+    let mem = &symbols.memories[0];
+    eprintln!(
+        "Memory name: {:?}, is_memory64: {}",
+        mem.name, mem.is_memory64
+    );
+    assert!(mem.is_memory64, "Memory should be detected as memory64");
 }
 
 #[test]
@@ -311,4 +315,161 @@ fn test_subtype_final_parsing() {
     // Both types should exist
     assert!(symbols.get_type_by_name("$base").is_some());
     assert!(symbols.get_type_by_name("$derived").is_some());
+}
+
+// =============================================================================
+// Multi-Memory Tests
+// =============================================================================
+
+#[test]
+fn test_parse_multi_memory_definitions() {
+    let wat = r#"
+(module
+  (memory $mem0 1)
+  (memory $mem1 2 4)
+  (memory $mem2 1 1)
+)
+"#;
+
+    let symbols = parse_document(wat).unwrap();
+    assert_eq!(symbols.memories.len(), 3, "Should have 3 memories");
+
+    // Verify each memory was parsed
+    assert!(symbols.get_memory_by_name("$mem0").is_some());
+    assert!(symbols.get_memory_by_name("$mem1").is_some());
+    assert!(symbols.get_memory_by_name("$mem2").is_some());
+}
+
+#[test]
+fn test_parse_multi_memory_with_import() {
+    let wat = r#"
+(module
+  (import "env" "external_mem" (memory $imported 1))
+  (memory $local 2)
+)
+"#;
+
+    let symbols = parse_document(wat).unwrap();
+    assert_eq!(
+        symbols.memories.len(),
+        2,
+        "Should have 2 memories (1 imported, 1 local)"
+    );
+
+    assert!(symbols.get_memory_by_name("$imported").is_some());
+    assert!(symbols.get_memory_by_name("$local").is_some());
+}
+
+#[test]
+fn test_parse_memory_size_with_index() {
+    // Test that memory.size with explicit index parses correctly
+    let wat = r#"
+(module
+  (memory $mem0 1)
+  (memory $mem1 1)
+  (func $test (result i32)
+    (memory.size $mem1)
+  )
+)
+"#;
+
+    let symbols = parse_document(wat).unwrap();
+    assert_eq!(symbols.memories.len(), 2);
+    assert_eq!(symbols.functions.len(), 1);
+}
+
+#[test]
+fn test_parse_memory_grow_with_index() {
+    // Test that memory.grow with explicit index parses correctly
+    let wat = r#"
+(module
+  (memory $mem0 1)
+  (memory $mem1 1)
+  (func $test (result i32)
+    (memory.grow $mem1 (i32.const 1))
+  )
+)
+"#;
+
+    let symbols = parse_document(wat).unwrap();
+    assert_eq!(symbols.memories.len(), 2);
+    assert_eq!(symbols.functions.len(), 1);
+}
+
+#[test]
+fn test_parse_memory_copy_between_memories() {
+    // Test memory.copy with two memory indices (dest, src)
+    let wat = r#"
+(module
+  (memory $mem0 1)
+  (memory $mem1 1)
+  (func $test
+    (memory.copy $mem0 $mem1
+      (i32.const 0)
+      (i32.const 0)
+      (i32.const 10))
+  )
+)
+"#;
+
+    let symbols = parse_document(wat).unwrap();
+    assert_eq!(symbols.memories.len(), 2);
+    assert_eq!(symbols.functions.len(), 1);
+}
+
+#[test]
+fn test_parse_memory_fill_with_index() {
+    // Test memory.fill with explicit memory index
+    let wat = r#"
+(module
+  (memory $mem0 1)
+  (memory $mem1 1)
+  (func $test
+    (memory.fill $mem1
+      (i32.const 0)
+      (i32.const 0)
+      (i32.const 10))
+  )
+)
+"#;
+
+    let symbols = parse_document(wat).unwrap();
+    assert_eq!(symbols.memories.len(), 2);
+    assert_eq!(symbols.functions.len(), 1);
+}
+
+#[test]
+fn test_parse_data_segment_with_memory_index() {
+    // Test data segments targeting specific memories
+    let wat = r#"
+(module
+  (memory $mem0 1)
+  (memory $mem1 1)
+  (data $d0 (memory $mem0) (i32.const 0) "hello")
+  (data $d1 (memory $mem1) (i32.const 0) "world")
+)
+"#;
+
+    let symbols = parse_document(wat).unwrap();
+    assert_eq!(symbols.memories.len(), 2);
+    assert_eq!(symbols.data_segments.len(), 2);
+}
+
+#[test]
+fn test_parse_load_store_with_memory_index() {
+    // Test load/store operations with explicit memory index
+    let wat = r#"
+(module
+  (memory $mem0 1)
+  (memory $mem1 1)
+  (func $test (param $addr i32) (result i32)
+    (i32.store $mem1 (local.get $addr) (i32.const 42))
+    (i32.load $mem0 (local.get $addr))
+  )
+)
+"#;
+
+    let symbols = parse_document(wat).unwrap();
+    assert_eq!(symbols.memories.len(), 2);
+    assert_eq!(symbols.functions.len(), 1);
 }


### PR DESCRIPTION
## Summary

- Add documentation for 21 Relaxed SIMD instructions
- Add full Memory64 proposal support (grammar, parser, semantic validation)
- Improve multi-memory support with tests and instruction metadata fixes
- Add func.bind instruction documentation

## Changes

- **Relaxed SIMD:** Added docs for fused multiply-add, swizzle, truncation, min/max, lane select, Q15 multiply, dot products
- **Memory64:** Grammar support for `i64` keyword, parser detection, semantic hints for address types
- **Multi-memory:** Comprehensive tests, fixed instruction metadata for memory ops