### PR TITLE
fix repository URL for npm provenance verification

### DIFF
--- a/packages/wat-lsp/package.json
+++ b/packages/wat-lsp/package.json
@@ -28,7 +28,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/EmNudge/wat-lsp-rust.git",
+    "url": "git+https://github.com/EmNudge/wat-lsp.git",
     "directory": "packages/wat-lsp"
   },
   "keywords": [
@@ -43,9 +43,9 @@
   "author": "EmNudge",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/EmNudge/wat-lsp-rust/issues"
+    "url": "https://github.com/EmNudge/wat-lsp/issues"
   },
-  "homepage": "https://github.com/EmNudge/wat-lsp-rust#readme",
+  "homepage": "https://github.com/EmNudge/wat-lsp#readme",
   "devDependencies": {
     "web-tree-sitter": "^0.25.3"
   },


### PR DESCRIPTION
Update repository URL in package.json from `wat-lsp-rust` to `wat-lsp` to match the actual GitHub repo. npm provenance verification requires these to match.