### PR TITLE
fix race condition causing false errors after character delete+re-add (#79)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -92,15 +92,19 @@ impl Backend {
             .parse_and_publish_immediate_diagnostics(&uri, &text, None)
             .await
         {
+            // Update document text first, then tree, for consistency with did_change
+            // and to minimize race conditions with validation tasks
+            self.document_map.insert(uri.clone(), text.clone());
             self.tree_map.insert(uri.clone(), tree);
+        } else {
+            self.document_map.insert(uri.clone(), text.clone());
         }
-        self.document_map.insert(uri.clone(), text.clone());
 
         // Schedule debounced wast validation
         self.schedule_wast_validation(uri, text).await;
     }
 
-    async fn schedule_wast_validation(&self, uri: String, text: String) {
+    async fn schedule_wast_validation(&self, uri: String, _text: String) {
         // Cancel any existing validation task for this document
         if let Some(entry) = self.validation_cancellation.get(&uri) {
             let _ = entry.send(true); // Signal cancellation
@@ -112,6 +116,7 @@ impl Backend {
 
         // Clone what we need for the async task
         let client = self.client.clone();
+        let document_map = self.document_map.clone();
         let tree_map = self.tree_map.clone();
         let symbol_map = self.symbol_map.clone();
 
@@ -127,6 +132,18 @@ impl Backend {
                     return;
                 }
             }
+
+            // IMPORTANT: Re-fetch the current text from document_map instead of using
+            // captured text. This fixes a race condition (issue #79) where:
+            // 1. This task is spawned with text at time T1
+            // 2. After debounce period, another edit updated tree_map to T2
+            // 3. If we used the captured text (T1) with the new tree (T2), the tree's
+            //    byte ranges wouldn't match the text, causing wrong error positions.
+            // By re-fetching, we ensure tree and text are always from the same state.
+            let text = match document_map.get(&uri) {
+                Some(doc) => doc.clone(),
+                None => return, // Document was closed
+            };
 
             // Get tree-sitter diagnostics (from cached tree)
             let tree_diags = if let Some(tree) = tree_map.get(&uri) {
@@ -285,11 +302,16 @@ impl LanguageServer for Backend {
             .parse_and_publish_immediate_diagnostics(&uri, &text, old_tree.as_ref())
             .await
         {
+            // Update document text first, then tree, to minimize race conditions
+            // with the debounced validation task (see issue #79). The validation
+            // task fetches text then tree, so updating text first makes it more
+            // likely to get a consistent pair.
+            self.document_map.insert(uri.clone(), text.clone());
             self.tree_map.insert(uri.clone(), tree);
+        } else {
+            // Even if parsing failed, update the document text
+            self.document_map.insert(uri.clone(), text.clone());
         }
-
-        // Update document text
-        self.document_map.insert(uri.clone(), text.clone());
 
         // Schedule debounced wast validation
         self.schedule_wast_validation(uri, text).await;

--- a/tests/incremental_parsing.rs
+++ b/tests/incremental_parsing.rs
@@ -1,5 +1,6 @@
 use std::time::Instant;
 use tower_lsp::lsp_types::Position;
+use wat_lsp_rust::diagnostics::provide_tree_sitter_diagnostics;
 use wat_lsp_rust::tree_sitter_bindings::create_parser;
 use wat_lsp_rust::utils::apply_text_edit;
 
@@ -232,4 +233,165 @@ fn test_multiple_incremental_edits() {
     // Verify tree has no errors
     let root = tree.root_node();
     assert!(!root.has_error(), "Final tree should not have errors");
+}
+
+/// Test for issue #79: false errors appear when removing and re-adding the same character
+/// https://github.com/EmNudge/wat-lsp/issues/79
+#[test]
+fn test_delete_and_readd_character() {
+    // Start with valid code
+    let original_document = "(func $test (param $x i32) (result i32)\n  (local.get $x))";
+    let mut parser = create_parser();
+
+    // Initial parse - should have no errors
+    let tree = parser
+        .parse(original_document, None)
+        .expect("Initial parse failed");
+    let diagnostics = provide_tree_sitter_diagnostics(&tree, original_document);
+    assert!(
+        diagnostics.is_empty(),
+        "Initial document should have no syntax errors"
+    );
+
+    // STEP 1: Delete the closing ')' at position (1, 16)
+    // The document is:
+    // (func $test (param $x i32) (result i32)
+    //   (local.get $x))
+    // We want to delete the last ')' at position (1, 16)
+
+    let mut modified_doc = original_document.to_string();
+    let delete_start = Position::new(1, 16);
+    let delete_end = Position::new(1, 17);
+
+    let start_byte = wat_lsp_rust::utils::position_to_byte(&modified_doc, delete_start.into());
+    let old_end_byte = wat_lsp_rust::utils::position_to_byte(&modified_doc, delete_end.into());
+
+    // Apply the delete (replace with empty string)
+    let new_end = apply_text_edit(
+        &mut modified_doc,
+        delete_start.into(),
+        delete_end.into(),
+        "", // delete = replace with empty string
+    );
+    let new_end_byte = start_byte; // Empty insert means new_end_byte == start_byte
+
+    // Create and apply tree edit
+    let mut tree_after_delete = tree.clone();
+    let tree_edit = tree_sitter::InputEdit {
+        start_byte,
+        old_end_byte,
+        new_end_byte,
+        start_position: tree_sitter::Point {
+            row: delete_start.line as usize,
+            column: delete_start.character as usize,
+        },
+        old_end_position: tree_sitter::Point {
+            row: delete_end.line as usize,
+            column: delete_end.character as usize,
+        },
+        new_end_position: tree_sitter::Point {
+            row: new_end.line as usize,
+            column: new_end.character as usize,
+        },
+    };
+    tree_after_delete.edit(&tree_edit);
+
+    // Reparse incrementally
+    let tree_after_delete = parser
+        .parse(&modified_doc, Some(&tree_after_delete))
+        .expect("Incremental reparse after delete failed");
+
+    // Verify the document now has a missing ')' - should show error
+    let diagnostics_after_delete =
+        provide_tree_sitter_diagnostics(&tree_after_delete, &modified_doc);
+    assert!(
+        !diagnostics_after_delete.is_empty() || tree_after_delete.root_node().has_error(),
+        "Document with missing ')' should have syntax errors. Doc: {}",
+        modified_doc
+    );
+
+    // STEP 2: Re-add the ')' at position (1, 16)
+    let insert_pos = Position::new(1, 16);
+    let insert_start_byte = wat_lsp_rust::utils::position_to_byte(&modified_doc, insert_pos.into());
+    let insert_old_end_byte = insert_start_byte; // Insert, so old range is zero-length
+
+    // Apply the insert
+    let insert_new_end = apply_text_edit(
+        &mut modified_doc,
+        insert_pos.into(),
+        insert_pos.into(),
+        ")", // re-add the character
+    );
+    let insert_new_end_byte = insert_start_byte + 1;
+
+    // Create and apply tree edit
+    let mut tree_after_readd = tree_after_delete.clone();
+    let tree_edit2 = tree_sitter::InputEdit {
+        start_byte: insert_start_byte,
+        old_end_byte: insert_old_end_byte,
+        new_end_byte: insert_new_end_byte,
+        start_position: tree_sitter::Point {
+            row: insert_pos.line as usize,
+            column: insert_pos.character as usize,
+        },
+        old_end_position: tree_sitter::Point {
+            row: insert_pos.line as usize,
+            column: insert_pos.character as usize,
+        },
+        new_end_position: tree_sitter::Point {
+            row: insert_new_end.line as usize,
+            column: insert_new_end.character as usize,
+        },
+    };
+    tree_after_readd.edit(&tree_edit2);
+
+    // Reparse incrementally
+    let tree_after_readd = parser
+        .parse(&modified_doc, Some(&tree_after_readd))
+        .expect("Incremental reparse after re-add failed");
+
+    // CRITICAL CHECK: After re-adding the character, document should be valid again
+    assert_eq!(
+        modified_doc, original_document,
+        "Document should be restored to original"
+    );
+
+    let diagnostics_after_readd = provide_tree_sitter_diagnostics(&tree_after_readd, &modified_doc);
+
+    // Also check that any error positions are valid
+    for diag in &diagnostics_after_readd {
+        let start_line = diag.range.start.line as usize;
+        let end_line = diag.range.end.line as usize;
+        let lines: Vec<&str> = modified_doc.lines().collect();
+
+        assert!(
+            start_line < lines.len(),
+            "Diagnostic start line {} is out of bounds (doc has {} lines)",
+            start_line,
+            lines.len()
+        );
+        assert!(
+            end_line < lines.len() || (end_line == lines.len() && diag.range.end.character == 0),
+            "Diagnostic end line {} is out of bounds (doc has {} lines)",
+            end_line,
+            lines.len()
+        );
+    }
+
+    assert!(
+        diagnostics_after_readd.is_empty(),
+        "After re-adding the deleted character, there should be no syntax errors.\nDiagnostics: {:?}\nTree has_error: {}",
+        diagnostics_after_readd,
+        tree_after_readd.root_node().has_error()
+    );
+
+    // Also verify that incremental parse matches full parse
+    let full_tree = parser
+        .parse(&modified_doc, None)
+        .expect("Full reparse failed");
+    assert_eq!(
+        tree_after_readd.root_node().to_sexp(),
+        full_tree.root_node().to_sexp(),
+        "Incremental parse should match full parse after delete+re-add"
+    );
 }


### PR DESCRIPTION
Fixes #79

**Problem:** Race condition in debounced validation task where captured text (from spawn time) didn’t match the current tree (fetched at validation time). This caused `source[node.byte_range()]` to extract wrong text, showing errors at wrong positions.

**Fix:**
- Re-fetch text from `document_map` at validation time instead of using captured text
- Update order changed to insert text before tree to minimize race window
- Added regression test for delete+re-add scenario