### PR TITLE
Add folded try/do/catch exception handling syntax and exnref type support

### DIFF
--- a/docs/examples/exceptions.wat
+++ b/docs/examples/exceptions.wat
@@ -1,40 +1,114 @@
-;; Exception Handling Proposal
-;; Demonstrates try/catch/throw/rethrow
+;; Exception Handling in WebAssembly
+;;
+;; This file demonstrates both:
+;; 1. Legacy exception handling (try/catch/throw) - supported in browsers since 2022
+;; 2. Modern exception handling (try_table) - WebAssembly 3.0 standard (2025)
+;;
+;; The legacy syntax is still supported in browsers but may be deprecated.
+;; New code should prefer try_table.
 
 (module
-  ;; Define exception tags
-  (tag $div_by_zero (param i32))
-  (tag $out_of_bounds (param i32 i32))  ;; index, length
-  (tag $invalid_input)
-  (tag $custom_error (param i32 i32 i32))
+  ;; ============================================================
+  ;; Exception Tags
+  ;; Tags define the signature of exceptions (what values they carry)
+  ;; ============================================================
+
+  (tag $div_by_zero (param i32))           ;; carries the dividend
+  (tag $out_of_bounds (param i32 i32))     ;; carries index and length
+  (tag $invalid_input)                      ;; no payload
+  (tag $custom_error (param i32 i32 i32))  ;; multi-value payload
 
   (memory 1)
 
+  ;; ============================================================
+  ;; PART 1: MODERN SYNTAX (try_table) - WebAssembly 3.0
+  ;;
+  ;; try_table uses labeled branches for exception handling.
+  ;; When an exception is caught, control branches to the label
+  ;; with the exception payload (and optionally an exnref).
+  ;; ============================================================
+
+  ;; Safe division using try_table
+  (func $safe_divide_modern (param $a i32) (param $b i32) (result i32)
+    (block $catch (result i32)       ;; catch target - receives the exception payload
+      (try_table (result i32) (catch $div_by_zero $catch)
+        (if (i32.eqz (local.get $b))
+          (then
+            (throw $div_by_zero (local.get $a))))
+        (i32.div_s (local.get $a) (local.get $b)))))
+
+  ;; Division with default value using try_table
+  (func $divide_with_default_modern (param $a i32) (param $b i32) (param $default i32) (result i32)
+    (block $on_error (result i32)    ;; receives dividend from exception
+      (drop                          ;; drop the exception payload
+        (br_on_null $on_error        ;; if somehow null, use default
+          (block $catch (result i32 exnref)
+            (try_table (result i32) (catch_ref $div_by_zero $catch)
+              (call $safe_divide_modern (local.get $a) (local.get $b))
+              (return)))))
+      (local.get $default)))
+
+  ;; Catch any exception using catch_all
+  (func $try_any_modern (param $op i32) (result i32)
+    (block $catch_all_handler (result exnref)
+      (try_table (result i32) (catch_all_ref $catch_all_handler)
+        (if (i32.eqz (local.get $op))
+          (then (throw $invalid_input)))
+        (i32.const 42)
+        (return)))
+    (drop)  ;; drop the exnref
+    (i32.const -1))
+
+  ;; Nested try_table blocks
+  (func $nested_modern (param $x i32) (result i32)
+    (block $outer_catch (result i32)
+      (try_table (result i32) (catch $invalid_input $outer_catch)
+        (block $inner_catch (result i32)
+          (try_table (result i32) (catch $div_by_zero $inner_catch)
+            (if (i32.lt_s (local.get $x) (i32.const 0))
+              (then (throw $invalid_input)))
+            (call $safe_divide_modern (i32.const 100) (local.get $x))
+            (return)))
+        (drop)  ;; inner catch: drop dividend, return 0
+        (i32.const 0)
+        (return)))
+    (i32.const -1))  ;; outer catch: invalid input
+
+  ;; Rethrow using throw_ref
+  (func $log_and_rethrow_modern (param $a i32) (param $b i32) (result i32)
+    (block $catch (result i32 exnref)
+      (try_table (result i32) (catch_ref $div_by_zero $catch)
+        (call $safe_divide_modern (local.get $a) (local.get $b))
+        (return)))
+    ;; Stack: [dividend, exnref]
+    (i32.store (i32.const 0) (i32.const 1))  ;; log error flag
+    (throw_ref))  ;; rethrow the caught exception
+
+  ;; ============================================================
+  ;; PART 2: LEGACY SYNTAX (try/do/catch)
+  ;;
+  ;; This syntax is still supported in browsers but deprecated.
+  ;; The folded form uses (do ...) for the try body.
+  ;; ============================================================
+
   ;; Safe division that throws on divide by zero
-  (func $safe_divide (param $a i32) (param $b i32) (result i32)
+  (func $safe_divide_legacy (param $a i32) (param $b i32) (result i32)
     (if (i32.eqz (local.get $b))
       (then
         (throw $div_by_zero (local.get $a))))
     (i32.div_s (local.get $a) (local.get $b)))
 
-  ;; Bounds-checked array access
-  (func $checked_load (param $idx i32) (param $len i32) (result i32)
-    (if (i32.ge_u (local.get $idx) (local.get $len))
-      (then
-        (throw $out_of_bounds (local.get $idx) (local.get $len))))
-    (i32.load (i32.shl (local.get $idx) (i32.const 2))))
-
-  ;; Function that catches division errors
-  (func $divide_with_default (param $a i32) (param $b i32) (param $default i32) (result i32)
+  ;; Function that catches division errors (legacy folded syntax)
+  (func $divide_with_default_legacy (param $a i32) (param $b i32) (param $default i32) (result i32)
     (try (result i32)
       (do
-        (call $safe_divide (local.get $a) (local.get $b)))
+        (call $safe_divide_legacy (local.get $a) (local.get $b)))
       (catch $div_by_zero
         (drop)  ;; drop the exception payload
         (local.get $default))))
 
-  ;; Function demonstrating catch_all
-  (func $try_operation (param $op i32) (result i32)
+  ;; Multiple catch clauses (legacy)
+  (func $try_operation_legacy (param $op i32) (result i32)
     (try (result i32)
       (do
         (if (result i32) (i32.eq (local.get $op) (i32.const 0))
@@ -56,8 +130,8 @@
       (catch_all
         (i32.const -999))))
 
-  ;; Nested try blocks
-  (func $nested_try (param $x i32) (result i32)
+  ;; Nested try blocks (legacy)
+  (func $nested_try_legacy (param $x i32) (result i32)
     (try (result i32)
       (do
         (try (result i32)
@@ -65,26 +139,26 @@
             (if (i32.lt_s (local.get $x) (i32.const 0))
               (then
                 (throw $invalid_input)))
-            (call $safe_divide (i32.const 100) (local.get $x)))
+            (call $safe_divide_legacy (i32.const 100) (local.get $x)))
           (catch $div_by_zero
             (drop)
             (i32.const 0))))
       (catch $invalid_input
         (i32.const -1))))
 
-  ;; Function that rethrows an exception
-  (func $log_and_rethrow (param $a i32) (param $b i32) (result i32)
+  ;; Function that rethrows an exception (legacy)
+  (func $log_and_rethrow_legacy (param $a i32) (param $b i32) (result i32)
     (try (result i32)
       (do
-        (call $safe_divide (local.get $a) (local.get $b)))
+        (call $safe_divide_legacy (local.get $a) (local.get $b)))
       (catch $div_by_zero
         ;; Log the error (store to memory)
         (i32.store (i32.const 0) (i32.const 1))  ;; error flag
         ;; Rethrow the exception
         (rethrow 0))))
 
-  ;; Function using try with delegate
-  (func $delegating_handler (param $x i32) (result i32)
+  ;; Delegate to outer handler (legacy)
+  (func $delegating_handler_legacy (param $x i32) (result i32)
     (try (result i32)
       (do
         (try (result i32)
@@ -98,50 +172,36 @@
         (drop)
         (i32.const -1))))
 
-  ;; Multi-value exception payload
-  (func $throw_custom (param $a i32) (param $b i32) (param $c i32)
-    (throw $custom_error (local.get $a) (local.get $b) (local.get $c)))
+  ;; ============================================================
+  ;; PART 3: UNFOLD SYNTAX (also legacy, but different form)
+  ;;
+  ;; The unfold form doesn't use (do ...), instructions are inline.
+  ;; ============================================================
 
-  ;; Catch multi-value exception
-  (func $catch_custom (result i32)
-    (try (result i32)
-      (do
-        (call $throw_custom (i32.const 10) (i32.const 20) (i32.const 30))
-        (i32.const 0))
-      (catch $custom_error
-        ;; Stack has: a b c (top)
-        ;; Sum them all
-        (i32.add (i32.add)))))
+  (func $unfold_example (param $x i32) (result i32)
+    try (result i32)
+      local.get $x
+      i32.eqz
+      if
+        i32.const 42
+        throw $div_by_zero
+      end
+      local.get $x
+    catch $div_by_zero
+      drop
+      i32.const -1
+    end)
 
-  ;; Example: Validate input and process
-  (func $validate_and_process (param $input i32) (result i32)
-    (local $result i32)
-    (try (result i32)
-      (do
-        ;; Validate: must be positive
-        (if (i32.le_s (local.get $input) (i32.const 0))
-          (then
-            (throw $invalid_input)))
-        ;; Validate: must be less than 1000
-        (if (i32.ge_s (local.get $input) (i32.const 1000))
-          (then
-            (throw $out_of_bounds (local.get $input) (i32.const 1000))))
-        ;; Process: double and add 1
-        (i32.add
-          (i32.mul (local.get $input) (i32.const 2))
-          (i32.const 1)))
-      (catch $invalid_input
-        (i32.const -1))
-      (catch $out_of_bounds
-        (drop)
-        (drop)
-        (i32.const -2))
-      (catch_all
-        (i32.const -999))))
-
+  ;; ============================================================
   ;; Exports
-  (export "safe_divide" (func $safe_divide))
-  (export "divide_with_default" (func $divide_with_default))
-  (export "try_operation" (func $try_operation))
-  (export "nested_try" (func $nested_try))
-  (export "validate_and_process" (func $validate_and_process)))
+  ;; ============================================================
+
+  ;; Modern (try_table)
+  (export "safe_divide" (func $safe_divide_modern))
+  (export "divide_with_default" (func $divide_with_default_modern))
+  (export "nested" (func $nested_modern))
+
+  ;; Legacy (try/do/catch)
+  (export "safe_divide_legacy" (func $safe_divide_legacy))
+  (export "divide_with_default_legacy" (func $divide_with_default_legacy))
+  (export "nested_legacy" (func $nested_try_legacy)))

--- a/grammars/tree-sitter-wat/grammar.js
+++ b/grammars/tree-sitter-wat/grammar.js
@@ -124,7 +124,7 @@ module.exports = grammar({
 
     expr: $ => seq("(", $.expr1, ")"),
 
-    expr1: $ => choice($.expr1_plain, $.expr1_call, $.expr1_block, $.expr1_loop, $.expr1_if, $.expr1_try_table),
+    expr1: $ => choice($.expr1_plain, $.expr1_call, $.expr1_block, $.expr1_loop, $.expr1_if, $.expr1_try_table, $.expr1_try),
 
     expr1_block: $ =>
       seq(
@@ -164,6 +164,31 @@ module.exports = grammar({
         repeat($.catch_clause),
         optional($.instr_list),
       ),
+
+    // Folded form of legacy try: (try (result ...) (do ...) (catch ...) ...)
+    expr1_try: $ =>
+      seq(
+        "try",
+        optional($.identifier),
+        seq(optional($.type_use), repeat($.func_type_params_many), repeat($.func_type_results)),
+        $.try_do_clause,
+        choice(
+          // Either catch clauses (with optional catch_all)
+          seq(repeat1($.try_catch_clause), optional($.try_catch_all_clause)),
+          // Or just catch_all
+          $.try_catch_all_clause,
+          // Or delegate
+          $.try_delegate_clause,
+        ),
+      ),
+
+    try_do_clause: $ => seq("(", "do", optional($.instr_list), ")"),
+
+    try_catch_clause: $ => seq("(", "catch", $.index, optional($.instr_list), ")"),
+
+    try_catch_all_clause: $ => seq("(", "catch_all", optional($.instr_list), ")"),
+
+    try_delegate_clause: $ => seq("(", "delegate", $.index, ")"),
 
     float: $ => seq(optional($.sign), choice($.dec_float, $.hex_float, "inf", $.nan)),
 
@@ -872,13 +897,13 @@ module.exports = grammar({
     offset_value: $ => seq("offset", imm("="), $.align_offset_value),
 
     // proposal: reference-types
-    ref_kind: $ => /extern|func|struct|array|i31|any|eq|null|none|noextern|nofunc/,
+    ref_kind: $ => /extern|func|struct|array|i31|any|eq|null|none|noextern|nofunc|exn|noexn/,
 
     // Helper for instructions that take either a heap type or (ref ...) form
     _heap_type_or_ref: $ => choice($.ref_kind, $.index, $.ref_type_ref),
 
     // proposal: reference-types
-    ref_type: $ => choice($.ref_type_externref, $.ref_type_funcref, $.ref_type_ref, "anyref", "eqref", "i31ref", "structref", "arrayref", "nullref", "nullfuncref", "nullexternref", "nullref"),
+    ref_type: $ => choice($.ref_type_externref, $.ref_type_funcref, $.ref_type_ref, "anyref", "eqref", "i31ref", "structref", "arrayref", "nullref", "nullfuncref", "nullexternref", "exnref", "nullexnref"),
 
     ref_type_concrete: $ =>
       seq("(", "ref", optional("null"), $.index, ")"),

--- a/grammars/tree-sitter-wat/queries/highlights.scm
+++ b/grammars/tree-sitter-wat/queries/highlights.scm
@@ -34,6 +34,8 @@
   "nullref"
   "nullfuncref"
   "nullexternref"
+  "exnref"
+  "nullexnref"
 ] @type.builtin
 
 ; Heap type keywords (used in ref.null, ref.cast, etc.)
@@ -53,11 +55,16 @@
   "br_table"
   "call_indirect"
   "try"
+  "try_table"
   "catch"
+  "catch_ref"
   "catch_all"
+  "catch_all_ref"
   "throw"
+  "throw_ref"
   "rethrow"
   "delegate"
+  "do"
 ] @keyword.control
 
 ; Module structure keywords


### PR DESCRIPTION
Adds support for legacy folded exception handling syntax with `(do ...)` blocks and `exnref` type.

- Grammar: Added `expr1_try` for folded `try/do/catch` form
- Grammar: Added `exnref`, `nullexnref`, `exn`, `noexn` types
- Highlighting: Added `try_table`, `catch_ref`, `throw_ref`, `do` keywords
- Example: Updated exceptions.wat to show both modern `try_table` and legacy `try/do/catch` syntax