### PR TITLE
fix: validate memory references in load/store instructions

### DIFF
--- a/docs/examples/invalid/undefined_memory_load.wat
+++ b/docs/examples/invalid/undefined_memory_load.wat
@@ -1,0 +1,7 @@
+;; Invalid: undefined memory reference in load instruction
+;; The memory $missing is never declared (multi-memory proposal)
+
+(module
+  (memory $other 1)
+  (func (export "test") (result i32)
+    (i32.load $missing (i32.const 0))))

--- a/src/diagnostics/semantic_diagnostics.rs
+++ b/src/diagnostics/semantic_diagnostics.rs
@@ -2361,4 +2361,133 @@ mod tests {
             diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
         );
     }
+
+    // Multi-memory load/store validation tests
+
+    #[test]
+    fn test_undefined_memory_in_load_instruction() {
+        // Load instruction referencing undefined memory should produce an error
+        let document = r#"(module
+  (memory $other 1)
+  (func (export "test") (result i32)
+    (i32.load $missing (i32.const 0))))"#;
+
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        let memory_errors: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.message.contains("Undefined memory") && d.message.contains("$missing"))
+            .collect();
+        assert_eq!(
+            memory_errors.len(),
+            1,
+            "Undefined memory in i32.load should produce one error, got: {:?}",
+            diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_undefined_memory_in_store_instruction() {
+        // Store instruction referencing undefined memory should produce an error
+        let document = r#"(module
+  (memory $mem0 1)
+  (func (export "test")
+    (i32.store $nonexistent (i32.const 0) (i32.const 42))))"#;
+
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        let memory_errors: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| {
+                d.message.contains("Undefined memory") && d.message.contains("$nonexistent")
+            })
+            .collect();
+        assert_eq!(
+            memory_errors.len(),
+            1,
+            "Undefined memory in i32.store should produce one error"
+        );
+    }
+
+    #[test]
+    fn test_valid_memory_in_load_store_instructions() {
+        // Load/store with valid memory references should not produce errors
+        let document = r#"(module
+  (memory $mem0 1)
+  (memory $mem1 2)
+  (func $test (param $addr i32) (result i32)
+    (i32.store $mem0 (local.get $addr) (i32.const 42))
+    (i32.store $mem1 (local.get $addr) (i32.const 43))
+    (i32.load $mem0 (local.get $addr))))"#;
+
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        let memory_errors: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.message.contains("Undefined memory"))
+            .collect();
+        assert_eq!(
+            memory_errors.len(),
+            0,
+            "Valid memory references should not produce errors, got: {:?}",
+            memory_errors.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_undefined_memory_in_load_with_offset() {
+        // Load with offset and align still needs memory validation
+        let document = r#"(module
+  (memory $mem0 1)
+  (func (param $addr i32) (result i32)
+    (i32.load $undefined offset=4 align=4 (local.get $addr))))"#;
+
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        let memory_errors: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.message.contains("Undefined memory") && d.message.contains("$undefined"))
+            .collect();
+        assert_eq!(
+            memory_errors.len(),
+            1,
+            "Undefined memory in i32.load with offset should produce one error"
+        );
+    }
+
+    #[test]
+    fn test_undefined_memory_various_load_types() {
+        // Test various load instruction types
+        let document = r#"(module
+  (memory $mem 1)
+  (func (result i64)
+    (i64.load $bad (i32.const 0))))"#;
+
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        let memory_errors: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.message.contains("Undefined memory") && d.message.contains("$bad"))
+            .collect();
+        assert_eq!(
+            memory_errors.len(),
+            1,
+            "Undefined memory in i64.load should produce one error"
+        );
+    }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -245,7 +245,10 @@ pub fn determine_instruction_context_at_node(node: &Node, document: &str) -> Ins
             return InstructionContext::Global;
         } else if first_token.starts_with("table.") {
             return InstructionContext::Table;
-        } else if first_token.starts_with("memory.") {
+        } else if first_token.starts_with("memory.")
+            || first_token.contains(".load")
+            || first_token.contains(".store")
+        {
             return InstructionContext::Memory;
         } else if first_token == "throw" || first_token == "rethrow" {
             return InstructionContext::Tag;


### PR DESCRIPTION
Fixes #83. The semantic validator now catches undefined memory references when used with load/store instructions in multi-memory scenarios.

Previously, instructions like `(i32.load $missing ...)` would pass validation even if the memory didn't exist. Now they correctly produce an error.

## Changes
- Updated `determine_instruction_context_at_node` in `src/utils.rs` to recognize `.load` and `.store` instructions as memory operations
- Added 5 new tests for memory validation in load/store instructions
- Added example invalid file `docs/examples/invalid/undefined_memory_load.wat`