### PR TITLE
fix false errors for function calls with unfolded expressions (#78)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,41 @@ jobs:
       - name: Run tests (native, release mode)
         run: cargo test --features native --release --verbose
 
+      - name: Validate example files with wat-check
+        shell: bash
+        run: |
+          cargo build --features native --release --bin wat-check
+          failed=0
+
+          echo "=== Checking valid examples (should pass) ==="
+          for file in docs/examples/*.wat; do
+            echo "Checking $file..."
+            if ! ./target/release/wat-check "$file"; then
+              echo "ERROR: $file has diagnostics (expected none)"
+              failed=1
+            fi
+          done
+
+          echo ""
+          echo "=== Checking invalid examples (should fail) ==="
+          for file in docs/examples/invalid/*.wat; do
+            echo "Checking $file..."
+            if ./target/release/wat-check "$file" 2>/dev/null; then
+              echo "ERROR: $file passed validation (expected diagnostics)"
+              failed=1
+            else
+              echo "OK: $file correctly rejected"
+            fi
+          done
+
+          if [ $failed -eq 1 ]; then
+            echo ""
+            echo "Example validation failed"
+            exit 1
+          fi
+          echo ""
+          echo "All example files validated correctly"
+
   clippy:
     name: Clippy
     needs: changes

--- a/docs/examples/invalid/multiple_errors.wat
+++ b/docs/examples/invalid/multiple_errors.wat
@@ -1,0 +1,11 @@
+;; Invalid: multiple errors in one file
+;; This file has both undefined references and wrong parameter counts
+
+(module
+  (func (export "bad") (result i32)
+    ;; Error 1: undefined local
+    (local.get $x)
+    ;; Error 2: too many params to i32.const (expects 0 nested operands)
+    (i32.const 1 (i32.const 2))
+    ;; Error 3: undefined function
+    (call $ghost)))

--- a/docs/examples/invalid/syntax_missing_paren.wat
+++ b/docs/examples/invalid/syntax_missing_paren.wat
@@ -1,0 +1,6 @@
+;; Invalid: syntax error - missing closing parenthesis
+;; The module is missing its closing paren
+
+(module
+  (func (export "test") (result i32)
+    (i32.const 42))

--- a/docs/examples/invalid/syntax_unexpected_token.wat
+++ b/docs/examples/invalid/syntax_unexpected_token.wat
@@ -1,0 +1,6 @@
+;; Invalid: syntax error - unexpected token
+;; "foobar" is not a valid instruction
+
+(module
+  (func (export "test") (result i32)
+    (foobar 42)))

--- a/docs/examples/invalid/too_many_params.wat
+++ b/docs/examples/invalid/too_many_params.wat
@@ -1,0 +1,9 @@
+;; Invalid: too many parameters to i32.add
+;; i32.add takes exactly 2 operands, not 3
+
+(module
+  (func (export "test") (result i32)
+    (i32.add
+      (i32.const 1)
+      (i32.const 2)
+      (i32.const 3))))

--- a/docs/examples/invalid/undefined_function.wat
+++ b/docs/examples/invalid/undefined_function.wat
@@ -1,0 +1,6 @@
+;; Invalid: undefined function reference
+;; The function $nonexistent is never defined
+
+(module
+  (func (export "caller") (result i32)
+    (call $nonexistent)))

--- a/docs/examples/invalid/undefined_global.wat
+++ b/docs/examples/invalid/undefined_global.wat
@@ -1,0 +1,6 @@
+;; Invalid: undefined global variable reference
+;; The global $missing_global is never declared
+
+(module
+  (func (export "test") (result i32)
+    (global.get $missing_global)))

--- a/docs/examples/invalid/undefined_label.wat
+++ b/docs/examples/invalid/undefined_label.wat
@@ -1,0 +1,7 @@
+;; Invalid: undefined label reference
+;; The label $nowhere is never defined
+
+(module
+  (func (export "test")
+    (block $here
+      (br $nowhere))))

--- a/docs/examples/invalid/undefined_local.wat
+++ b/docs/examples/invalid/undefined_local.wat
@@ -1,0 +1,6 @@
+;; Invalid: undefined local variable reference
+;; The local $missing is never declared
+
+(module
+  (func (export "test") (result i32)
+    (local.get $missing)))

--- a/docs/examples/invalid/undefined_table_init.wat
+++ b/docs/examples/invalid/undefined_table_init.wat
@@ -1,0 +1,7 @@
+;; Invalid: undefined table in table.init
+;; The table $missing is never declared
+
+(module
+  (table $other 1 funcref)
+  (func (export "test")
+    (table.init $missing (i32.const 0) (i32.const 0) (i32.const 0))))

--- a/docs/examples/invalid/undefined_type.wat
+++ b/docs/examples/invalid/undefined_type.wat
@@ -1,0 +1,7 @@
+;; Invalid: undefined type reference
+;; The type $missing_type is never declared
+
+(module
+  (table 1 funcref)
+  (func (export "test") (result i32)
+    (call_indirect (type $missing_type) (i32.const 0))))

--- a/docs/examples/invalid/unreachable_br.wat
+++ b/docs/examples/invalid/unreachable_br.wat
@@ -1,0 +1,8 @@
+;; Invalid: br_if with undefined label
+;; Demonstrates branch instruction with bad reference
+
+(module
+  (func (export "test") (result i32)
+    (block $outer (result i32)
+      (br_if $inner (i32.const 1))
+      (i32.const 0))))

--- a/docs/examples/linear_style.wat
+++ b/docs/examples/linear_style.wat
@@ -1,0 +1,190 @@
+;; Linear (Unfolded) Style
+;; Demonstrates stack-based programming where values are pushed
+;; to the stack before operations consume them.
+;; This is an alternative to the more common folded/S-expression style.
+
+(module
+  ;; Helper function: add two numbers
+  (func $add (param $a i32) (param $b i32) (result i32)
+    local.get $a
+    local.get $b
+    i32.add)
+
+  ;; Helper function: multiply two numbers
+  (func $mul (param $a i32) (param $b i32) (result i32)
+    local.get $a
+    local.get $b
+    i32.mul)
+
+  ;; Compute (a + b) * (c + d) using purely linear style
+  (func $compute (export "compute")
+        (param $a i32) (param $b i32) (param $c i32) (param $d i32)
+        (result i32)
+    ;; Push a and b, then call $add
+    local.get $a
+    local.get $b
+    call $add
+
+    ;; Push c and d, then call $add
+    local.get $c
+    local.get $d
+    call $add
+
+    ;; Multiply the two results (both are on the stack)
+    call $mul)
+
+  ;; Same computation mixing folded and unfolded styles
+  (func $compute_mixed (export "compute_mixed")
+        (param $a i32) (param $b i32) (param $c i32) (param $d i32)
+        (result i32)
+    ;; First addition in folded style, result goes on stack
+    (call $add (local.get $a) (local.get $b))
+
+    ;; Second addition in unfolded style
+    local.get $c
+    local.get $d
+    call $add
+
+    ;; Multiply both results
+    call $mul)
+
+  ;; Factorial using linear style with a loop
+  (func $factorial (export "factorial") (param $n i32) (result i32)
+    (local $result i32)
+    (local $i i32)
+
+    ;; Initialize result = 1
+    i32.const 1
+    local.set $result
+
+    ;; Initialize i = 2 (we'll multiply from 2 to n)
+    i32.const 2
+    local.set $i
+
+    ;; Loop while i <= n
+    block $done
+      loop $continue
+        ;; Check if i > n, if so exit
+        local.get $i
+        local.get $n
+        i32.gt_s
+        br_if $done
+
+        ;; result = result * i
+        local.get $result
+        local.get $i
+        i32.mul
+        local.set $result
+
+        ;; i = i + 1
+        local.get $i
+        i32.const 1
+        i32.add
+        local.set $i
+
+        ;; Continue loop
+        br $continue
+      end
+    end
+
+    ;; Return result
+    local.get $result)
+
+  ;; Demonstrate global access in linear style
+  (global $counter (mut i32) (i32.const 0))
+
+  (func $increment (export "increment") (result i32)
+    ;; Load current counter value
+    global.get $counter
+
+    ;; Add 1 to it
+    i32.const 1
+    i32.add
+
+    ;; Store back (but also keep on stack for return)
+    ;; Need to duplicate: load, add, tee to local, store, get local
+    ;; Actually simpler: load, add 1, set, load again
+    global.set $counter
+    global.get $counter)
+
+  ;; Memory operations in linear style
+  (memory $mem 1)
+
+  (func $store_and_load (export "store_and_load") (param $addr i32) (param $value i32) (result i32)
+    ;; Store value at address
+    local.get $addr
+    local.get $value
+    i32.store
+
+    ;; Load and return it
+    local.get $addr
+    i32.load)
+
+  ;; Conditional logic in linear style
+  (func $max (export "max") (param $a i32) (param $b i32) (result i32)
+    local.get $a
+    local.get $b
+    local.get $a
+    local.get $b
+    i32.gt_s
+    select)
+
+  ;; Demonstrating br_if with stack values
+  (func $sum_to_n (export "sum_to_n") (param $n i32) (result i32)
+    (local $sum i32)
+    (local $i i32)
+
+    i32.const 0
+    local.set $sum
+
+    i32.const 1
+    local.set $i
+
+    block $done
+      loop $continue
+        ;; if i > n, break
+        local.get $i
+        local.get $n
+        i32.gt_s
+        br_if $done
+
+        ;; sum += i
+        local.get $sum
+        local.get $i
+        i32.add
+        local.set $sum
+
+        ;; i++
+        local.get $i
+        i32.const 1
+        i32.add
+        local.set $i
+
+        br $continue
+      end
+    end
+
+    local.get $sum)
+
+  ;; Multiple return values (multi-value) in linear style
+  (func $divmod (export "divmod") (param $a i32) (param $b i32) (result i32 i32)
+    ;; Push quotient
+    local.get $a
+    local.get $b
+    i32.div_s
+
+    ;; Push remainder
+    local.get $a
+    local.get $b
+    i32.rem_s)
+
+  ;; Call a function that returns multiple values
+  (func $use_divmod (export "use_divmod") (param $a i32) (param $b i32) (result i32)
+    ;; Call divmod, get quotient and remainder on stack
+    local.get $a
+    local.get $b
+    call $divmod
+
+    ;; Add quotient + remainder
+    i32.add)
+)

--- a/src/diagnostics/semantic_diagnostics.rs
+++ b/src/diagnostics/semantic_diagnostics.rs
@@ -693,9 +693,14 @@ fn validate_dynamic_operands(
                     use crate::symbols::TypeKind;
                     if let TypeKind::Struct { fields } = &type_def.kind {
                         let expected = fields.len();
-                        if operand_count != expected {
-                            let msg =
-                                format!("{} operands (fields of struct {})", expected, type_name);
+                        // Only report error if there are TOO MANY operands.
+                        // Having fewer operands is valid in WAT because remaining operands
+                        // can come from the implicit stack (linear or partially folded style).
+                        if operand_count > expected {
+                            let msg = format!(
+                                "at most {} operands (fields of struct {})",
+                                expected, type_name
+                            );
                             let diagnostic = create_operand_count_diagnostic(
                                 node,
                                 instr_name,
@@ -721,8 +726,12 @@ fn validate_dynamic_operands(
             if let Some(tag_name) = extract_instruction_type_param(node, source) {
                 if let Some(tag) = symbols.get_tag_by_name(&tag_name) {
                     let expected = tag.params.len();
-                    if operand_count != expected {
-                        let msg = format!("{} operands (params of tag {})", expected, tag_name);
+                    // Only report error if there are TOO MANY operands.
+                    // Having fewer operands is valid in WAT because remaining operands
+                    // can come from the implicit stack (linear or partially folded style).
+                    if operand_count > expected {
+                        let msg =
+                            format!("at most {} operands (params of tag {})", expected, tag_name);
                         let diagnostic =
                             create_operand_count_diagnostic(node, instr_name, operand_count, &msg);
                         diagnostics.push(diagnostic);
@@ -732,13 +741,17 @@ fn validate_dynamic_operands(
         }
         "call" => {
             // (call $func (arg)*)
-            // The number of operands should match the function's parameter count
+            // Only report error if there are TOO MANY operands.
+            // Having fewer operands is valid in WAT because remaining operands
+            // can come from the implicit stack (linear or partially folded style).
             if let Some(func_name) = extract_instruction_type_param(node, source) {
                 if let Some(func) = symbols.get_function_by_name(&func_name) {
                     let expected = func.parameters.len();
-                    if operand_count != expected {
-                        let msg =
-                            format!("{} operands (params of function {})", expected, func_name);
+                    if operand_count > expected {
+                        let msg = format!(
+                            "at most {} operands (params of function {})",
+                            expected, func_name
+                        );
                         let diagnostic =
                             create_operand_count_diagnostic(node, instr_name, operand_count, &msg);
                         diagnostics.push(diagnostic);
@@ -747,10 +760,10 @@ fn validate_dynamic_operands(
                     // Numeric function index
                     if let Some(func) = symbols.get_function_by_index(idx) {
                         let expected = func.parameters.len();
-                        if operand_count != expected {
+                        if operand_count > expected {
                             let func_display = func.name.as_deref().unwrap_or(&func_name);
                             let msg = format!(
-                                "{} operands (params of function {})",
+                                "at most {} operands (params of function {})",
                                 expected, func_display
                             );
                             let diagnostic = create_operand_count_diagnostic(
@@ -1485,6 +1498,62 @@ mod tests {
                 .count(),
             0,
             "Valid call with 1 parameter should have no diagnostics"
+        );
+    }
+
+    #[test]
+    fn test_call_with_unfolded_args() {
+        // Unfolded style: arguments are pushed to stack before the call
+        // This should NOT produce false errors (issue #78)
+        let document = r#"(module
+  (func $add (param i32 i32) (result i32)
+    i32.add)
+
+  (func $main (result i32)
+    (i32.const 1)
+    (i32.const 2)
+    (call $add)))"#;
+
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        let operand_errors: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.message.contains("operand"))
+            .collect();
+        assert_eq!(
+            operand_errors.len(),
+            0,
+            "Unfolded call style should not produce false operand errors: {:?}",
+            operand_errors
+        );
+    }
+
+    #[test]
+    fn test_call_with_too_many_operands() {
+        // Should still catch too many operands in folded style
+        let document = r#"(module
+  (func $single (param i32) (result i32)
+    local.get 0)
+
+  (func $main (result i32)
+    (call $single (i32.const 1) (i32.const 2))))"#;
+
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        let operand_errors: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.message.contains("operand"))
+            .collect();
+        assert_eq!(
+            operand_errors.len(),
+            1,
+            "Call with too many operands should produce an error"
         );
     }
 


### PR DESCRIPTION
Fixes #78: Calling functions with parameters using unfolded expressions no longer causes false errors.

**Changes:**
- Changed operand validation for `call`, `struct.new`, and `throw` to only report errors when there are too many operands (not fewer)
- Added `linear_style.wat` example demonstrating unfolded/stack-based WAT style
- Added CI step to validate all example files with wat-check
- Added tests for unfolded call style and too-many-operands detection