### PR TITLE
Add document symbols LSP feature with playground outline view

### DIFF
--- a/packages/playground/index.html
+++ b/packages/playground/index.html
@@ -42,6 +42,7 @@
         <div class="resize-handle"></div>
         <div class="tabs">
           <button class="tab active" data-tab="module-info">Module Info</button>
+          <button class="tab" data-tab="outline">Outline</button>
           <button class="tab" data-tab="console">Console</button>
           <button class="tab" data-tab="hex">Hex View</button>
           <button class="tab" data-tab="lsp-debug">LSP Debug</button>
@@ -71,6 +72,12 @@
                 <button id="call-fn-btn" class="btn btn-small" disabled>Call</button>
               </div>
               <div id="fn-result" class="fn-result"></div>
+            </div>
+          </div>
+
+          <div id="outline" class="tab-pane">
+            <div id="outline-view" class="outline-tree">
+              <p class="placeholder">Parse document to see outline</p>
             </div>
           </div>
 
@@ -116,7 +123,7 @@
     </div>
 
     <footer>
-      <span>WAT LSP Playground - Hover, Go to Definition (F12), Find References (Shift+F12)</span>
+      <span>WAT LSP Playground - Hover, Go to Definition (F12), Find References (Shift+F12), Outline</span>
       <span id="status">Ready</span>
     </footer>
   </div>

--- a/packages/playground/main.ts
+++ b/packages/playground/main.ts
@@ -69,6 +69,24 @@ interface WatLSP {
   getSymbolTableHTML(): string;
   getSemanticTokensLegend(): monaco.languages.SemanticTokensLegend;
   provideSemanticTokens(): Uint32Array;
+  provideDocumentSymbols?(): Array<{
+    name: string;
+    detail?: string;
+    kind: number;
+    range: {
+      start: { line: number; character: number };
+      end: { line: number; character: number };
+    };
+    children?: Array<{
+      name: string;
+      detail?: string;
+      kind: number;
+      range: {
+        start: { line: number; character: number };
+        end: { line: number; character: number };
+      };
+    }>;
+  }>;
 }
 
 // Global state
@@ -100,6 +118,7 @@ let elements: {
   diagnosticsView: HTMLElement;
   symbolTableView: HTMLElement;
   hoverDebug: HTMLElement;
+  outlineView: HTMLElement;
   testLine: HTMLInputElement;
   testCol: HTMLInputElement;
   testHoverBtn: HTMLButtonElement;
@@ -415,6 +434,57 @@ async function initMonaco(): Promise<void> {
     },
   });
 
