### PR TITLE
use npm trusted publishing with OIDC and add --no-pack flag to local build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -326,6 +326,9 @@ jobs:
       needs.prepare-release.result == 'success' &&
       (needs.prepare-release.outputs.publish_target == 'both' || needs.prepare-release.outputs.publish_target == 'npm')
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -362,6 +365,4 @@ jobs:
 
       - name: Publish to npm
         working-directory: packages/wat-lsp
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public --provenance

--- a/packages/wat-lsp/package.json
+++ b/packages/wat-lsp/package.json
@@ -19,7 +19,7 @@
     "dist"
   ],
   "scripts": {
-    "build:wasm": "cd ../.. && wasm-pack build --target web --no-opt -- --features wasm --no-default-features && mkdir -p packages/wat-lsp/dist/wasm && cp pkg/wat_lsp_rust.js pkg/wat_lsp_rust.d.ts pkg/wat_lsp_rust_bg.wasm packages/wat-lsp/dist/wasm/",
+    "build:wasm": "cd ../.. && wasm-pack build --target web --no-opt --no-pack -- --features wasm --no-default-features && mkdir -p packages/wat-lsp/dist/wasm && cp pkg/wat_lsp_rust.js pkg/wat_lsp_rust.d.ts pkg/wat_lsp_rust_bg.wasm packages/wat-lsp/dist/wasm/",
     "build:wrapper": "mkdir -p dist && cp src/*.js dist/ && cp src/*.d.ts dist/",
     "build:assets": "node scripts/copy-assets.js",
     "build": "npm run build:wasm && npm run build:wrapper && npm run build:assets",


### PR DESCRIPTION
- Switch npm publish to OIDC trusted publishing (no token needed)
- Add `id-token: write` permission and `--provenance` flag
- Add `--no-pack` to local wasm-pack build to fix package.json generation error