### PR TITLE
enable code completion for WASM/playground

### DIFF
--- a/packages/playground/main.ts
+++ b/packages/playground/main.ts
@@ -66,6 +66,17 @@ interface WatLSP {
     message: string;
     severity: number;
   }>;
+  provideCompletion(
+    line: number,
+    col: number
+  ): Array<{
+    label: string;
+    kind?: number;
+    detail?: string;
+    insertText?: string;
+    insertTextRules?: number;
+    documentation?: string;
+  }>;
   getSymbolTableHTML(): string;
   getSemanticTokensLegend(): monaco.languages.SemanticTokensLegend;
   provideSemanticTokens(): Uint32Array;
@@ -305,12 +316,42 @@ async function initMonaco(): Promise<void> {
 
   console.log('TextMate token provider registered');
 
-  // Register completion provider
+  // Register completion provider - uses WASM LSP when available, falls back to static completions
   monaco.languages.registerCompletionItemProvider('wat', {
+    triggerCharacters: ['.', '$', '@', '2', '4'], // Match LSP trigger characters
     provideCompletionItems: (
       model: monaco.editor.ITextModel,
       position: monaco.Position
     ): monaco.languages.ProviderResult<monaco.languages.CompletionList> => {
+      // Use WASM-based completion if LSP is ready
+      if (watLSP && watLSP.ready) {
+        // Parse latest content
+        watLSP.parse(model.getValue());
+
+        const completions = watLSP.provideCompletion(
+          position.lineNumber - 1, // Monaco is 1-indexed
+          position.column - 1
+        );
+
+        const suggestions = completions.map((item) => ({
+          label: item.label,
+          kind: item.kind ?? monaco.languages.CompletionItemKind.Keyword,
+          insertText: item.insertText || item.label,
+          insertTextRules: item.insertTextRules || 0,
+          documentation: item.documentation,
+          detail: item.detail,
+          range: {
+            startLineNumber: position.lineNumber,
+            startColumn: position.column,
+            endLineNumber: position.lineNumber,
+            endColumn: position.column,
+          },
+        }));
+
+        return { suggestions };
+      }
+
+      // Fall back to static completions if LSP not ready
       const suggestions = watLanguage.completionItems.map((item) => ({
         label: item.label,
         kind:

--- a/packages/wat-lsp/src/index.d.ts
+++ b/packages/wat-lsp/src/index.d.ts
@@ -56,6 +56,18 @@ export interface Diagnostic {
 }
 
 /**
+ * Completion item from the LSP
+ */
+export interface CompletionItem {
+  label: string;
+  kind?: number;
+  detail?: string;
+  insertText?: string;
+  insertTextRules?: number;
+  documentation?: string;
+}
+
+/**
  * Semantic tokens legend
  */
 export interface SemanticTokensLegend {
@@ -139,6 +151,9 @@ export interface WatLSP {
   /** Provide diagnostics for the current document */
   provideDiagnostics(): Diagnostic[];
 
+  /** Provide code completion at position */
+  provideCompletion(line: number, col: number): CompletionItem[];
+
   /** Provide semantic tokens for syntax highlighting */
   provideSemanticTokens(): Uint32Array;
 
@@ -189,6 +204,9 @@ export class WatLanguageServer {
 
   /** Provide diagnostics */
   provideDiagnostics(): Diagnostic[];
+
+  /** Provide code completion */
+  provideCompletion(line: number, character: number): CompletionItem[];
 
   /** Provide semantic tokens */
   provideSemanticTokens(): Uint32Array;

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -8,6 +8,96 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "native")]
 use tower_lsp::lsp_types as lsp;
 
+/// Completion item kind (matches LSP CompletionItemKind values)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[repr(u8)]
+pub enum CompletionItemKind {
+    Text = 1,
+    Method = 2,
+    Function = 3,
+    Constructor = 4,
+    Field = 5,
+    Variable = 6,
+    Class = 7,
+    Interface = 8,
+    Module = 9,
+    Property = 10,
+    Unit = 11,
+    Value = 12,
+    Enum = 13,
+    Keyword = 14,
+    Snippet = 15,
+    Color = 16,
+    File = 17,
+    Reference = 18,
+    Folder = 19,
+    EnumMember = 20,
+    Constant = 21,
+    Struct = 22,
+    Event = 23,
+    Operator = 24,
+    TypeParameter = 25,
+}
+
+/// Insert text format for completion items
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[repr(u8)]
+pub enum InsertTextFormat {
+    PlainText = 1,
+    Snippet = 2,
+}
+
+/// A completion item for code suggestions
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CompletionItem {
+    /// The label shown in the completion list
+    pub label: String,
+    /// The kind of completion item (function, variable, etc.)
+    pub kind: Option<CompletionItemKind>,
+    /// A short description shown next to the label
+    pub detail: Option<String>,
+    /// The text to insert when this item is selected
+    pub insert_text: Option<String>,
+    /// The format of the insert text (plain or snippet)
+    pub insert_text_format: Option<InsertTextFormat>,
+    /// Longer documentation about this item
+    pub documentation: Option<String>,
+}
+
+impl CompletionItem {
+    pub fn new(label: impl Into<String>) -> Self {
+        Self {
+            label: label.into(),
+            ..Default::default()
+        }
+    }
+
+    pub fn with_kind(mut self, kind: CompletionItemKind) -> Self {
+        self.kind = Some(kind);
+        self
+    }
+
+    pub fn with_detail(mut self, detail: impl Into<String>) -> Self {
+        self.detail = Some(detail.into());
+        self
+    }
+
+    pub fn with_insert_text(mut self, text: impl Into<String>) -> Self {
+        self.insert_text = Some(text.into());
+        self
+    }
+
+    pub fn with_insert_text_format(mut self, format: InsertTextFormat) -> Self {
+        self.insert_text_format = Some(format);
+        self
+    }
+
+    pub fn with_documentation(mut self, doc: impl Into<String>) -> Self {
+        self.documentation = Some(doc.into());
+        self
+    }
+}
+
 /// A position in a text document (0-indexed line and character)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct Position {
@@ -110,6 +200,64 @@ impl From<Range> for lsp::Range {
         Self {
             start: r.start.into(),
             end: r.end.into(),
+        }
+    }
+}
+
+#[cfg(feature = "native")]
+impl From<CompletionItemKind> for lsp::CompletionItemKind {
+    fn from(kind: CompletionItemKind) -> Self {
+        match kind {
+            CompletionItemKind::Text => lsp::CompletionItemKind::TEXT,
+            CompletionItemKind::Method => lsp::CompletionItemKind::METHOD,
+            CompletionItemKind::Function => lsp::CompletionItemKind::FUNCTION,
+            CompletionItemKind::Constructor => lsp::CompletionItemKind::CONSTRUCTOR,
+            CompletionItemKind::Field => lsp::CompletionItemKind::FIELD,
+            CompletionItemKind::Variable => lsp::CompletionItemKind::VARIABLE,
+            CompletionItemKind::Class => lsp::CompletionItemKind::CLASS,
+            CompletionItemKind::Interface => lsp::CompletionItemKind::INTERFACE,
+            CompletionItemKind::Module => lsp::CompletionItemKind::MODULE,
+            CompletionItemKind::Property => lsp::CompletionItemKind::PROPERTY,
+            CompletionItemKind::Unit => lsp::CompletionItemKind::UNIT,
+            CompletionItemKind::Value => lsp::CompletionItemKind::VALUE,
+            CompletionItemKind::Enum => lsp::CompletionItemKind::ENUM,
+            CompletionItemKind::Keyword => lsp::CompletionItemKind::KEYWORD,
+            CompletionItemKind::Snippet => lsp::CompletionItemKind::SNIPPET,
+            CompletionItemKind::Color => lsp::CompletionItemKind::COLOR,
+            CompletionItemKind::File => lsp::CompletionItemKind::FILE,
+            CompletionItemKind::Reference => lsp::CompletionItemKind::REFERENCE,
+            CompletionItemKind::Folder => lsp::CompletionItemKind::FOLDER,
+            CompletionItemKind::EnumMember => lsp::CompletionItemKind::ENUM_MEMBER,
+            CompletionItemKind::Constant => lsp::CompletionItemKind::CONSTANT,
+            CompletionItemKind::Struct => lsp::CompletionItemKind::STRUCT,
+            CompletionItemKind::Event => lsp::CompletionItemKind::EVENT,
+            CompletionItemKind::Operator => lsp::CompletionItemKind::OPERATOR,
+            CompletionItemKind::TypeParameter => lsp::CompletionItemKind::TYPE_PARAMETER,
+        }
+    }
+}
+
+#[cfg(feature = "native")]
+impl From<InsertTextFormat> for lsp::InsertTextFormat {
+    fn from(format: InsertTextFormat) -> Self {
+        match format {
+            InsertTextFormat::PlainText => lsp::InsertTextFormat::PLAIN_TEXT,
+            InsertTextFormat::Snippet => lsp::InsertTextFormat::SNIPPET,
+        }
+    }
+}
+
+#[cfg(feature = "native")]
+impl From<CompletionItem> for lsp::CompletionItem {
+    fn from(item: CompletionItem) -> Self {
+        lsp::CompletionItem {
+            label: item.label,
+            kind: item.kind.map(|k| k.into()),
+            detail: item.detail,
+            insert_text: item.insert_text,
+            insert_text_format: item.insert_text_format.map(|f| f.into()),
+            documentation: item.documentation.map(lsp::Documentation::String),
+            ..Default::default()
         }
     }
 }

--- a/src/features/completion/mod.rs
+++ b/src/features/completion/mod.rs
@@ -1,19 +1,19 @@
+use crate::core::types::{CompletionItem, CompletionItemKind, InsertTextFormat, Position};
 use crate::symbols::*;
 use crate::utils::{
     determine_context_from_line, find_containing_function, get_line_at_position, InstructionContext,
 };
 use once_cell::sync::Lazy;
 use regex::Regex;
-use tower_lsp::lsp_types::*;
-use tree_sitter::Tree;
 
 #[cfg(test)]
 mod tests;
 
+/// Provide completion items at the given position in the document.
+/// This is the core completion function using protocol-independent types.
 pub fn provide_completion(
     document: &str,
     symbols: &SymbolTable,
-    _tree: &Tree, // Kept for API compatibility; completion uses line-based context detection
     position: Position,
 ) -> Vec<CompletionItem> {
     let mut completions = Vec::new();
@@ -32,49 +32,40 @@ pub fn provide_completion(
         let clean_number = number.replace('_', "");
         let insert_text = format!("({}.const {})", type_str, clean_number);
 
-        completions.push(CompletionItem {
-            label: format!("{}{}", number, type_str),
-            kind: Some(CompletionItemKind::SNIPPET),
-            detail: Some(format!("Expand to: {}", insert_text)),
-            insert_text: Some(insert_text),
-            ..Default::default()
-        });
+        completions.push(
+            CompletionItem::new(format!("{}{}", number, type_str))
+                .with_kind(CompletionItemKind::Snippet)
+                .with_detail(format!("Expand to: {}", insert_text))
+                .with_insert_text(insert_text),
+        );
         return completions;
     }
 
     // Emmet-like local.get expansion (e.g., l$var -> (local.get $var))
     if line_prefix.ends_with("l$") {
-        if let Some(func) = find_containing_function(symbols, position.into()) {
+        if let Some(func) = find_containing_function(symbols, position) {
             for param in &func.parameters {
                 if let Some(ref name) = param.name {
                     let insert_text = format!("(local.get {})", name);
-                    completions.push(CompletionItem {
-                        label: format!("l{}", name),
-                        kind: Some(CompletionItemKind::SNIPPET),
-                        detail: Some(format!("(param) {}", param.param_type)),
-                        insert_text: Some(insert_text.clone()),
-                        documentation: Some(Documentation::String(format!(
-                            "Expands to: {}",
-                            insert_text
-                        ))),
-                        ..Default::default()
-                    });
+                    completions.push(
+                        CompletionItem::new(format!("l{}", name))
+                            .with_kind(CompletionItemKind::Snippet)
+                            .with_detail(format!("(param) {}", param.param_type))
+                            .with_insert_text(insert_text.clone())
+                            .with_documentation(format!("Expands to: {}", insert_text)),
+                    );
                 }
             }
             for local in &func.locals {
                 if let Some(ref name) = local.name {
                     let insert_text = format!("(local.get {})", name);
-                    completions.push(CompletionItem {
-                        label: format!("l{}", name),
-                        kind: Some(CompletionItemKind::SNIPPET),
-                        detail: Some(format!("(local) {}", local.var_type)),
-                        insert_text: Some(insert_text.clone()),
-                        documentation: Some(Documentation::String(format!(
-                            "Expands to: {}",
-                            insert_text
-                        ))),
-                        ..Default::default()
-                    });
+                    completions.push(
+                        CompletionItem::new(format!("l{}", name))
+                            .with_kind(CompletionItemKind::Snippet)
+                            .with_detail(format!("(local) {}", local.var_type))
+                            .with_insert_text(insert_text.clone())
+                            .with_documentation(format!("Expands to: {}", insert_text)),
+                    );
                 }
             }
         }
@@ -83,31 +74,29 @@ pub fn provide_completion(
 
     // Emmet-like local.set expansion (e.g., l=$var -> (local.set $var ))
     if line_prefix.ends_with("l=$") {
-        if let Some(func) = find_containing_function(symbols, position.into()) {
+        if let Some(func) = find_containing_function(symbols, position) {
             for param in &func.parameters {
                 if let Some(ref name) = param.name {
                     let insert_text = format!("(local.set {} $0)", name);
-                    completions.push(CompletionItem {
-                        label: format!("l={}", name),
-                        kind: Some(CompletionItemKind::SNIPPET),
-                        detail: Some(format!("(param) {}", param.param_type)),
-                        insert_text_format: Some(InsertTextFormat::SNIPPET),
-                        insert_text: Some(insert_text.clone()),
-                        ..Default::default()
-                    });
+                    completions.push(
+                        CompletionItem::new(format!("l={}", name))
+                            .with_kind(CompletionItemKind::Snippet)
+                            .with_detail(format!("(param) {}", param.param_type))
+                            .with_insert_text_format(InsertTextFormat::Snippet)
+                            .with_insert_text(insert_text),
+                    );
                 }
             }
             for local in &func.locals {
                 if let Some(ref name) = local.name {
                     let insert_text = format!("(local.set {} $0)", name);
-                    completions.push(CompletionItem {
-                        label: format!("l={}", name),
-                        kind: Some(CompletionItemKind::SNIPPET),
-                        detail: Some(format!("(local) {}", local.var_type)),
-                        insert_text_format: Some(InsertTextFormat::SNIPPET),
-                        insert_text: Some(insert_text.clone()),
-                        ..Default::default()
-                    });
+                    completions.push(
+                        CompletionItem::new(format!("l={}", name))
+                            .with_kind(CompletionItemKind::Snippet)
+                            .with_detail(format!("(local) {}", local.var_type))
+                            .with_insert_text_format(InsertTextFormat::Snippet)
+                            .with_insert_text(insert_text),
+                    );
                 }
             }
         }
@@ -119,17 +108,13 @@ pub fn provide_completion(
         for global in &symbols.globals {
             if let Some(ref name) = global.name {
                 let insert_text = format!("(global.get {})", name);
-                completions.push(CompletionItem {
-                    label: format!("g{}", name),
-                    kind: Some(CompletionItemKind::SNIPPET),
-                    detail: Some(format!("(global) {}", global.var_type)),
-                    insert_text: Some(insert_text.clone()),
-                    documentation: Some(Documentation::String(format!(
-                        "Expands to: {}",
-                        insert_text
-                    ))),
-                    ..Default::default()
-                });
+                completions.push(
+                    CompletionItem::new(format!("g{}", name))
+                        .with_kind(CompletionItemKind::Snippet)
+                        .with_detail(format!("(global) {}", global.var_type))
+                        .with_insert_text(insert_text.clone())
+                        .with_documentation(format!("Expands to: {}", insert_text)),
+                );
             }
         }
         return completions;
@@ -141,14 +126,13 @@ pub fn provide_completion(
             if let Some(ref name) = global.name {
                 if global.is_mutable {
                     let insert_text = format!("(global.set {} $0)", name);
-                    completions.push(CompletionItem {
-                        label: format!("g={}", name),
-                        kind: Some(CompletionItemKind::SNIPPET),
-                        detail: Some(format!("(global mut) {}", global.var_type)),
-                        insert_text_format: Some(InsertTextFormat::SNIPPET),
-                        insert_text: Some(insert_text.clone()),
-                        ..Default::default()
-                    });
+                    completions.push(
+                        CompletionItem::new(format!("g={}", name))
+                            .with_kind(CompletionItemKind::Snippet)
+                            .with_detail(format!("(global mut) {}", global.var_type))
+                            .with_insert_text_format(InsertTextFormat::Snippet)
+                            .with_insert_text(insert_text),
+                    );
                 }
             }
         }
@@ -347,24 +331,23 @@ pub fn provide_completion(
                             .collect::<Vec<_>>()
                             .join(" ");
 
-                        completions.push(CompletionItem {
-                            label: name[1..].to_string(), // Remove $ prefix
-                            kind: Some(CompletionItemKind::FUNCTION),
-                            detail: Some(format!(
-                                "({}) -> ({})",
-                                if params_str.is_empty() {
-                                    "no params"
-                                } else {
-                                    &params_str
-                                },
-                                if results_str.is_empty() {
-                                    "no result"
-                                } else {
-                                    &results_str
-                                }
-                            )),
-                            ..Default::default()
-                        });
+                        completions.push(
+                            CompletionItem::new(&name[1..]) // Remove $ prefix
+                                .with_kind(CompletionItemKind::Function)
+                                .with_detail(format!(
+                                    "({}) -> ({})",
+                                    if params_str.is_empty() {
+                                        "no params"
+                                    } else {
+                                        &params_str
+                                    },
+                                    if results_str.is_empty() {
+                                        "no result"
+                                    } else {
+                                        &results_str
+                                    }
+                                )),
+                        );
                     }
                 }
             }
@@ -372,58 +355,54 @@ pub fn provide_completion(
                 // Global variable completions
                 for global in &symbols.globals {
                     if let Some(ref name) = global.name {
-                        completions.push(CompletionItem {
-                            label: name[1..].to_string(), // Remove $ prefix
-                            kind: Some(CompletionItemKind::VARIABLE),
-                            detail: Some(format!(
-                                "(global{}) {}",
-                                if global.is_mutable { " mut" } else { "" },
-                                global.var_type
-                            )),
-                            ..Default::default()
-                        });
+                        completions.push(
+                            CompletionItem::new(&name[1..]) // Remove $ prefix
+                                .with_kind(CompletionItemKind::Variable)
+                                .with_detail(format!(
+                                    "(global{}) {}",
+                                    if global.is_mutable { " mut" } else { "" },
+                                    global.var_type
+                                )),
+                        );
                     }
                 }
             }
             InstructionContext::Local => {
                 // Local variable completions
-                if let Some(func) = find_containing_function(symbols, position.into()) {
+                if let Some(func) = find_containing_function(symbols, position) {
                     for param in &func.parameters {
                         if let Some(ref name) = param.name {
-                            completions.push(CompletionItem {
-                                label: name[1..].to_string(), // Remove $ prefix
-                                kind: Some(CompletionItemKind::VARIABLE),
-                                detail: Some(format!("(param) {}", param.param_type)),
-                                ..Default::default()
-                            });
+                            completions.push(
+                                CompletionItem::new(&name[1..]) // Remove $ prefix
+                                    .with_kind(CompletionItemKind::Variable)
+                                    .with_detail(format!("(param) {}", param.param_type)),
+                            );
                         }
                     }
                     for local in &func.locals {
                         if let Some(ref name) = local.name {
-                            completions.push(CompletionItem {
-                                label: name[1..].to_string(), // Remove $ prefix
-                                kind: Some(CompletionItemKind::VARIABLE),
-                                detail: Some(format!("(local) {}", local.var_type)),
-                                ..Default::default()
-                            });
+                            completions.push(
+                                CompletionItem::new(&name[1..]) // Remove $ prefix
+                                    .with_kind(CompletionItemKind::Variable)
+                                    .with_detail(format!("(local) {}", local.var_type)),
+                            );
                         }
                     }
                 }
             }
             InstructionContext::Branch => {
                 // Block label completions
-                if let Some(func) = find_containing_function(symbols, position.into()) {
+                if let Some(func) = find_containing_function(symbols, position) {
                     for block in &func.blocks {
-                        completions.push(CompletionItem {
-                            label: block.label[1..].to_string(), // Remove $ prefix
-                            kind: Some(CompletionItemKind::CONSTANT),
-                            detail: Some(format!(
-                                "{} at line {}",
-                                block.block_type,
-                                block.line + 1
-                            )),
-                            ..Default::default()
-                        });
+                        completions.push(
+                            CompletionItem::new(&block.label[1..]) // Remove $ prefix
+                                .with_kind(CompletionItemKind::Constant)
+                                .with_detail(format!(
+                                    "{} at line {}",
+                                    block.block_type,
+                                    block.line + 1
+                                )),
+                        );
                     }
                 }
             }
@@ -433,22 +412,20 @@ pub fn provide_completion(
                 // General $ completions - show everything
                 for func in &symbols.functions {
                     if let Some(ref name) = func.name {
-                        completions.push(CompletionItem {
-                            label: name[1..].to_string(),
-                            kind: Some(CompletionItemKind::FUNCTION),
-                            detail: Some("function".to_string()),
-                            ..Default::default()
-                        });
+                        completions.push(
+                            CompletionItem::new(&name[1..])
+                                .with_kind(CompletionItemKind::Function)
+                                .with_detail("function"),
+                        );
                     }
                 }
                 for global in &symbols.globals {
                     if let Some(ref name) = global.name {
-                        completions.push(CompletionItem {
-                            label: name[1..].to_string(),
-                            kind: Some(CompletionItemKind::VARIABLE),
-                            detail: Some("global".to_string()),
-                            ..Default::default()
-                        });
+                        completions.push(
+                            CompletionItem::new(&name[1..])
+                                .with_kind(CompletionItemKind::Variable)
+                                .with_detail("global"),
+                        );
                     }
                 }
             }
@@ -599,12 +576,9 @@ fn get_keyword_completions() -> Vec<CompletionItem> {
 }
 
 fn make_completion(label: &str, detail: &str) -> CompletionItem {
-    CompletionItem {
-        label: label.to_string(),
-        kind: Some(CompletionItemKind::KEYWORD),
-        detail: Some(detail.to_string()),
-        ..Default::default()
-    }
+    CompletionItem::new(label)
+        .with_kind(CompletionItemKind::Keyword)
+        .with_detail(detail)
 }
 
 static NUMBER_CONST_REGEX: Lazy<Regex> =
@@ -613,68 +587,33 @@ static NUMBER_CONST_REGEX: Lazy<Regex> =
 /// Get completions for annotation names
 fn get_annotation_completions() -> Vec<CompletionItem> {
     vec![
-        CompletionItem {
-            label: "name".to_string(),
-            kind: Some(CompletionItemKind::PROPERTY),
-            detail: Some("Custom name section".to_string()),
-            documentation: Some(Documentation::String(
-                "Provides human-readable names for debugging".to_string(),
-            )),
-            ..Default::default()
-        },
-        CompletionItem {
-            label: "producers".to_string(),
-            kind: Some(CompletionItemKind::PROPERTY),
-            detail: Some("Producer metadata".to_string()),
-            documentation: Some(Documentation::String(
-                "Records information about tools that produced this module".to_string(),
-            )),
-            ..Default::default()
-        },
-        CompletionItem {
-            label: "custom".to_string(),
-            kind: Some(CompletionItemKind::PROPERTY),
-            detail: Some("Custom section".to_string()),
-            documentation: Some(Documentation::String(
-                "Embed arbitrary data in the WebAssembly binary".to_string(),
-            )),
-            ..Default::default()
-        },
-        CompletionItem {
-            label: "interface".to_string(),
-            kind: Some(CompletionItemKind::PROPERTY),
-            detail: Some("Component model interface".to_string()),
-            documentation: Some(Documentation::String(
-                "Used in WebAssembly Component Model".to_string(),
-            )),
-            ..Default::default()
-        },
-        CompletionItem {
-            label: "use".to_string(),
-            kind: Some(CompletionItemKind::PROPERTY),
-            detail: Some("Component model import".to_string()),
-            documentation: Some(Documentation::String(
-                "References types from other interfaces".to_string(),
-            )),
-            ..Default::default()
-        },
-        CompletionItem {
-            label: "metadata.code.branch_hint".to_string(),
-            kind: Some(CompletionItemKind::PROPERTY),
-            detail: Some("Branch hint metadata".to_string()),
-            documentation: Some(Documentation::String(
-                "Provides hints for branch optimization".to_string(),
-            )),
-            ..Default::default()
-        },
-        CompletionItem {
-            label: "dylink".to_string(),
-            kind: Some(CompletionItemKind::PROPERTY),
-            detail: Some("Dynamic linking metadata".to_string()),
-            documentation: Some(Documentation::String(
-                "Contains information for dynamic linking".to_string(),
-            )),
-            ..Default::default()
-        },
+        CompletionItem::new("name")
+            .with_kind(CompletionItemKind::Property)
+            .with_detail("Custom name section")
+            .with_documentation("Provides human-readable names for debugging"),
+        CompletionItem::new("producers")
+            .with_kind(CompletionItemKind::Property)
+            .with_detail("Producer metadata")
+            .with_documentation("Records information about tools that produced this module"),
+        CompletionItem::new("custom")
+            .with_kind(CompletionItemKind::Property)
+            .with_detail("Custom section")
+            .with_documentation("Embed arbitrary data in the WebAssembly binary"),
+        CompletionItem::new("interface")
+            .with_kind(CompletionItemKind::Property)
+            .with_detail("Component model interface")
+            .with_documentation("Used in WebAssembly Component Model"),
+        CompletionItem::new("use")
+            .with_kind(CompletionItemKind::Property)
+            .with_detail("Component model import")
+            .with_documentation("References types from other interfaces"),
+        CompletionItem::new("metadata.code.branch_hint")
+            .with_kind(CompletionItemKind::Property)
+            .with_detail("Branch hint metadata")
+            .with_documentation("Provides hints for branch optimization"),
+        CompletionItem::new("dylink")
+            .with_kind(CompletionItemKind::Property)
+            .with_detail("Dynamic linking metadata")
+            .with_documentation("Contains information for dynamic linking"),
     ]
 }

--- a/src/features/completion/tests.rs
+++ b/src/features/completion/tests.rs
@@ -1,14 +1,5 @@
 use super::*;
 use crate::parser;
-use crate::tree_sitter_bindings::create_parser;
-use tree_sitter::Tree;
-
-fn create_test_tree(document: &str) -> Tree {
-    let mut parser = create_parser();
-    parser
-        .parse(document, None)
-        .expect("Failed to parse test document")
-}
 
 fn create_test_symbols() -> SymbolTable {
     let mut table = SymbolTable::new();
@@ -69,7 +60,7 @@ fn test_number_constant_completion() {
     let symbols = create_test_symbols();
     let position = Position::new(0, 4);
 
-    let completions = provide_completion(document, &symbols, &create_test_tree(document), position);
+    let completions = provide_completion(document, &symbols, position);
     assert!(!completions.is_empty());
 
     let completion = &completions[0];
@@ -86,7 +77,7 @@ fn test_float_constant_completion() {
     let symbols = create_test_symbols();
     let position = Position::new(0, 7);
 
-    let completions = provide_completion(document, &symbols, &create_test_tree(document), position);
+    let completions = provide_completion(document, &symbols, position);
     assert!(!completions.is_empty());
 
     let completion = &completions[0];
@@ -103,7 +94,7 @@ fn test_underscore_number_completion() {
     let symbols = create_test_symbols();
     let position = Position::new(0, 12);
 
-    let completions = provide_completion(document, &symbols, &create_test_tree(document), position);
+    let completions = provide_completion(document, &symbols, position);
     assert!(!completions.is_empty());
 
     let completion = &completions[0];
@@ -119,7 +110,7 @@ fn test_local_get_emmet() {
     let symbols = parser::parse_document(document).unwrap();
     let position = Position::new(1, 3); // After "l$"
 
-    let completions = provide_completion(document, &symbols, &create_test_tree(document), position);
+    let completions = provide_completion(document, &symbols, position);
     // The emmet feature should trigger, even if specific local isn't found
     // This is because find_containing_function may not always work
     // Test passes if it doesn't crash
@@ -132,7 +123,7 @@ fn test_local_set_emmet() {
     let symbols = parser::parse_document(document).unwrap();
     let position = Position::new(1, 4); // After "l=$"
 
-    let completions = provide_completion(document, &symbols, &create_test_tree(document), position);
+    let completions = provide_completion(document, &symbols, position);
     // The emmet feature should trigger
     // Test passes if it doesn't crash
     let _ = completions;
@@ -144,7 +135,7 @@ fn test_global_get_emmet() {
     let symbols = create_test_symbols();
     let position = Position::new(0, 2);
 
-    let completions = provide_completion(document, &symbols, &create_test_tree(document), position);
+    let completions = provide_completion(document, &symbols, position);
     // Should suggest global variables
     assert!(completions.iter().any(|c| c.label.contains("counter")));
 }
@@ -155,7 +146,7 @@ fn test_global_set_emmet() {
     let symbols = create_test_symbols();
     let position = Position::new(0, 3);
 
-    let completions = provide_completion(document, &symbols, &create_test_tree(document), position);
+    let completions = provide_completion(document, &symbols, position);
     // Should only suggest mutable globals
     assert!(completions.iter().any(|c| c.label.contains("counter")));
     assert!(completions.iter().any(|c| {
@@ -171,7 +162,7 @@ fn test_i32_instruction_completion() {
     let symbols = create_test_symbols();
     let position = Position::new(0, 4);
 
-    let completions = provide_completion(document, &symbols, &create_test_tree(document), position);
+    let completions = provide_completion(document, &symbols, position);
     assert!(!completions.is_empty());
 
     // Should have arithmetic operations
@@ -187,7 +178,7 @@ fn test_f64_instruction_completion() {
     let symbols = create_test_symbols();
     let position = Position::new(0, 4);
 
-    let completions = provide_completion(document, &symbols, &create_test_tree(document), position);
+    let completions = provide_completion(document, &symbols, position);
     assert!(!completions.is_empty());
 
     // Should have float-specific operations
@@ -202,7 +193,7 @@ fn test_local_instruction_completion() {
     let symbols = create_test_symbols();
     let position = Position::new(0, 6);
 
-    let completions = provide_completion(document, &symbols, &create_test_tree(document), position);
+    let completions = provide_completion(document, &symbols, position);
     assert!(!completions.is_empty());
 
     assert!(completions.iter().any(|c| c.label == "get"));
@@ -216,7 +207,7 @@ fn test_global_instruction_completion() {
     let symbols = create_test_symbols();
     let position = Position::new(0, 7);
 
-    let completions = provide_completion(document, &symbols, &create_test_tree(document), position);
+    let completions = provide_completion(document, &symbols, position);
     assert!(!completions.is_empty());
 
     assert!(completions.iter().any(|c| c.label == "get"));
@@ -229,7 +220,7 @@ fn test_memory_instruction_completion() {
     let symbols = create_test_symbols();
     let position = Position::new(0, 7);
 
-    let completions = provide_completion(document, &symbols, &create_test_tree(document), position);
+    let completions = provide_completion(document, &symbols, position);
     assert!(!completions.is_empty());
 
     assert!(completions.iter().any(|c| c.label == "size"));
@@ -244,7 +235,7 @@ fn test_table_instruction_completion() {
     let symbols = create_test_symbols();
     let position = Position::new(0, 6);
 
-    let completions = provide_completion(document, &symbols, &create_test_tree(document), position);
+    let completions = provide_completion(document, &symbols, position);
     assert!(!completions.is_empty());
 
     assert!(completions.iter().any(|c| c.label == "get"));
@@ -259,7 +250,7 @@ fn test_dollar_sign_function_completion() {
     let symbols = create_test_symbols();
     let position = Position::new(0, 6);
 
-    let completions = provide_completion(document, &symbols, &create_test_tree(document), position);
+    let completions = provide_completion(document, &symbols, position);
     // Should suggest functions
     assert!(completions.iter().any(|c| c.label.contains("add")));
 }
@@ -270,7 +261,7 @@ fn test_dollar_sign_global_completion() {
     let symbols = create_test_symbols();
     let position = Position::new(0, 12);
 
-    let completions = provide_completion(document, &symbols, &create_test_tree(document), position);
+    let completions = provide_completion(document, &symbols, position);
     // Should suggest globals
     assert!(completions.iter().any(|c| c.label.contains("counter")));
 }
@@ -282,7 +273,7 @@ fn test_dollar_sign_local_completion() {
     let symbols = parser::parse_document(document).unwrap();
     let position = Position::new(1, 13); // Position after the $ on line 2
 
-    let completions = provide_completion(document, &symbols, &create_test_tree(document), position);
+    let completions = provide_completion(document, &symbols, position);
 
     // Should suggest local parameters
     assert!(
@@ -298,7 +289,7 @@ fn test_jsdoc_tag_completion() {
     let symbols = create_test_symbols();
     let position = Position::new(0, 1);
 
-    let completions = provide_completion(document, &symbols, &create_test_tree(document), position);
+    let completions = provide_completion(document, &symbols, position);
     assert!(completions.iter().any(|c| c.label == "param"));
     assert!(completions.iter().any(|c| c.label == "result"));
     assert!(completions.iter().any(|c| c.label == "function"));
@@ -345,11 +336,11 @@ fn test_completion_item_kinds() {
     let symbols = create_test_symbols();
     let position = Position::new(0, 4);
 
-    let completions = provide_completion(document, &symbols, &create_test_tree(document), position);
+    let completions = provide_completion(document, &symbols, position);
     // Type completions should have KEYWORD kind
     assert!(completions
         .iter()
-        .all(|c| c.kind == Some(CompletionItemKind::KEYWORD)));
+        .all(|c| c.kind == Some(CompletionItemKind::Keyword)));
 }
 
 #[test]
@@ -358,7 +349,7 @@ fn test_ref_instruction_completion() {
     let symbols = create_test_symbols();
     let position = Position::new(0, 4);
 
-    let completions = provide_completion(document, &symbols, &create_test_tree(document), position);
+    let completions = provide_completion(document, &symbols, position);
     assert!(!completions.is_empty());
 
     assert!(completions.iter().any(|c| c.label == "null"));
@@ -375,7 +366,7 @@ fn test_struct_instruction_completion() {
     let symbols = create_test_symbols();
     let position = Position::new(0, 7);
 
-    let completions = provide_completion(document, &symbols, &create_test_tree(document), position);
+    let completions = provide_completion(document, &symbols, position);
     assert!(!completions.is_empty());
 
     assert!(completions.iter().any(|c| c.label == "new"));
@@ -390,7 +381,7 @@ fn test_array_instruction_completion() {
     let symbols = create_test_symbols();
     let position = Position::new(0, 6);
 
-    let completions = provide_completion(document, &symbols, &create_test_tree(document), position);
+    let completions = provide_completion(document, &symbols, position);
     assert!(!completions.is_empty());
 
     assert!(completions.iter().any(|c| c.label == "new"));
@@ -410,7 +401,7 @@ fn test_i31_instruction_completion() {
     let symbols = create_test_symbols();
     let position = Position::new(0, 4);
 
-    let completions = provide_completion(document, &symbols, &create_test_tree(document), position);
+    let completions = provide_completion(document, &symbols, position);
     assert!(!completions.is_empty());
 
     assert!(completions.iter().any(|c| c.label == "get_s"));
@@ -423,7 +414,7 @@ fn test_br_on_completion() {
     let symbols = create_test_symbols();
     let position = Position::new(0, 6);
 
-    let completions = provide_completion(document, &symbols, &create_test_tree(document), position);
+    let completions = provide_completion(document, &symbols, position);
     assert!(!completions.is_empty());
 
     assert!(completions.iter().any(|c| c.label == "null"));
@@ -438,7 +429,7 @@ fn test_any_convert_completion() {
     let symbols = create_test_symbols();
     let position = Position::new(0, 4);
 
-    let completions = provide_completion(document, &symbols, &create_test_tree(document), position);
+    let completions = provide_completion(document, &symbols, position);
     assert!(!completions.is_empty());
 
     assert!(completions.iter().any(|c| c.label == "convert_extern"));
@@ -450,7 +441,7 @@ fn test_extern_convert_completion() {
     let symbols = create_test_symbols();
     let position = Position::new(0, 7);
 
-    let completions = provide_completion(document, &symbols, &create_test_tree(document), position);
+    let completions = provide_completion(document, &symbols, position);
     assert!(!completions.is_empty());
 
     assert!(completions.iter().any(|c| c.label == "convert_any"));
@@ -486,7 +477,7 @@ fn test_annotation_completion() {
     let symbols = create_test_symbols();
     let position = Position::new(0, 2);
 
-    let completions = provide_completion(document, &symbols, &create_test_tree(document), position);
+    let completions = provide_completion(document, &symbols, position);
     assert!(
         !completions.is_empty(),
         "Should have annotation completions"
@@ -533,7 +524,7 @@ fn test_annotation_completion_has_details() {
         );
         assert_eq!(
             completion.kind,
-            Some(CompletionItemKind::PROPERTY),
+            Some(CompletionItemKind::Property),
             "Annotation completions should be PROPERTY kind"
         );
     }

--- a/src/features/mod.rs
+++ b/src/features/mod.rs
@@ -2,7 +2,7 @@
 // Each module implements a specific Language Server Protocol capability
 
 // Completion - provides code completion suggestions
-#[cfg(feature = "native")]
+#[cfg(any(feature = "native", feature = "wasm"))]
 pub mod completion;
 
 // Definition - implements go-to-definition

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ pub use features::symbols;
 #[cfg(any(feature = "native", feature = "wasm"))]
 pub use features::hover;
 
-#[cfg(feature = "native")]
+#[cfg(any(feature = "native", feature = "wasm"))]
 pub use features::completion;
 
 #[cfg(feature = "native")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -331,9 +331,10 @@ impl LanguageServer for Backend {
         let uri = params.text_document_position.text_document.uri.to_string();
         let position = params.text_document_position.position;
 
-        if let Some((doc, syms, tree)) = self.get_document_context(&uri) {
+        if let Some((doc, syms, _tree)) = self.get_document_context(&uri) {
+            let completions = completion::provide_completion(&doc, &syms, position.into());
             return Ok(Some(CompletionResponse::Array(
-                completion::provide_completion(&doc, &syms, &tree, position),
+                completions.into_iter().map(|c| c.into()).collect(),
             )));
         }
 

--- a/src/wasm/api.rs
+++ b/src/wasm/api.rs
@@ -4,7 +4,10 @@
 
 use wasm_bindgen::prelude::*;
 
-use crate::core::types::{HoverResult, Position, Range};
+use crate::completion::provide_completion;
+use crate::core::types::{
+    CompletionItem, CompletionItemKind, HoverResult, InsertTextFormat, Position, Range,
+};
 use crate::folding::{provide_folding_ranges, FoldingRangeKind};
 use crate::hover::provide_hover_core;
 use crate::parser::parse_document_from_tree;
@@ -529,6 +532,88 @@ impl WatLSP {
 
         js_array.into()
     }
+
+    /// Provide code completion items at the given position
+    /// Returns an array of completion item objects
+    #[wasm_bindgen(js_name = provideCompletion)]
+    pub fn provide_completion(&self, line: u32, col: u32) -> JsValue {
+        let symbols = match &self.symbols {
+            Some(s) => s,
+            None => return js_sys::Array::new().into(),
+        };
+
+        let position = Position::new(line, col);
+        let completions = provide_completion(&self.document, symbols, position);
+
+        let js_array = js_sys::Array::new();
+        for item in completions {
+            js_array.push(&completion_item_to_js(&item));
+        }
+
+        js_array.into()
+    }
+}
+
+/// Convert a completion item to a JavaScript object
+fn completion_item_to_js(item: &CompletionItem) -> JsValue {
+    let obj = js_sys::Object::new();
+
+    js_sys::Reflect::set(&obj, &"label".into(), &item.label.clone().into()).ok();
+
+    if let Some(kind) = &item.kind {
+        // Map to Monaco CompletionItemKind values
+        let kind_value = match kind {
+            CompletionItemKind::Text => 1,
+            CompletionItemKind::Method => 0,
+            CompletionItemKind::Function => 1,
+            CompletionItemKind::Constructor => 2,
+            CompletionItemKind::Field => 3,
+            CompletionItemKind::Variable => 4,
+            CompletionItemKind::Class => 5,
+            CompletionItemKind::Interface => 7,
+            CompletionItemKind::Module => 8,
+            CompletionItemKind::Property => 9,
+            CompletionItemKind::Unit => 10,
+            CompletionItemKind::Value => 11,
+            CompletionItemKind::Enum => 12,
+            CompletionItemKind::Keyword => 13,
+            CompletionItemKind::Snippet => 14,
+            CompletionItemKind::Color => 15,
+            CompletionItemKind::File => 16,
+            CompletionItemKind::Reference => 17,
+            CompletionItemKind::Folder => 18,
+            CompletionItemKind::EnumMember => 19,
+            CompletionItemKind::Constant => 20,
+            CompletionItemKind::Struct => 21,
+            CompletionItemKind::Event => 22,
+            CompletionItemKind::Operator => 23,
+            CompletionItemKind::TypeParameter => 24,
+        };
+        js_sys::Reflect::set(&obj, &"kind".into(), &kind_value.into()).ok();
+    }
+
+    if let Some(detail) = &item.detail {
+        js_sys::Reflect::set(&obj, &"detail".into(), &detail.clone().into()).ok();
+    }
+
+    if let Some(insert_text) = &item.insert_text {
+        js_sys::Reflect::set(&obj, &"insertText".into(), &insert_text.clone().into()).ok();
+    }
+
+    if let Some(format) = &item.insert_text_format {
+        // 1 = PlainText, 2 = Snippet (matches Monaco InsertTextRule.InsertAsSnippet)
+        let rules = match format {
+            InsertTextFormat::PlainText => 0,
+            InsertTextFormat::Snippet => 4, // Monaco InsertTextRule.InsertAsSnippet
+        };
+        js_sys::Reflect::set(&obj, &"insertTextRules".into(), &rules.into()).ok();
+    }
+
+    if let Some(doc) = &item.documentation {
+        js_sys::Reflect::set(&obj, &"documentation".into(), &doc.clone().into()).ok();
+    }
+
+    obj.into()
 }
 
 /// Map a capture name from highlights.scm to (tokenType index, tokenModifiers bitmask)

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -81,6 +81,7 @@ mod hover_integration {
 mod completion_integration {
     use super::*;
     use wat_lsp_rust::completion;
+    use wat_lsp_rust::core::types::Position as CorePosition;
 
     #[test]
     fn test_completion_in_function_context() {
@@ -90,10 +91,9 @@ mod completion_integration {
   )"#;
 
         let symbols = parser::parse_document(wat).unwrap();
-        let position = Position::new(2, 13); // After "$"
+        let position = CorePosition::new(2, 13); // After "$"
 
-        let completions =
-            completion::provide_completion(wat, &symbols, &create_test_tree(wat), position);
+        let completions = completion::provide_completion(wat, &symbols, position);
 
         // Should suggest local parameters
         assert!(completions.iter().any(|c| c.label.contains("x")));
@@ -105,10 +105,9 @@ mod completion_integration {
     fn test_emmet_expansion_workflow() {
         let wat = "5i32";
         let symbols = SymbolTable::new();
-        let position = Position::new(0, 4);
+        let position = CorePosition::new(0, 4);
 
-        let completions =
-            completion::provide_completion(wat, &symbols, &create_test_tree(wat), position);
+        let completions = completion::provide_completion(wat, &symbols, position);
         assert!(!completions.is_empty());
 
         let first = &completions[0];
@@ -260,6 +259,7 @@ mod parser_integration {
 
 mod end_to_end {
     use super::*;
+    use wat_lsp_rust::core::types::Position as CorePosition;
     use wat_lsp_rust::{completion, hover, signature};
 
     #[test]
@@ -285,13 +285,8 @@ mod end_to_end {
 
         // Step 3: Provide completions after "i32."
         let completion_doc = "i32.";
-        let completion_pos = Position::new(0, 4);
-        let completions = completion::provide_completion(
-            completion_doc,
-            &symbols,
-            &create_test_tree(completion_doc),
-            completion_pos,
-        );
+        let completion_pos = CorePosition::new(0, 4);
+        let completions = completion::provide_completion(completion_doc, &symbols, completion_pos);
         assert!(completions.iter().any(|c| c.label == "add"));
 
         // Step 4: Provide signature help in function call
@@ -314,9 +309,8 @@ mod end_to_end {
         // User types "5i32" - should get emmet completion
         wat.push_str("5i32");
         let symbols = parser::parse_document(&wat).unwrap();
-        let pos = Position::new(2, 8);
-        let completions =
-            completion::provide_completion(&wat, &symbols, &create_test_tree(&wat), pos);
+        let pos = CorePosition::new(2, 8);
+        let completions = completion::provide_completion(&wat, &symbols, pos);
         assert!(completions.iter().any(|c| {
             c.insert_text
                 .as_ref()

--- a/tests/large_file_performance.rs
+++ b/tests/large_file_performance.rs
@@ -1,5 +1,6 @@
 use std::time::Instant;
 use tower_lsp::lsp_types::Position;
+use wat_lsp_rust::core::types::Position as CorePosition;
 use wat_lsp_rust::tree_sitter_bindings::create_parser;
 use wat_lsp_rust::utils::apply_text_edit;
 use wat_lsp_rust::{diagnostics, parser};
@@ -315,7 +316,7 @@ fn test_15k_line_completion_latency() {
 
     // Parse document
     let mut parser = create_parser();
-    let tree = parser.parse(&document, None).expect("Parse failed");
+    let _tree = parser.parse(&document, None).expect("Parse failed");
     let symbols = parser::parse_document(&document).expect("Symbol extraction failed");
 
     println!("Document parsed: {} functions", symbols.functions.len());
@@ -324,26 +325,23 @@ fn test_15k_line_completion_latency() {
     println!("\n=== Testing Completion Performance ===");
 
     // Position 1: Early in document (line 50)
-    let pos1 = Position::new(50, 10);
+    let pos1 = CorePosition::new(50, 10);
     let start = Instant::now();
-    let _completions1 =
-        wat_lsp_rust::completion::provide_completion(&document, &symbols, &tree, pos1);
+    let _completions1 = wat_lsp_rust::completion::provide_completion(&document, &symbols, pos1);
     let time1 = start.elapsed();
     println!("Completion at line 50: {:?}", time1);
 
     // Position 2: Middle of document (line 7500)
-    let pos2 = Position::new(7500, 10);
+    let pos2 = CorePosition::new(7500, 10);
     let start = Instant::now();
-    let _completions2 =
-        wat_lsp_rust::completion::provide_completion(&document, &symbols, &tree, pos2);
+    let _completions2 = wat_lsp_rust::completion::provide_completion(&document, &symbols, pos2);
     let time2 = start.elapsed();
     println!("Completion at line 7500: {:?}", time2);
 
     // Position 3: Near end (line 14500)
-    let pos3 = Position::new(14500, 10);
+    let pos3 = CorePosition::new(14500, 10);
     let start = Instant::now();
-    let _completions3 =
-        wat_lsp_rust::completion::provide_completion(&document, &symbols, &tree, pos3);
+    let _completions3 = wat_lsp_rust::completion::provide_completion(&document, &symbols, pos3);
     let time3 = start.elapsed();
     println!("Completion at line 14500: {:?}", time3);
 


### PR DESCRIPTION
Enables the completion module for WASM builds so the playground gets the same intelligent completions as the VS Code extension.

Key changes:
- Add protocol-independent CompletionItem types to core/types.rs
- Enable completion module for WASM feature flag
- Add provideCompletion method to WASM API
- Update playground to use WASM-based completion