### PR TITLE
Add failure examples to playground and real-time semantic diagnostics

### DIFF
--- a/packages/playground/examples.ts
+++ b/packages/playground/examples.ts
@@ -14,6 +14,16 @@ const exampleModules = import.meta.glob<string>('../../docs/examples/*.wat', {
   import: 'default',
 });
 
+// Import invalid examples from docs/examples/invalid
+const invalidExampleModules = import.meta.glob<string>(
+  '../../docs/examples/invalid/*.wat',
+  {
+    eager: true,
+    query: '?raw',
+    import: 'default',
+  }
+);
+
 // Extract a human-readable label from the file content
 // Looks for a comment on the first line like: ";; Exception Handling Proposal"
 function extractLabel(code: string, filename: string): string {
@@ -35,13 +45,30 @@ function filenameToId(path: string): string {
 }
 
 // Build the examples array from imported modules
-export const examples: ExampleDefinition[] = Object.entries(exampleModules)
-  .map(([path, code]) => {
-    const id = filenameToId(path);
-    const label = extractLabel(code, id);
+const validExamples = Object.entries(exampleModules).map(([path, code]) => {
+  const id = filenameToId(path);
+  const label = extractLabel(code, id);
+  return { id, label, code };
+});
+
+// Build invalid examples with "Failure - " prefix
+const invalidExamples = Object.entries(invalidExampleModules).map(
+  ([path, code]) => {
+    const id = `invalid_${filenameToId(path)}`;
+    let label = extractLabel(code, id);
+    // Replace "Invalid: " prefix with "Failure - " or add "Failure - " prefix
+    if (label.startsWith('Invalid: ')) {
+      label = 'Failure - ' + label.slice('Invalid: '.length);
+    } else {
+      label = 'Failure - ' + label;
+    }
     return { id, label, code };
-  })
-  .sort((a, b) => a.label.localeCompare(b.label));
+  }
+);
+
+export const examples: ExampleDefinition[] = [...validExamples, ...invalidExamples].sort(
+  (a, b) => a.label.localeCompare(b.label)
+);
 
 // Helper to get example by ID
 export function getExampleById(id: string): ExampleDefinition | undefined {

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -163,6 +163,72 @@ pub type DefinitionResult = Option<Range>;
 /// References result - list of ranges where a symbol is referenced
 pub type ReferencesResult = Vec<Range>;
 
+/// Diagnostic severity (matches LSP DiagnosticSeverity values)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[repr(u8)]
+pub enum DiagnosticSeverity {
+    Error = 1,
+    Warning = 2,
+    Information = 3,
+    Hint = 4,
+}
+
+/// A diagnostic message (error, warning, etc.)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Diagnostic {
+    /// The range where the diagnostic applies
+    pub range: Range,
+    /// The severity of the diagnostic
+    pub severity: DiagnosticSeverity,
+    /// The diagnostic message
+    pub message: String,
+    /// Optional diagnostic code
+    pub code: Option<String>,
+    /// Optional source identifier (e.g., "wat-lsp")
+    pub source: Option<String>,
+}
+
+impl Diagnostic {
+    /// Create a new error diagnostic
+    pub fn error(range: Range, message: impl Into<String>) -> Self {
+        Self {
+            range,
+            severity: DiagnosticSeverity::Error,
+            message: message.into(),
+            code: None,
+            source: Some("wat-lsp".to_string()),
+        }
+    }
+
+    /// Create a new warning diagnostic
+    pub fn warning(range: Range, message: impl Into<String>) -> Self {
+        Self {
+            range,
+            severity: DiagnosticSeverity::Warning,
+            message: message.into(),
+            code: None,
+            source: Some("wat-lsp".to_string()),
+        }
+    }
+
+    /// Create a new hint diagnostic
+    pub fn hint(range: Range, message: impl Into<String>) -> Self {
+        Self {
+            range,
+            severity: DiagnosticSeverity::Hint,
+            message: message.into(),
+            code: None,
+            source: Some("wat-lsp".to_string()),
+        }
+    }
+
+    /// Set the diagnostic code
+    pub fn with_code(mut self, code: impl Into<String>) -> Self {
+        self.code = Some(code.into());
+        self
+    }
+}
+
 // Conversion implementations for native builds (tower-lsp types)
 #[cfg(feature = "native")]
 impl From<lsp::Position> for Position {
@@ -258,6 +324,35 @@ impl From<CompletionItem> for lsp::CompletionItem {
             insert_text_format: item.insert_text_format.map(|f| f.into()),
             documentation: item.documentation.map(lsp::Documentation::String),
             ..Default::default()
+        }
+    }
+}
+
+#[cfg(feature = "native")]
+impl From<DiagnosticSeverity> for lsp::DiagnosticSeverity {
+    fn from(severity: DiagnosticSeverity) -> Self {
+        match severity {
+            DiagnosticSeverity::Error => lsp::DiagnosticSeverity::ERROR,
+            DiagnosticSeverity::Warning => lsp::DiagnosticSeverity::WARNING,
+            DiagnosticSeverity::Information => lsp::DiagnosticSeverity::INFORMATION,
+            DiagnosticSeverity::Hint => lsp::DiagnosticSeverity::HINT,
+        }
+    }
+}
+
+#[cfg(feature = "native")]
+impl From<Diagnostic> for lsp::Diagnostic {
+    fn from(diag: Diagnostic) -> Self {
+        lsp::Diagnostic {
+            range: diag.range.into(),
+            severity: Some(diag.severity.into()),
+            code: diag.code.map(lsp::NumberOrString::String),
+            code_description: None,
+            source: diag.source,
+            message: diag.message,
+            related_information: None,
+            tags: None,
+            data: None,
         }
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -630,6 +630,23 @@ pub fn node_to_lsp_range(node: &Node) -> LspRange {
     }
 }
 
+/// Convert a tree-sitter node to a core Range (works in both native and WASM)
+pub fn node_to_range(node: &Node) -> crate::core::types::Range {
+    let start_point = node.start_position();
+    let end_point = node.end_position();
+
+    crate::core::types::Range {
+        start: crate::core::types::Position {
+            line: start_point.row as u32,
+            character: start_point.column as u32,
+        },
+        end: crate::core::types::Position {
+            line: end_point.row as u32,
+            character: end_point.column as u32,
+        },
+    }
+}
+
 /// Determine instruction context using AST with fallback to line-based detection.
 /// This is the unified context detection function used across hover, definition,
 /// references, and completion modules.

--- a/src/wasm/api.rs
+++ b/src/wasm/api.rs
@@ -126,14 +126,26 @@ impl WatLSP {
         }
     }
 
