### PR TITLE
fix wasm-pack version in CI to support --no-pack flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,7 +223,7 @@ jobs:
       - name: Install wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
         with:
-          version: 'latest'
+          version: '0.14.0'
 
       - name: Install Node.js
         uses: actions/setup-node@v6
@@ -271,7 +271,7 @@ jobs:
       - name: Install wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
         with:
-          version: 'latest'
+          version: '0.14.0'
 
       - name: Install Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
Pin wasm-pack to version 0.14.0 instead of 'latest' to fix CI failing with unrecognized --no-pack flag