+  // Register document symbol provider for outline view
+  monaco.languages.registerDocumentSymbolProvider('wat', {
+    provideDocumentSymbols: (
+      model: monaco.editor.ITextModel
+    ): monaco.languages.ProviderResult<monaco.languages.DocumentSymbol[]> => {
+      if (!watLSP || !watLSP.ready || !watLSP.provideDocumentSymbols) return [];
+
+      // Parse latest content
+      watLSP.parse(model.getValue());
+
+      const symbols = watLSP.provideDocumentSymbols();
+      if (!symbols || symbols.length === 0) return [];
+
+      // Convert to Monaco DocumentSymbol format (recursively handle children)
+      function convertSymbol(sym: {
+        name: string;
+        detail?: string;
+        kind: number;
+        range: { start: { line: number; character: number }; end: { line: number; character: number } };
+        children?: Array<{ name: string; detail?: string; kind: number; range: { start: { line: number; character: number }; end: { line: number; character: number } } }>;
+      }): monaco.languages.DocumentSymbol {
+        const range = sym.range
+          ? new monaco.Range(
+              sym.range.start.line + 1,
+              sym.range.start.character + 1,
+              sym.range.end.line + 1,
+              sym.range.end.character + 1
+            )
+          : new monaco.Range(1, 1, 1, 1);
+
+        const result: monaco.languages.DocumentSymbol = {
+          name: sym.name,
+          detail: sym.detail || '',
+          kind: sym.kind as monaco.languages.SymbolKind,
+          range: range,
+          selectionRange: range,
+          children: [],
+          tags: [],
+        };
+
+        if (sym.children && sym.children.length > 0) {
+          result.children = sym.children.map(convertSymbol);
+        }
+
+        return result;
+      }
+
+      return symbols.map(convertSymbol);
+    },
+  });
+
   // Define custom theme matching VS Code Dark+ colors
   monaco.editor.defineTheme('wat-dark', {
     base: 'vs-dark',
@@ -555,6 +625,70 @@ function updateDiagnostics(): void {
 function updateLSPDebugPanel(): void {
   if (!watLSP) return;
   elements.symbolTableView.innerHTML = watLSP.getSymbolTableHTML();
+  updateOutlineView();
+}
+
+// Symbol kind to icon/class mapping
+const kindInfo: Record<number, { icon: string; class: string; label: string }> = {
+  11: { icon: 'I', class: 'interface', label: 'type' },     // Interface (type)
+  12: { icon: 'F', class: 'function', label: 'function' },   // Function
+  13: { icon: 'V', class: 'variable', label: 'variable' },   // Variable
+  14: { icon: 'C', class: 'constant', label: 'global' },     // Constant (global)
+  15: { icon: 'S', class: 'string', label: 'data' },         // String (data)
+  18: { icon: 'A', class: 'array', label: 'table/elem' },    // Array (table/elem)
+  19: { icon: 'M', class: 'object', label: 'memory' },       // Object (memory)
+  20: { icon: 'L', class: 'key', label: 'label' },           // Key (block label)
+  24: { icon: 'T', class: 'event', label: 'tag' },           // Event (tag)
+};
+
+// Update outline view with document symbols
+function updateOutlineView(): void {
+  if (!elements.outlineView || !watLSP || !watLSP.ready || !watLSP.provideDocumentSymbols) {
+    if (elements.outlineView) {
+      elements.outlineView.innerHTML = '<p class="placeholder">No symbols found</p>';
+    }
+    return;
+  }
+
+  const symbols = watLSP.provideDocumentSymbols();
+  if (!symbols || symbols.length === 0) {
+    elements.outlineView.innerHTML = '<p class="placeholder">No symbols found</p>';
+    return;
+  }
+
+  interface SymbolInfo {
+    name: string;
+    detail?: string;
+    kind: number;
+    range?: { start: { line: number; character: number }; end: { line: number; character: number } };
+    children?: SymbolInfo[];
+  }
+
+  function renderSymbol(sym: SymbolInfo, depth: number = 0): string {
+    const info = kindInfo[sym.kind] || { icon: '?', class: 'unknown', label: 'unknown' };
+    const line = sym.range?.start?.line ?? 0;
+    const hasChildren = sym.children && sym.children.length > 0;
+
+    let html = `
+      <div class="outline-item depth-${depth}" onclick="goToLine(${line + 1}, 1)" title="${info.label}: ${sym.name}${sym.detail ? ' - ' + sym.detail : ''}">
+        <span class="outline-icon ${info.class}">${info.icon}</span>
+        <span class="outline-name">${escapeHtml(sym.name)}</span>
+        ${sym.detail ? `<span class="outline-detail">${escapeHtml(sym.detail)}</span>` : ''}
+      </div>
+    `;
+
+    if (hasChildren) {
+      html += `<div class="outline-children">`;
+      for (const child of sym.children!) {
+        html += renderSymbol(child, depth + 1);
+      }
+      html += `</div>`;
+    }
+
+    return html;
+  }
+
+  elements.outlineView.innerHTML = symbols.map((sym) => renderSymbol(sym)).join('');
 }
 
 // Update hover debug info
@@ -648,10 +782,11 @@ async function initLSP(): Promise<boolean> {
   setLSPStatus(false, 'Loading WASM LSP...');
 
   try {
-    watLSP = await createWatLSP({
+    const lsp = await createWatLSP({
       treeSitterWasmPath: '/tree-sitter.wasm',
       watLspWasmPath: '/wat_lsp_rust_bg.wasm',
     });
+    watLSP = lsp as WatLSP;
 
     setLSPStatus(true, 'LSP Ready (Rust WASM)');
     consoleOutput.info('LSP initialized with @emnudge/wat-lsp');
@@ -661,13 +796,13 @@ async function initLSP(): Promise<boolean> {
 
     registerSemanticTokensProvider();
 
-    if (editor) {
+    if (editor && watLSP) {
       watLSP.parse(editor.getValue());
       updateDiagnostics();
       updateLSPDebugPanel();
     }
 
-    (window as unknown as { watLSP: WatLSP }).watLSP = watLSP;
+    (window as unknown as { watLSP: WatLSP | null }).watLSP = watLSP;
 
     return true;
   } catch (error) {
@@ -1110,6 +1245,7 @@ function initElements(): void {
     diagnosticsView: document.getElementById('diagnostics-view')!,
     symbolTableView: document.getElementById('symbol-table-view')!,
     hoverDebug: document.getElementById('hover-debug')!,
+    outlineView: document.getElementById('outline-view')!,
     testLine: document.getElementById('test-line') as HTMLInputElement,
     testCol: document.getElementById('test-col') as HTMLInputElement,
     testHoverBtn: document.getElementById(

--- a/packages/playground/style.css
+++ b/packages/playground/style.css
@@ -590,6 +590,113 @@ footer {
   word-break: break-word;
 }
 
+/* Outline view */
+.outline-tree {
+  font-family: 'Consolas', 'Monaco', monospace;
+  font-size: 0.85rem;
+}
+
+.outline-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 8px;
+  cursor: pointer;
+  border-radius: 3px;
+  transition: background-color 0.1s ease;
+}
+
+.outline-item:hover {
+  background: var(--bg-hover);
+}
+
+.outline-item.depth-1 {
+  padding-left: 24px;
+}
+
+.outline-item.depth-2 {
+  padding-left: 40px;
+}
+
+.outline-item.depth-3 {
+  padding-left: 56px;
+}
+
+.outline-icon {
+  width: 18px;
+  height: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 3px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
+.outline-icon.function {
+  background: var(--accent-purple);
+  color: white;
+}
+
+.outline-icon.variable {
+  background: var(--accent-blue);
+  color: white;
+}
+
+.outline-icon.constant {
+  background: var(--accent-green);
+  color: white;
+}
+
+.outline-icon.interface {
+  background: var(--accent-orange);
+  color: white;
+}
+
+.outline-icon.string {
+  background: #ce9178;
+  color: white;
+}
+
+.outline-icon.array {
+  background: #569cd6;
+  color: white;
+}
+
+.outline-icon.object {
+  background: #4ec9b0;
+  color: white;
+}
+
+.outline-icon.key {
+  background: #9cdcfe;
+  color: #1e1e1e;
+}
+
+.outline-icon.event {
+  background: #c586c0;
+  color: white;
+}
+
+.outline-name {
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.outline-detail {
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.outline-children {
+  border-left: 1px solid var(--border-color);
+  margin-left: 12px;
+}
+
 /* Responsive */
 @media (max-width: 900px) {
   .main-content {

--- a/src/features/document_symbols/mod.rs
+++ b/src/features/document_symbols/mod.rs
@@ -1,0 +1,462 @@
+use crate::symbols::*;
+use tower_lsp::lsp_types::{DocumentSymbol, Position, Range, SymbolKind};
+
+#[cfg(test)]
+mod tests;
+
+/// Provide document symbols for the outline view.
+/// Returns a hierarchical list of symbols where functions contain their locals/params as children.
+pub fn provide_document_symbols(symbols: &SymbolTable) -> Vec<DocumentSymbol> {
+    let mut result = Vec::new();
+
+    // Add types
+    for type_def in &symbols.types {
+        result.push(type_to_document_symbol(type_def));
+    }
+
+    // Add functions with their children (params, locals, blocks)
+    for func in &symbols.functions {
+        result.push(function_to_document_symbol(func));
+    }
+
+    // Add globals
+    for global in &symbols.globals {
+        result.push(global_to_document_symbol(global));
+    }
+
+    // Add tables
+    for table in &symbols.tables {
+        result.push(table_to_document_symbol(table));
+    }
+
+    // Add memories
+    for memory in &symbols.memories {
+        result.push(memory_to_document_symbol(memory));
+    }
+
+    // Add tags
+    for tag in &symbols.tags {
+        result.push(tag_to_document_symbol(tag));
+    }
+
+    // Add data segments
+    for data in &symbols.data_segments {
+        result.push(data_to_document_symbol(data));
+    }
+
+    // Add element segments
+    for elem in &symbols.elem_segments {
+        result.push(elem_to_document_symbol(elem));
+    }
+
+    result
+}
+
+fn core_range_to_lsp(range: &crate::core::types::Range) -> Range {
+    Range {
+        start: Position {
+            line: range.start.line,
+            character: range.start.character,
+        },
+        end: Position {
+            line: range.end.line,
+            character: range.end.character,
+        },
+    }
+}
+
+fn make_range_from_line(line: u32) -> Range {
+    Range {
+        start: Position { line, character: 0 },
+        end: Position { line, character: 0 },
+    }
+}
+
+fn type_to_document_symbol(type_def: &TypeDef) -> DocumentSymbol {
+    let name = type_def
+        .name
+        .clone()
+        .unwrap_or_else(|| format!("(type {})", type_def.index));
+
+    let detail = match &type_def.kind {
+        TypeKind::Func { params, results } => {
+            let params_str = params
+                .iter()
+                .map(|t| t.to_string())
+                .collect::<Vec<_>>()
+                .join(" ");
+            let results_str = results
+                .iter()
+                .map(|t| t.to_string())
+                .collect::<Vec<_>>()
+                .join(" ");
+            if results_str.is_empty() {
+                format!("(func ({}))", params_str)
+            } else {
+                format!("(func ({}) -> ({}))", params_str, results_str)
+            }
+        }
+        TypeKind::Struct { fields } => format!("(struct {} fields)", fields.len()),
+        TypeKind::Array { element_type, .. } => format!("(array {})", element_type),
+    };
+
+    let range = type_def
+        .range
+        .as_ref()
+        .map(core_range_to_lsp)
+        .unwrap_or_else(|| make_range_from_line(type_def.line));
+
+    #[allow(deprecated)]
+    DocumentSymbol {
+        name,
+        detail: Some(detail),
+        kind: SymbolKind::INTERFACE,
+        tags: None,
+        deprecated: None,
+        range,
+        selection_range: range,
+        children: None,
+    }
+}
+
+fn function_to_document_symbol(func: &Function) -> DocumentSymbol {
+    let name = func
+        .name
+        .clone()
+        .unwrap_or_else(|| format!("(func {})", func.index));
+
+    // Build function signature for detail
+    let params_str = func
+        .parameters
+        .iter()
+        .map(|p| {
+            if let Some(ref name) = p.name {
+                format!("{} {}", name, p.param_type)
+            } else {
+                p.param_type.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    let results_str = func
+        .results
+        .iter()
+        .map(|t| t.to_string())
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    let detail = if results_str.is_empty() {
+        format!("({})", params_str)
+    } else {
+        format!("({}) -> ({})", params_str, results_str)
+    };
+
+    let range = func
+        .range
+        .as_ref()
+        .map(core_range_to_lsp)
+        .unwrap_or_else(|| Range {
+            start: Position {
+                line: func.line,
+                character: 0,
+            },
+            end: Position {
+                line: func.end_line,
+                character: 0,
+            },
+        });
+
+    // Build children: parameters, locals, and block labels
+    let mut children = Vec::new();
+
+    // Add parameters
+    for param in &func.parameters {
+        children.push(param_to_document_symbol(param));
+    }
+
+    // Add locals
+    for local in &func.locals {
+        children.push(local_to_document_symbol(local));
+    }
+
+    // Add block labels
+    for block in &func.blocks {
+        children.push(block_to_document_symbol(block));
+    }
+
+    #[allow(deprecated)]
+    DocumentSymbol {
+        name,
+        detail: Some(detail),
+        kind: SymbolKind::FUNCTION,
+        tags: None,
+        deprecated: None,
+        range,
+        selection_range: range,
+        children: if children.is_empty() {
+            None
+        } else {
+            Some(children)
+        },
+    }
+}
+
+fn param_to_document_symbol(param: &Parameter) -> DocumentSymbol {
+    let name = param
+        .name
+        .clone()
+        .unwrap_or_else(|| format!("(param {})", param.index));
+
+    let range = param
+        .range
+        .as_ref()
+        .map(core_range_to_lsp)
+        .unwrap_or_else(|| make_range_from_line(0));
+
+    #[allow(deprecated)]
+    DocumentSymbol {
+        name,
+        detail: Some(param.param_type.to_string()),
+        kind: SymbolKind::VARIABLE,
+        tags: None,
+        deprecated: None,
+        range,
+        selection_range: range,
+        children: None,
+    }
+}
+
+fn local_to_document_symbol(local: &Variable) -> DocumentSymbol {
+    let name = local
+        .name
+        .clone()
+        .unwrap_or_else(|| format!("(local {})", local.index));
+
+    let range = local
+        .range
+        .as_ref()
+        .map(core_range_to_lsp)
+        .unwrap_or_else(|| make_range_from_line(0));
+
+    #[allow(deprecated)]
+    DocumentSymbol {
+        name,
+        detail: Some(local.var_type.to_string()),
+        kind: SymbolKind::VARIABLE,
+        tags: None,
+        deprecated: None,
+        range,
+        selection_range: range,
+        children: None,
+    }
+}
+
+fn block_to_document_symbol(block: &BlockLabel) -> DocumentSymbol {
+    let range = block
+        .range
+        .as_ref()
+        .map(core_range_to_lsp)
+        .unwrap_or_else(|| make_range_from_line(block.line));
+
+    #[allow(deprecated)]
+    DocumentSymbol {
+        name: block.label.clone(),
+        detail: Some(block.block_type.clone()),
+        kind: SymbolKind::KEY,
+        tags: None,
+        deprecated: None,
+        range,
+        selection_range: range,
+        children: None,
+    }
+}
+
+fn global_to_document_symbol(global: &Global) -> DocumentSymbol {
+    let name = global
+        .name
+        .clone()
+        .unwrap_or_else(|| format!("(global {})", global.index));
+
+    let detail = format!(
+        "{}{}",
+        if global.is_mutable { "mut " } else { "" },
+        global.var_type
+    );
+
+    let range = global
+        .range
+        .as_ref()
+        .map(core_range_to_lsp)
+        .unwrap_or_else(|| make_range_from_line(global.line));
+
+    #[allow(deprecated)]
+    DocumentSymbol {
+        name,
+        detail: Some(detail),
+        kind: SymbolKind::CONSTANT,
+        tags: None,
+        deprecated: None,
+        range,
+        selection_range: range,
+        children: None,
+    }
+}
+
+fn table_to_document_symbol(table: &Table) -> DocumentSymbol {
+    let name = table
+        .name
+        .clone()
+        .unwrap_or_else(|| format!("(table {})", table.index));
+
+    let detail = format!(
+        "{} {} {}",
+        table.limits.0,
+        table.limits.1.map_or("".to_string(), |m| m.to_string()),
+        table.ref_type
+    );
+
+    let range = table
+        .range
+        .as_ref()
+        .map(core_range_to_lsp)
+        .unwrap_or_else(|| make_range_from_line(table.line));
+
+    #[allow(deprecated)]
+    DocumentSymbol {
+        name,
+        detail: Some(detail),
+        kind: SymbolKind::ARRAY,
+        tags: None,
+        deprecated: None,
+        range,
+        selection_range: range,
+        children: None,
+    }
+}
+
+fn memory_to_document_symbol(memory: &Memory) -> DocumentSymbol {
+    let name = memory
+        .name
+        .clone()
+        .unwrap_or_else(|| format!("(memory {})", memory.index));
+
+    let detail = format!(
+        "{}{}",
+        memory.limits.0,
+        memory
+            .limits
+            .1
+            .map_or("".to_string(), |m| format!(" {}", m))
+    );
+
+    let range = memory
+        .range
+        .as_ref()
+        .map(core_range_to_lsp)
+        .unwrap_or_else(|| make_range_from_line(memory.line));
+
+    #[allow(deprecated)]
+    DocumentSymbol {
+        name,
+        detail: Some(detail),
+        kind: SymbolKind::OBJECT,
+        tags: None,
+        deprecated: None,
+        range,
+        selection_range: range,
+        children: None,
+    }
+}
+
+fn tag_to_document_symbol(tag: &Tag) -> DocumentSymbol {
+    let name = tag
+        .name
+        .clone()
+        .unwrap_or_else(|| format!("(tag {})", tag.index));
+
+    let detail = if tag.params.is_empty() {
+        "()".to_string()
+    } else {
+        format!(
+            "({})",
+            tag.params
+                .iter()
+                .map(|t| t.to_string())
+                .collect::<Vec<_>>()
+                .join(" ")
+        )
+    };
+
+    let range = tag
+        .range
+        .as_ref()
+        .map(core_range_to_lsp)
+        .unwrap_or_else(|| make_range_from_line(tag.line));
+
+    #[allow(deprecated)]
+    DocumentSymbol {
+        name,
+        detail: Some(detail),
+        kind: SymbolKind::EVENT,
+        tags: None,
+        deprecated: None,
+        range,
+        selection_range: range,
+        children: None,
+    }
+}
+
+fn data_to_document_symbol(data: &DataSegment) -> DocumentSymbol {
+    let name = data
+        .name
+        .clone()
+        .unwrap_or_else(|| format!("(data {})", data.index));
+
+    let detail = format!("{} bytes", data.byte_length);
+
+    let range = data
+        .range
+        .as_ref()
+        .map(core_range_to_lsp)
+        .unwrap_or_else(|| make_range_from_line(data.line));
+
+    #[allow(deprecated)]
+    DocumentSymbol {
+        name,
+        detail: Some(detail),
+        kind: SymbolKind::STRING,
+        tags: None,
+        deprecated: None,
+        range,
+        selection_range: range,
+        children: None,
+    }
+}
+
+fn elem_to_document_symbol(elem: &ElemSegment) -> DocumentSymbol {
+    let name = elem
+        .name
+        .clone()
+        .unwrap_or_else(|| format!("(elem {})", elem.index));
+
+    let detail = format!("{} functions", elem.func_names.len());
+
+    let range = elem
+        .range
+        .as_ref()
+        .map(core_range_to_lsp)
+        .unwrap_or_else(|| make_range_from_line(elem.line));
+
+    #[allow(deprecated)]
+    DocumentSymbol {
+        name,
+        detail: Some(detail),
+        kind: SymbolKind::ARRAY,
+        tags: None,
+        deprecated: None,
+        range,
+        selection_range: range,
+        children: None,
+    }
+}

--- a/src/features/document_symbols/tests.rs
+++ b/src/features/document_symbols/tests.rs
@@ -1,0 +1,158 @@
+use super::*;
+use crate::parser::parse_document;
+
+#[test]
+fn test_empty_document() {
+    let symbols = SymbolTable::new();
+    let result = provide_document_symbols(&symbols);
+    assert!(result.is_empty());
+}
+
+#[test]
+fn test_function_symbols() {
+    let source = r#"
+(module
+  (func $add (param $a i32) (param $b i32) (result i32)
+    (local $tmp i32)
+    (i32.add (local.get $a) (local.get $b))
+  )
+)
+"#;
+
+    let symbols = parse_document(source).unwrap();
+    let result = provide_document_symbols(&symbols);
+
+    assert_eq!(result.len(), 1);
+    let func_sym = &result[0];
+    assert_eq!(func_sym.name, "$add");
+    assert_eq!(func_sym.kind, SymbolKind::FUNCTION);
+
+    // Check children (params and locals)
+    let children = func_sym.children.as_ref().unwrap();
+    assert_eq!(children.len(), 3); // 2 params + 1 local
+
+    assert_eq!(children[0].name, "$a");
+    assert_eq!(children[0].kind, SymbolKind::VARIABLE);
+    assert_eq!(children[0].detail.as_deref(), Some("i32"));
+
+    assert_eq!(children[1].name, "$b");
+    assert_eq!(children[2].name, "$tmp");
+}
+
+#[test]
+fn test_global_symbols() {
+    let source = r#"
+(module
+  (global $counter (mut i32) (i32.const 0))
+  (global $max i32 (i32.const 100))
+)
+"#;
+
+    let symbols = parse_document(source).unwrap();
+    let result = provide_document_symbols(&symbols);
+
+    assert_eq!(result.len(), 2);
+
+    let counter = &result[0];
+    assert_eq!(counter.name, "$counter");
+    assert_eq!(counter.kind, SymbolKind::CONSTANT);
+    assert_eq!(counter.detail.as_deref(), Some("mut i32"));
+
+    let max = &result[1];
+    assert_eq!(max.name, "$max");
+    assert_eq!(max.detail.as_deref(), Some("i32"));
+}
+
+#[test]
+fn test_type_symbols() {
+    let source = r#"
+(module
+  (type $sig (func (param i32) (result i32)))
+)
+"#;
+
+    let symbols = parse_document(source).unwrap();
+    let result = provide_document_symbols(&symbols);
+
+    assert_eq!(result.len(), 1);
+    let type_sym = &result[0];
+    assert_eq!(type_sym.name, "$sig");
+    assert_eq!(type_sym.kind, SymbolKind::INTERFACE);
+}
+
+#[test]
+fn test_memory_and_table_symbols() {
+    let source = r#"
+(module
+  (memory $mem 1 10)
+  (table $tbl 1 funcref)
+)
+"#;
+
+    let symbols = parse_document(source).unwrap();
+    let result = provide_document_symbols(&symbols);
+
+    assert_eq!(result.len(), 2);
+
+    // Table comes before memory in the output order (tables, then memories)
+    let table = result.iter().find(|s| s.name == "$tbl").unwrap();
+    assert_eq!(table.kind, SymbolKind::ARRAY);
+
+    let memory = result.iter().find(|s| s.name == "$mem").unwrap();
+    assert_eq!(memory.kind, SymbolKind::OBJECT);
+}
+
+#[test]
+fn test_block_labels() {
+    let source = r#"
+(module
+  (func $test
+    (block $outer
+      (loop $inner
+        (br $inner)
+      )
+    )
+  )
+)
+"#;
+
+    let symbols = parse_document(source).unwrap();
+    let result = provide_document_symbols(&symbols);
+
+    assert_eq!(result.len(), 1);
+    let func = &result[0];
+    let children = func.children.as_ref().unwrap();
+
+    // Should have 2 block labels
+    assert_eq!(children.len(), 2);
+
+    let outer = children.iter().find(|c| c.name == "$outer").unwrap();
+    assert_eq!(outer.kind, SymbolKind::KEY);
+    assert_eq!(outer.detail.as_deref(), Some("block"));
+
+    let inner = children.iter().find(|c| c.name == "$inner").unwrap();
+    assert_eq!(inner.detail.as_deref(), Some("loop"));
+}
+
+#[test]
+fn test_unnamed_symbols_use_index() {
+    let source = r#"
+(module
+  (func (param i32) (result i32)
+    (local.get 0)
+  )
+)
+"#;
+
+    let symbols = parse_document(source).unwrap();
+    let result = provide_document_symbols(&symbols);
+
+    assert_eq!(result.len(), 1);
+    let func = &result[0];
+    // Unnamed function should show index
+    assert_eq!(func.name, "(func 0)");
+
+    // Check that unnamed param also uses index
+    let children = func.children.as_ref().unwrap();
+    assert_eq!(children[0].name, "(param 0)");
+}

--- a/src/features/mod.rs
+++ b/src/features/mod.rs
@@ -9,6 +9,10 @@ pub mod completion;
 #[cfg(feature = "native")]
 pub mod definition;
 
+// Document symbols - provides outline/symbol tree for a document
+#[cfg(feature = "native")]
+pub mod document_symbols;
+
 // Hover - provides hover documentation
 #[cfg(any(feature = "native", feature = "wasm"))]
 pub mod hover;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,9 @@ pub use features::completion;
 pub use features::definition;
 
 #[cfg(feature = "native")]
+pub use features::document_symbols;
+
+#[cfg(feature = "native")]
 pub use features::references;
 
 #[cfg(feature = "native")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 // Use modules from the library crate
 use wat_lsp_rust::{
-    completion, definition, diagnostics, hover, parser, references, signature, symbols,
-    tree_sitter_bindings, utils,
+    completion, definition, diagnostics, document_symbols, hover, parser, references, signature,
+    symbols, tree_sitter_bindings, utils,
 };
 
 use dashmap::DashMap;
@@ -176,6 +176,7 @@ impl LanguageServer for Backend {
                 }),
                 definition_provider: Some(OneOf::Left(true)),
                 references_provider: Some(OneOf::Left(true)),
+                document_symbol_provider: Some(OneOf::Left(true)),
                 rename_provider: Some(OneOf::Right(RenameOptions {
                     prepare_provider: Some(true),
                     work_done_progress_options: WorkDoneProgressOptions::default(),
@@ -425,6 +426,20 @@ impl LanguageServer for Backend {
         self.client
             .log_message(MessageType::WARNING, "No document/symbols/tree found")
             .await;
+
+        Ok(None)
+    }
+
+    async fn document_symbol(
+        &self,
+        params: DocumentSymbolParams,
+    ) -> Result<Option<DocumentSymbolResponse>> {
+        let uri = params.text_document.uri.to_string();
+
+        if let Some(syms) = self.symbol_map.get(&uri) {
+            let symbols = document_symbols::provide_document_symbols(&syms);
+            return Ok(Some(DocumentSymbolResponse::Nested(symbols)));
+        }
 
         Ok(None)
     }

--- a/src/wasm/api.rs
+++ b/src/wasm/api.rs
@@ -407,6 +407,60 @@ impl WatLSP {
         js_sys::Uint32Array::from(&result[..])
     }
 
+    /// Provide document symbols (outline) for the current document
+    /// Returns a hierarchical array of symbols matching the LSP DocumentSymbol structure
+    #[wasm_bindgen(js_name = provideDocumentSymbols)]
+    pub fn provide_document_symbols(&self) -> JsValue {
+        let symbols = match &self.symbols {
+            Some(s) => s,
+            None => return js_sys::Array::new().into(),
+        };
+
+        let result = js_sys::Array::new();
+
+        // Add types
+        for type_def in &symbols.types {
+            result.push(&type_to_js_symbol(type_def));
+        }
+
+        // Add functions with children
+        for func in &symbols.functions {
+            result.push(&function_to_js_symbol(func));
+        }
+
+        // Add globals
+        for global in &symbols.globals {
+            result.push(&global_to_js_symbol(global));
+        }
+
+        // Add tables
+        for table in &symbols.tables {
+            result.push(&table_to_js_symbol(table));
+        }
+
+        // Add memories
+        for memory in &symbols.memories {
+            result.push(&memory_to_js_symbol(memory));
+        }
+
+        // Add tags
+        for tag in &symbols.tags {
+            result.push(&tag_to_js_symbol(tag));
+        }
+
+        // Add data segments
+        for data in &symbols.data_segments {
+            result.push(&data_to_js_symbol(data));
+        }
+
+        // Add element segments
+        for elem in &symbols.elem_segments {
+            result.push(&elem_to_js_symbol(elem));
+        }
+
+        result.into()
+    }
+
     /// Get the semantic token legend (token types and modifiers)
     #[wasm_bindgen(js_name = getSemanticTokensLegend)]
     pub fn get_semantic_tokens_legend(&self) -> JsValue {
@@ -661,4 +715,361 @@ fn diagnostic_to_js(diag: &WasmDiagnostic) -> JsValue {
     js_sys::Reflect::set(&obj, &"severity".into(), &diag.severity.into()).ok();
 
     obj.into()
+}
+
+// ============================================================================
+// Document Symbol helpers
+// ============================================================================
+
+use crate::symbols::{
+    BlockLabel, DataSegment, ElemSegment, Function, Global, Memory, Parameter, Table, Tag, TypeDef,
+    TypeKind, Variable,
+};
+
+/// LSP SymbolKind constants (matching the LSP spec)
+mod symbol_kind {
+    pub const FUNCTION: u32 = 12;
+    pub const VARIABLE: u32 = 13;
+    pub const CONSTANT: u32 = 14;
+    pub const STRING: u32 = 15;
+    pub const ARRAY: u32 = 18;
+    pub const OBJECT: u32 = 19;
+    pub const KEY: u32 = 20;
+    pub const EVENT: u32 = 24;
+    pub const INTERFACE: u32 = 11;
+}
+
+fn make_js_range(line: u32, character: u32, end_line: u32, end_character: u32) -> js_sys::Object {
+    let range = js_sys::Object::new();
+    let start = js_sys::Object::new();
+    js_sys::Reflect::set(&start, &"line".into(), &line.into()).ok();
+    js_sys::Reflect::set(&start, &"character".into(), &character.into()).ok();
+    let end = js_sys::Object::new();
+    js_sys::Reflect::set(&end, &"line".into(), &end_line.into()).ok();
+    js_sys::Reflect::set(&end, &"character".into(), &end_character.into()).ok();
+    js_sys::Reflect::set(&range, &"start".into(), &start).ok();
+    js_sys::Reflect::set(&range, &"end".into(), &end).ok();
+    range
+}
+
+fn core_range_to_js_range(range: &Range) -> js_sys::Object {
+    make_js_range(
+        range.start.line,
+        range.start.character,
+        range.end.line,
+        range.end.character,
+    )
+}
+
+fn create_document_symbol(
+    name: &str,
+    detail: Option<&str>,
+    kind: u32,
+    range: js_sys::Object,
+    children: Option<js_sys::Array>,
+) -> JsValue {
+    let obj = js_sys::Object::new();
+    js_sys::Reflect::set(&obj, &"name".into(), &name.into()).ok();
+    if let Some(d) = detail {
+        js_sys::Reflect::set(&obj, &"detail".into(), &d.into()).ok();
+    }
+    js_sys::Reflect::set(&obj, &"kind".into(), &kind.into()).ok();
+    js_sys::Reflect::set(&obj, &"range".into(), &range).ok();
+    js_sys::Reflect::set(&obj, &"selectionRange".into(), &range).ok();
+    if let Some(c) = children {
+        js_sys::Reflect::set(&obj, &"children".into(), &c).ok();
+    }
+    obj.into()
+}
+
+fn type_to_js_symbol(type_def: &TypeDef) -> JsValue {
+    let name = type_def
+        .name
+        .clone()
+        .unwrap_or_else(|| format!("(type {})", type_def.index));
+
+    let detail = match &type_def.kind {
+        TypeKind::Func { params, results } => {
+            let params_str = params
+                .iter()
+                .map(|t| t.to_string())
+                .collect::<Vec<_>>()
+                .join(" ");
+            let results_str = results
+                .iter()
+                .map(|t| t.to_string())
+                .collect::<Vec<_>>()
+                .join(" ");
+            if results_str.is_empty() {
+                format!("(func ({}))", params_str)
+            } else {
+                format!("(func ({}) -> ({}))", params_str, results_str)
+            }
+        }
+        TypeKind::Struct { fields } => format!("(struct {} fields)", fields.len()),
+        TypeKind::Array { element_type, .. } => format!("(array {})", element_type),
+    };
+
+    let range = type_def
+        .range
+        .as_ref()
+        .map(core_range_to_js_range)
+        .unwrap_or_else(|| make_js_range(type_def.line, 0, type_def.line, 0));
+
+    create_document_symbol(&name, Some(&detail), symbol_kind::INTERFACE, range, None)
+}
+
+fn function_to_js_symbol(func: &Function) -> JsValue {
+    let name = func
+        .name
+        .clone()
+        .unwrap_or_else(|| format!("(func {})", func.index));
+
+    let params_str = func
+        .parameters
+        .iter()
+        .map(|p| {
+            if let Some(ref name) = p.name {
+                format!("{} {}", name, p.param_type)
+            } else {
+                p.param_type.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    let results_str = func
+        .results
+        .iter()
+        .map(|t| t.to_string())
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    let detail = if results_str.is_empty() {
+        format!("({})", params_str)
+    } else {
+        format!("({}) -> ({})", params_str, results_str)
+    };
+
+    let range = func
+        .range
+        .as_ref()
+        .map(core_range_to_js_range)
+        .unwrap_or_else(|| make_js_range(func.line, 0, func.end_line, 0));
+
+    // Build children
+    let children = js_sys::Array::new();
+
+    for param in &func.parameters {
+        children.push(&param_to_js_symbol(param));
+    }
+
+    for local in &func.locals {
+        children.push(&local_to_js_symbol(local));
+    }
+
+    for block in &func.blocks {
+        children.push(&block_to_js_symbol(block));
+    }
+
+    let children_opt = if children.length() > 0 {
+        Some(children)
+    } else {
+        None
+    };
+
+    create_document_symbol(
+        &name,
+        Some(&detail),
+        symbol_kind::FUNCTION,
+        range,
+        children_opt,
+    )
+}
+
+fn param_to_js_symbol(param: &Parameter) -> JsValue {
+    let name = param
+        .name
+        .clone()
+        .unwrap_or_else(|| format!("(param {})", param.index));
+
+    let range = param
+        .range
+        .as_ref()
+        .map(core_range_to_js_range)
+        .unwrap_or_else(|| make_js_range(0, 0, 0, 0));
+
+    create_document_symbol(
+        &name,
+        Some(&param.param_type.to_string()),
+        symbol_kind::VARIABLE,
+        range,
+        None,
+    )
+}
+
+fn local_to_js_symbol(local: &Variable) -> JsValue {
+    let name = local
+        .name
+        .clone()
+        .unwrap_or_else(|| format!("(local {})", local.index));
+
+    let range = local
+        .range
+        .as_ref()
+        .map(core_range_to_js_range)
+        .unwrap_or_else(|| make_js_range(0, 0, 0, 0));
+
+    create_document_symbol(
+        &name,
+        Some(&local.var_type.to_string()),
+        symbol_kind::VARIABLE,
+        range,
+        None,
+    )
+}
+
+fn block_to_js_symbol(block: &BlockLabel) -> JsValue {
+    let range = block
+        .range
+        .as_ref()
+        .map(core_range_to_js_range)
+        .unwrap_or_else(|| make_js_range(block.line, 0, block.line, 0));
+
+    create_document_symbol(
+        &block.label,
+        Some(&block.block_type),
+        symbol_kind::KEY,
+        range,
+        None,
+    )
+}
+
+fn global_to_js_symbol(global: &Global) -> JsValue {
+    let name = global
+        .name
+        .clone()
+        .unwrap_or_else(|| format!("(global {})", global.index));
+
+    let detail = format!(
+        "{}{}",
+        if global.is_mutable { "mut " } else { "" },
+        global.var_type
+    );
+
+    let range = global
+        .range
+        .as_ref()
+        .map(core_range_to_js_range)
+        .unwrap_or_else(|| make_js_range(global.line, 0, global.line, 0));
+
+    create_document_symbol(&name, Some(&detail), symbol_kind::CONSTANT, range, None)
+}
+
+fn table_to_js_symbol(table: &Table) -> JsValue {
+    let name = table
+        .name
+        .clone()
+        .unwrap_or_else(|| format!("(table {})", table.index));
+
+    let detail = format!(
+        "{} {} {}",
+        table.limits.0,
+        table.limits.1.map_or("".to_string(), |m| m.to_string()),
+        table.ref_type
+    );
+
+    let range = table
+        .range
+        .as_ref()
+        .map(core_range_to_js_range)
+        .unwrap_or_else(|| make_js_range(table.line, 0, table.line, 0));
+
+    create_document_symbol(&name, Some(&detail), symbol_kind::ARRAY, range, None)
+}
+
+fn memory_to_js_symbol(memory: &Memory) -> JsValue {
+    let name = memory
+        .name
+        .clone()
+        .unwrap_or_else(|| format!("(memory {})", memory.index));
+
+    let detail = format!(
+        "{}{}",
+        memory.limits.0,
+        memory
+            .limits
+            .1
+            .map_or("".to_string(), |m| format!(" {}", m))
+    );
+
+    let range = memory
+        .range
+        .as_ref()
+        .map(core_range_to_js_range)
+        .unwrap_or_else(|| make_js_range(memory.line, 0, memory.line, 0));
+
+    create_document_symbol(&name, Some(&detail), symbol_kind::OBJECT, range, None)
+}
+
+fn tag_to_js_symbol(tag: &Tag) -> JsValue {
+    let name = tag
+        .name
+        .clone()
+        .unwrap_or_else(|| format!("(tag {})", tag.index));
+
+    let detail = if tag.params.is_empty() {
+        "()".to_string()
+    } else {
+        format!(
+            "({})",
+            tag.params
+                .iter()
+                .map(|t| t.to_string())
+                .collect::<Vec<_>>()
+                .join(" ")
+        )
+    };
+
+    let range = tag
+        .range
+        .as_ref()
+        .map(core_range_to_js_range)
+        .unwrap_or_else(|| make_js_range(tag.line, 0, tag.line, 0));
+
+    create_document_symbol(&name, Some(&detail), symbol_kind::EVENT, range, None)
+}
+
+fn data_to_js_symbol(data: &DataSegment) -> JsValue {
+    let name = data
+        .name
+        .clone()
+        .unwrap_or_else(|| format!("(data {})", data.index));
+
+    let detail = format!("{} bytes", data.byte_length);
+
+    let range = data
+        .range
+        .as_ref()
+        .map(core_range_to_js_range)
+        .unwrap_or_else(|| make_js_range(data.line, 0, data.line, 0));
+
+    create_document_symbol(&name, Some(&detail), symbol_kind::STRING, range, None)
+}
+
+fn elem_to_js_symbol(elem: &ElemSegment) -> JsValue {
+    let name = elem
+        .name
+        .clone()
+        .unwrap_or_else(|| format!("(elem {})", elem.index));
+
+    let detail = format!("{} functions", elem.func_names.len());
+
+    let range = elem
+        .range
+        .as_ref()
+        .map(core_range_to_js_range)
+        .unwrap_or_else(|| make_js_range(elem.line, 0, elem.line, 0));
+
+    create_document_symbol(&name, Some(&detail), symbol_kind::ARRAY, range, None)
 }


### PR DESCRIPTION
Implements the textDocument/documentSymbol LSP capability:

- Native LSP server: Hierarchical document symbols for outline view
- WASM API: provideDocumentSymbols() method for browser use
- Playground: New Outline tab with clickable symbol tree

Supports all symbol types: functions, types, globals, tables, memories, tags, data, elems. Functions show params, locals, and block labels as children.