-    /// Get diagnostics (syntax errors) for the current document
+    /// Get diagnostics (syntax and semantic errors) for the current document
     #[wasm_bindgen(js_name = provideDiagnostics)]
     pub fn provide_diagnostics(&self) -> JsValue {
-        let diagnostics = validate_wat(&self.document);
         let js_array = js_sys::Array::new();
-        for diag in diagnostics {
+
+        // Add syntax errors from wast parser
+        let syntax_diagnostics = validate_wat(&self.document);
+        for diag in syntax_diagnostics {
             js_array.push(&diagnostic_to_js(&diag));
         }
+
+        // Add semantic diagnostics if tree and symbols are available
+        if let (Some(tree), Some(symbols)) = (&self.tree, &self.symbols) {
+            let semantic_diagnostics =
+                provide_wasm_semantic_diagnostics(tree, &self.document, symbols);
+            for diag in semantic_diagnostics {
+                js_array.push(&diagnostic_to_js(&diag));
+            }
+        }
+
         js_array.into()
     }
 
@@ -788,6 +800,159 @@ struct WasmDiagnostic {
     end_character: u32,
     message: String,
     severity: u32, // 1 = error, 2 = warning, 3 = info, 4 = hint
+}
+
+use crate::ts_facade::Node;
+use crate::utils::{
+    determine_instruction_context_at_node, find_containing_function, InstructionContext,
+};
+
+/// Provide semantic diagnostics for undefined references (WASM version)
+fn provide_wasm_semantic_diagnostics(
+    tree: &crate::ts_facade::Tree,
+    source: &str,
+    symbols: &SymbolTable,
+) -> Vec<WasmDiagnostic> {
+    let mut diagnostics = Vec::new();
+    walk_tree_for_diagnostics(tree.root_node(), source, symbols, &mut diagnostics);
+    diagnostics
+}
+
+fn walk_tree_for_diagnostics(
+    node: Node,
+    source: &str,
+    symbols: &SymbolTable,
+    diagnostics: &mut Vec<WasmDiagnostic>,
+) {
+    let _kind = node.kind();
+
+    // Check for undefined references based on instruction context
+    let context = determine_instruction_context_at_node(&node, source);
+    if context != InstructionContext::General {
+        check_undefined_references(&node, source, symbols, diagnostics, &context);
+
+        // Only recurse into nested expr nodes
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            if child.kind() == "expr" {
+                walk_tree_for_diagnostics(child, source, symbols, diagnostics);
+            }
+        }
+        return;
+    }
+
+    // Recursively check children
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        walk_tree_for_diagnostics(child, source, symbols, diagnostics);
+    }
+}
+
+fn check_undefined_references(
+    node: &Node,
+    source: &str,
+    symbols: &SymbolTable,
+    diagnostics: &mut Vec<WasmDiagnostic>,
+    context: &InstructionContext,
+) {
+    find_undefined_identifiers(node, source, symbols, diagnostics, context);
+}
+
+fn find_undefined_identifiers(
+    node: &Node,
+    source: &str,
+    symbols: &SymbolTable,
+    diagnostics: &mut Vec<WasmDiagnostic>,
+    context: &InstructionContext,
+) {
+    if node.kind() == "identifier" {
+        let identifier_name = &source[node.byte_range()];
+
+        // Only check identifiers that start with $
+        if !identifier_name.starts_with('$') {
+            return;
+        }
+
+        let start_point = node.start_position();
+        let end_point = node.end_position();
+        let position =
+            crate::core::types::Position::new(start_point.row as u32, start_point.column as u32);
+
+        let is_defined = match context {
+            InstructionContext::Branch | InstructionContext::Block => {
+                if let Some(func) = find_containing_function(symbols, position) {
+                    func.blocks.iter().any(|block| {
+                        format!("${}", block.label) == identifier_name
+                            || block.label == identifier_name
+                    })
+                } else {
+                    false
+                }
+            }
+            InstructionContext::Call => symbols.get_function_by_name(identifier_name).is_some(),
+            InstructionContext::Local => {
+                if let Some(func) = find_containing_function(symbols, position) {
+                    func.parameters
+                        .iter()
+                        .any(|p| p.name.as_ref() == Some(&identifier_name.to_string()))
+                        || func
+                            .locals
+                            .iter()
+                            .any(|l| l.name.as_ref() == Some(&identifier_name.to_string()))
+                } else {
+                    false
+                }
+            }
+            InstructionContext::Global => symbols.get_global_by_name(identifier_name).is_some(),
+            InstructionContext::Table => symbols.get_table_by_name(identifier_name).is_some(),
+            InstructionContext::Memory => symbols.get_memory_by_name(identifier_name).is_some(),
+            InstructionContext::Type => symbols.get_type_by_name(identifier_name).is_some(),
+            InstructionContext::Tag => symbols.get_tag_by_name(identifier_name).is_some(),
+            InstructionContext::Data => symbols.get_data_by_name(identifier_name).is_some(),
+            InstructionContext::Elem => symbols.get_elem_by_name(identifier_name).is_some(),
+            InstructionContext::Function | InstructionContext::General => true,
+        };
+
+        if !is_defined {
+            let message = match context {
+                InstructionContext::Branch | InstructionContext::Block => {
+                    format!("Undefined label '{}'", identifier_name)
+                }
+                InstructionContext::Call => format!("Undefined function '{}'", identifier_name),
+                InstructionContext::Local => {
+                    format!("Undefined local or parameter '{}'", identifier_name)
+                }
+                InstructionContext::Global => format!("Undefined global '{}'", identifier_name),
+                InstructionContext::Table => format!("Undefined table '{}'", identifier_name),
+                InstructionContext::Memory => format!("Undefined memory '{}'", identifier_name),
+                InstructionContext::Type => format!("Undefined type '{}'", identifier_name),
+                InstructionContext::Tag => format!("Undefined tag '{}'", identifier_name),
+                InstructionContext::Data => format!("Undefined data segment '{}'", identifier_name),
+                InstructionContext::Elem => format!("Undefined elem segment '{}'", identifier_name),
+                _ => format!("Undefined reference '{}'", identifier_name),
+            };
+
+            diagnostics.push(WasmDiagnostic {
+                line: start_point.row as u32,
+                character: start_point.column as u32,
+                end_character: end_point.column as u32,
+                message,
+                severity: 1, // Error
+            });
+        }
+        return;
+    }
+
+    // Don't recurse into nested expr nodes
+    if node.kind() == "expr" {
+        return;
+    }
+
+    // Recursively check children
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        find_undefined_identifiers(&child, source, symbols, diagnostics, context);
+    }
 }
 
 /// Validate WAT source and return diagnostics


### PR DESCRIPTION
## Summary
- Add failure/invalid WAT examples to playground dropdown with "Failure - " prefix
- Enable real-time semantic diagnostics in WASM build (errors show as you type, not just on compile)
- Add core Diagnostic type for cross-platform use

## Details
- Invalid examples from `docs/examples/invalid/` now appear in playground
- Semantic checks for undefined functions, locals, globals, labels, types, etc.
- 300ms debounce on content changes for diagnostics