### PR TITLE
upgrade npm for OIDC trusted publishing support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -337,6 +337,9 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Upgrade npm for OIDC support
+        run: npm install -g npm@latest
+
       - name: Install tree-sitter CLI
         run: npm install -g tree-sitter-cli
 


### PR DESCRIPTION
npm OIDC trusted publishing requires npm v11.5.1+. Node 20 bundles npm 10.x, so we need to explicitly upgrade npm to latest before publishing.