### PR TITLE
add stack underflow detection for unfolded WAT

### DIFF
--- a/docs/examples/invalid/stack_underflow_basic.wat
+++ b/docs/examples/invalid/stack_underflow_basic.wat
@@ -1,0 +1,8 @@
+;; Stack underflow: binary operation with empty stack
+;; Expected error: Stack underflow: 'i32.add' requires 2 values but only 0 available on stack
+
+(module
+  (func $empty_stack_add
+    i32.add  ;; ERROR: needs 2 values, stack is empty
+  )
+)

--- a/docs/examples/invalid/stack_underflow_call.wat
+++ b/docs/examples/invalid/stack_underflow_call.wat
@@ -1,0 +1,15 @@
+;; Stack underflow: call with insufficient arguments
+;; Expected error: Stack underflow: 'call' requires 2 values but only 1 available on stack
+
+(module
+  (func $add (param i32 i32) (result i32)
+    local.get 0
+    local.get 1
+    i32.add
+  )
+
+  (func $main (result i32)
+    i32.const 5
+    call $add  ;; ERROR: $add needs 2 params, only 1 value on stack
+  )
+)

--- a/docs/examples/invalid/stack_underflow_chain.wat
+++ b/docs/examples/invalid/stack_underflow_chain.wat
@@ -1,0 +1,11 @@
+;; Stack underflow: chain of operations with underflow in the middle
+;; Expected error: Stack underflow: 'i32.mul' requires 2 values but only 1 available on stack
+
+(module
+  (func $chain_underflow (result i32)
+    i32.const 1
+    i32.const 2
+    i32.add     ;; OK: consumes 2, produces 1 (stack: 1)
+    i32.mul     ;; ERROR: needs 2, only 1 on stack
+  )
+)

--- a/docs/examples/invalid/stack_underflow_drop.wat
+++ b/docs/examples/invalid/stack_underflow_drop.wat
@@ -1,0 +1,8 @@
+;; Stack underflow: drop with empty stack
+;; Expected error: Stack underflow: 'drop' requires 1 value but only 0 available on stack
+
+(module
+  (func $empty_drop
+    drop  ;; ERROR: needs 1 value, stack is empty
+  )
+)

--- a/docs/examples/invalid/stack_underflow_local_set.wat
+++ b/docs/examples/invalid/stack_underflow_local_set.wat
@@ -1,0 +1,8 @@
+;; Stack underflow: local.set with empty stack
+;; Expected error: Stack underflow: 'local.set' requires 1 value but only 0 available on stack
+
+(module
+  (func $empty_local_set (local $x i32)
+    local.set $x  ;; ERROR: needs 1 value to store, stack is empty
+  )
+)

--- a/docs/examples/invalid/stack_underflow_partial.wat
+++ b/docs/examples/invalid/stack_underflow_partial.wat
@@ -1,0 +1,9 @@
+;; Stack underflow: binary operation with only one value
+;; Expected error: Stack underflow: 'i32.add' requires 2 values but only 1 available on stack
+
+(module
+  (func $partial_stack_add (result i32)
+    i32.const 42
+    i32.add  ;; ERROR: needs 2 values, only 1 on stack
+  )
+)

--- a/docs/examples/invalid/stack_underflow_select.wat
+++ b/docs/examples/invalid/stack_underflow_select.wat
@@ -1,0 +1,10 @@
+;; Stack underflow: select with insufficient values
+;; Expected error: Stack underflow: 'select' requires 3 values but only 2 available on stack
+
+(module
+  (func $partial_select (result i32)
+    i32.const 10
+    i32.const 20
+    select  ;; ERROR: needs 3 values (val1, val2, condition), only 2 on stack
+  )
+)

--- a/src/diagnostics/instruction_metadata.rs
+++ b/src/diagnostics/instruction_metadata.rs
@@ -14,70 +14,103 @@ pub struct InstructionArity {
     pub param_description: &'static str,
     /// Number of operands this instruction consumes from the stack (for folded expressions)
     pub operand_mode: OperandMode,
+    /// Number of values this instruction pushes to the stack
+    pub produces: usize,
 }
 
 impl InstructionArity {
-    const fn exact(count: usize, description: &'static str, stack_operands: usize) -> Self {
+    const fn exact(
+        count: usize,
+        description: &'static str,
+        stack_operands: usize,
+        produces: usize,
+    ) -> Self {
         Self {
             min_params: count,
             max_params: count,
             param_description: description,
             operand_mode: OperandMode::Fixed(stack_operands),
+            produces,
         }
     }
 
     // For instructions with dynamic arity (like struct.new)
-    const fn dynamic(min_params: usize, max_params: usize, description: &'static str) -> Self {
+    const fn dynamic(
+        min_params: usize,
+        max_params: usize,
+        description: &'static str,
+        produces: usize,
+    ) -> Self {
         Self {
             min_params,
             max_params,
             param_description: description,
             operand_mode: OperandMode::Dynamic,
+            produces,
         }
     }
 
     /// Index-based instruction (local.get, global.get, etc.) - produces a value
     const fn index(description: &'static str) -> Self {
-        Self::exact(1, description, 0)
+        Self::exact(1, description, 0, 1)
+    }
+
+    /// Index-based instruction that consumes a value (local.set, global.set)
+    const fn index_set(description: &'static str) -> Self {
+        Self::exact(1, description, 1, 0)
+    }
+
+    /// Index-based instruction that consumes and produces a value (local.tee)
+    const fn index_tee(description: &'static str) -> Self {
+        Self::exact(1, description, 1, 1)
     }
 
     /// Constant instruction (i32.const, f64.const) - produces a value
     const fn constant(description: &'static str) -> Self {
-        Self::exact(1, description, 0)
+        Self::exact(1, description, 0, 1)
     }
 
-    /// Binary operator (i32.add, i32.mul, etc.) - consumes 2 values
+    /// Binary operator (i32.add, i32.mul, etc.) - consumes 2 values, produces 1
     const fn binary_op() -> Self {
-        Self::exact(0, "", 2)
+        Self::exact(0, "", 2, 1)
     }
 
-    /// Unary operator (i32.eqz, i32.clz, etc.) - consumes 1 value
+    /// Unary operator (i32.eqz, i32.clz, etc.) - consumes 1 value, produces 1
     const fn unary_op() -> Self {
-        Self::exact(0, "", 1)
+        Self::exact(0, "", 1, 1)
     }
 
-    /// Nullary instruction with no params or operands (drop, nop, return, unreachable)
+    /// Nullary instruction with no params or operands and no production (nop)
     const fn nullary() -> Self {
-        Self::exact(0, "", 0)
+        Self::exact(0, "", 0, 0)
+    }
+
+    /// Instruction that consumes 1 value and produces nothing (drop)
+    const fn drop_op() -> Self {
+        Self::exact(0, "", 1, 0)
     }
 
     /// Memory load operation - can take optional memory index (multi-memory proposal)
+    /// Consumes address, produces value
     const fn mem_load() -> Self {
         Self {
             min_params: 0,
             max_params: 1,
             param_description: "optional memory index",
             operand_mode: OperandMode::Fixed(1), // consumes address
+            produces: 1,
         }
     }
 
     /// Memory store operation - can take optional memory index (multi-memory proposal)
+    /// Consumes address and value, produces nothing
     const fn mem_store() -> Self {
         Self {
             min_params: 0,
             max_params: 1,
             param_description: "optional memory index",
             operand_mode: OperandMode::Fixed(2), // consumes address and value
+            produces: 0,
         }
     }
 
@@ -128,21 +161,21 @@ pub fn get_instruction_arity_map() -> HashMap<&'static str, InstructionArity> {
 
     // Local variable instructions (index-based, produce values)
     map.insert("local.get", InstructionArity::index("index"));
-    map.insert("local.set", InstructionArity::exact(1, "index", 1)); // consumes 1 value
-    map.insert("local.tee", InstructionArity::exact(1, "index", 1)); // consumes 1 value, produces 1
+    map.insert("local.set", InstructionArity::index_set("index")); // consumes 1 value
+    map.insert("local.tee", InstructionArity::index_tee("index")); // consumes 1 value, produces 1
 
     // Global variable instructions
     map.insert("global.get", InstructionArity::index("index"));
-    map.insert("global.set", InstructionArity::exact(1, "index", 1)); // consumes 1 value
+    map.insert("global.set", InstructionArity::index_set("index")); // consumes 1 value
 
     // Control flow instructions
     // br and br_if can pass values to blocks with result types (multi-value)
-    map.insert("br", InstructionArity::dynamic(1, 1, "label index"));
-    map.insert("br_if", InstructionArity::dynamic(1, 1, "label index")); // consumes condition + optional values
-    map.insert("call", InstructionArity::dynamic(1, 1, "function index")); // operands depend on function signature
-                                                                           // return can pass values for functions with result types
-    map.insert("return", InstructionArity::dynamic(0, 0, ""));
-    map.insert("unreachable", InstructionArity::nullary());
+    map.insert("br", InstructionArity::dynamic(1, 1, "label index", 0)); // terminates
+    map.insert("br_if", InstructionArity::dynamic(1, 1, "label index", 0)); // consumes condition + optional values
+    map.insert("call", InstructionArity::dynamic(1, 1, "function index", 0)); // produces depend on function signature (set to 0, handled dynamically)
+                                                                              // return can pass values for functions with result types
+    map.insert("return", InstructionArity::dynamic(0, 0, "", 0)); // terminates
+    map.insert("unreachable", InstructionArity::nullary()); // terminates
     map.insert("nop", InstructionArity::nullary());
 
     // Constant instructions (produce values)
@@ -152,8 +185,8 @@ pub fn get_instruction_arity_map() -> HashMap<&'static str, InstructionArity> {
     map.insert("f64.const", InstructionArity::constant("literal value"));
 
     // Stack manipulation
-    map.insert("drop", InstructionArity::unary_op()); // consumes 1 value
-    map.insert("select", InstructionArity::exact(0, "", 3)); // consumes 3 values
+    map.insert("drop", InstructionArity::drop_op()); // consumes 1 value, produces 0
+    map.insert("select", InstructionArity::exact(0, "", 3, 1)); // consumes 3 values, produces 1
 
     // i32 arithmetic operations (binary)
     map.insert("i32.add", InstructionArity::binary_op());
@@ -338,7 +371,8 @@ pub fn get_instruction_arity_map() -> HashMap<&'static str, InstructionArity> {
             min_params: 0,
             max_params: 1,
             param_description: "optional memory index",
-            operand_mode: OperandMode::Fixed(0), // produces i32 (current size)
+            operand_mode: OperandMode::Fixed(0),
+            produces: 1, // produces i32 (current size)
         },
     );
     map.insert(
@@ -347,116 +381,132 @@ pub fn get_instruction_arity_map() -> HashMap<&'static str, InstructionArity> {
             min_params: 0,
             max_params: 1,
             param_description: "optional memory index",
-            operand_mode: OperandMode::Fixed(1), // consumes delta, produces i32 (previous size or -1)
+            operand_mode: OperandMode::Fixed(1), // consumes delta
+            produces: 1,                         // produces i32 (previous size or -1)
         },
     );
 
     // WasmGC Instructions
     // Structs
-    map.insert("struct.new", InstructionArity::dynamic(1, 1, "type index"));
+    map.insert(
+        "struct.new",
+        InstructionArity::dynamic(1, 1, "type index", 1),
+    ); // produces structref
     map.insert(
         "struct.new_default",
-        InstructionArity::exact(1, "type index", 0),
+        InstructionArity::exact(1, "type index", 0, 1), // produces structref
     );
     map.insert(
         "struct.get",
-        InstructionArity::exact(2, "type and field index", 1),
-    ); // consumes structref
+        InstructionArity::exact(2, "type and field index", 1, 1), // consumes structref, produces value
+    );
     map.insert(
         "struct.get_s",
-        InstructionArity::exact(2, "type and field index", 1),
+        InstructionArity::exact(2, "type and field index", 1, 1),
     );
     map.insert(
         "struct.get_u",
-        InstructionArity::exact(2, "type and field index", 1),
+        InstructionArity::exact(2, "type and field index", 1, 1),
     );
     map.insert(
         "struct.set",
-        InstructionArity::exact(2, "type and field index", 2),
-    ); // consumes structref + value
+        InstructionArity::exact(2, "type and field index", 2, 0), // consumes structref + value, produces nothing
+    );
 
     // Arrays
-    map.insert("array.new", InstructionArity::exact(1, "type index", 2)); // value, len
+    map.insert("array.new", InstructionArity::exact(1, "type index", 2, 1)); // value, len -> arrayref
     map.insert(
         "array.new_default",
-        InstructionArity::exact(1, "type index", 1),
-    ); // len
+        InstructionArity::exact(1, "type index", 1, 1), // len -> arrayref
+    );
     map.insert(
         "array.new_fixed",
-        InstructionArity::dynamic(2, 2, "type index and length"),
+        InstructionArity::dynamic(2, 2, "type index and length", 1), // -> arrayref
     );
     map.insert(
         "array.new_data",
-        InstructionArity::exact(2, "type and data index", 2),
-    ); // offset, len
+        InstructionArity::exact(2, "type and data index", 2, 1), // offset, len -> arrayref
+    );
     map.insert(
         "array.new_elem",
-        InstructionArity::exact(2, "type and elem index", 2),
-    ); // offset, len
-    map.insert("array.get", InstructionArity::exact(1, "type index", 2)); // arrayref, index
-    map.insert("array.get_s", InstructionArity::exact(1, "type index", 2));
-    map.insert("array.get_u", InstructionArity::exact(1, "type index", 2));
-    map.insert("array.set", InstructionArity::exact(1, "type index", 3)); // arrayref, index, value
-    map.insert("array.len", InstructionArity::unary_op()); // arrayref
-    map.insert("array.fill", InstructionArity::exact(1, "type index", 4)); // arrayref, index, value, len
+        InstructionArity::exact(2, "type and elem index", 2, 1), // offset, len -> arrayref
+    );
+    map.insert("array.get", InstructionArity::exact(1, "type index", 2, 1)); // arrayref, index -> value
+    map.insert(
+        "array.get_s",
+        InstructionArity::exact(1, "type index", 2, 1),
+    );
+    map.insert(
+        "array.get_u",
+        InstructionArity::exact(1, "type index", 2, 1),
+    );
+    map.insert("array.set", InstructionArity::exact(1, "type index", 3, 0)); // arrayref, index, value -> nothing
+    map.insert("array.len", InstructionArity::unary_op()); // arrayref -> i32
+    map.insert("array.fill", InstructionArity::exact(1, "type index", 4, 0)); // arrayref, index, value, len -> nothing
     map.insert(
         "array.copy",
-        InstructionArity::exact(2, "dest and src type index", 5),
-    ); // dest, dest_idx, src, src_idx, len
+        InstructionArity::exact(2, "dest and src type index", 5, 0), // dest, dest_idx, src, src_idx, len -> nothing
+    );
 
     // I31
-    map.insert("ref.i31", InstructionArity::unary_op()); // i32
-    map.insert("i31.get_s", InstructionArity::unary_op()); // i31ref
-    map.insert("i31.get_u", InstructionArity::unary_op()); // i31ref
+    map.insert("ref.i31", InstructionArity::unary_op()); // i32 -> i31ref
+    map.insert("i31.get_s", InstructionArity::unary_op()); // i31ref -> i32
+    map.insert("i31.get_u", InstructionArity::unary_op()); // i31ref -> i32
 
     // Casts
-    map.insert("ref.test", InstructionArity::exact(1, "type index", 1));
-    map.insert("ref.cast", InstructionArity::exact(1, "type index", 1));
-    map.insert("ref.cast_null", InstructionArity::exact(1, "type index", 1));
+    map.insert("ref.test", InstructionArity::exact(1, "type index", 1, 1)); // ref -> i32
+    map.insert("ref.cast", InstructionArity::exact(1, "type index", 1, 1)); // ref -> ref
+    map.insert(
+        "ref.cast_null",
+        InstructionArity::exact(1, "type index", 1, 1),
+    ); // ref -> ref
     map.insert(
         "br_on_cast",
-        InstructionArity::exact(2, "label and type index", 1),
+        InstructionArity::exact(2, "label and type index", 1, 0), // ref -> (branches or continues)
     );
     map.insert(
         "br_on_cast_fail",
-        InstructionArity::exact(2, "label and type index", 1),
+        InstructionArity::exact(2, "label and type index", 1, 0), // ref -> (branches or continues)
     );
 
     // Exceptions
-    map.insert("throw", InstructionArity::dynamic(1, 1, "tag index"));
-    map.insert("throw_ref", InstructionArity::unary_op()); // exnref
-    map.insert("rethrow", InstructionArity::exact(1, "label index", 0));
+    map.insert("throw", InstructionArity::dynamic(1, 1, "tag index", 0)); // terminates
+    map.insert("throw_ref", InstructionArity::exact(0, "", 1, 0)); // exnref -> terminates (unary but not returning)
+    map.insert("rethrow", InstructionArity::exact(1, "label index", 0, 0)); // terminates
 
     // Typed function references
-    map.insert("call_ref", InstructionArity::dynamic(1, 1, "type index")); // args + funcref
+    map.insert("call_ref", InstructionArity::dynamic(1, 1, "type index", 0)); // args + funcref -> dynamic results
     map.insert(
         "return_call_ref",
-        InstructionArity::dynamic(1, 1, "type index"),
-    ); // args + funcref
+        InstructionArity::dynamic(1, 1, "type index", 0), // args + funcref -> terminates (tail call)
+    );
 
     // Null-checking branches
-    map.insert("br_on_null", InstructionArity::exact(1, "label index", 1)); // ref
+    map.insert(
+        "br_on_null",
+        InstructionArity::exact(1, "label index", 1, 1),
+    ); // ref -> non-null ref (or branches)
     map.insert(
         "br_on_non_null",
-        InstructionArity::exact(1, "label index", 1),
-    ); // ref
+        InstructionArity::exact(1, "label index", 1, 0), // ref -> (branches with non-null or continues with nothing)
+    );
 
     // Reference equality
-    map.insert("ref.eq", InstructionArity::binary_op()); // eqref, eqref
+    map.insert("ref.eq", InstructionArity::binary_op()); // eqref, eqref -> i32
 
     // Reference conversions
-    map.insert("any.convert_extern", InstructionArity::unary_op()); // externref
-    map.insert("extern.convert_any", InstructionArity::unary_op()); // anyref
+    map.insert("any.convert_extern", InstructionArity::unary_op()); // externref -> anyref
+    map.insert("extern.convert_any", InstructionArity::unary_op()); // anyref -> externref
 
     // Array initialization from segments
     map.insert(
         "array.init_data",
-        InstructionArity::exact(2, "type and data index", 4),
-    ); // array, dst, src, len
+        InstructionArity::exact(2, "type and data index", 4, 0), // array, dst, src, len -> nothing
+    );
     map.insert(
         "array.init_elem",
-        InstructionArity::exact(2, "type and elem index", 4),
-    ); // array, dst, src, len
+        InstructionArity::exact(2, "type and elem index", 4, 0), // array, dst, src, len -> nothing
+    );
 
     // Bulk memory operations - support optional memory indices (multi-memory proposal)
     map.insert(
@@ -466,6 +516,7 @@ pub fn get_instruction_arity_map() -> HashMap<&'static str, InstructionArity> {
             max_params: 2,
             param_description: "optional dest and src memory indices",
             operand_mode: OperandMode::Fixed(3), // dest offset, src offset, len
+            produces: 0,
         },
     );
     map.insert(
@@ -475,6 +526,7 @@ pub fn get_instruction_arity_map() -> HashMap<&'static str, InstructionArity> {
             max_params: 1,
             param_description: "optional memory index",
             operand_mode: OperandMode::Fixed(3), // dest, val, len
+            produces: 0,
         },
     );
     map.insert(
@@ -484,31 +536,44 @@ pub fn get_instruction_arity_map() -> HashMap<&'static str, InstructionArity> {
             max_params: 2,
             param_description: "data index and optional memory index",
             operand_mode: OperandMode::Fixed(3), // dest, offset, len
+            produces: 0,
         },
     );
-    map.insert("data.drop", InstructionArity::exact(1, "data index", 0));
+    map.insert("data.drop", InstructionArity::exact(1, "data index", 0, 0));
 
     // Table operations
-    map.insert("table.get", InstructionArity::exact(1, "table index", 1)); // index
-    map.insert("table.set", InstructionArity::exact(1, "table index", 2)); // index, value
-    map.insert("table.size", InstructionArity::exact(1, "table index", 0));
-    map.insert("table.grow", InstructionArity::exact(1, "table index", 2)); // init, delta
-    map.insert("table.fill", InstructionArity::exact(1, "table index", 3)); // index, value, len
+    map.insert("table.get", InstructionArity::exact(1, "table index", 1, 1)); // index -> ref
+    map.insert("table.set", InstructionArity::exact(1, "table index", 2, 0)); // index, value -> nothing
+    map.insert(
+        "table.size",
+        InstructionArity::exact(1, "table index", 0, 1),
+    ); // -> i32
+    map.insert(
+        "table.grow",
+        InstructionArity::exact(1, "table index", 2, 1),
+    ); // init, delta -> i32
+    map.insert(
+        "table.fill",
+        InstructionArity::exact(1, "table index", 3, 0),
+    ); // index, value, len -> nothing
     map.insert(
         "table.copy",
-        InstructionArity::exact(2, "dest and src table index", 3),
-    ); // dest, src, len
+        InstructionArity::exact(2, "dest and src table index", 3, 0), // dest, src, len -> nothing
+    );
     map.insert(
         "table.init",
-        InstructionArity::exact(2, "table and elem index", 3),
-    ); // dest, offset, len
-    map.insert("elem.drop", InstructionArity::exact(1, "elem index", 0));
+        InstructionArity::exact(2, "table and elem index", 3, 0), // dest, offset, len -> nothing
+    );
+    map.insert("elem.drop", InstructionArity::exact(1, "elem index", 0, 0));
 
     // Reference operations
-    map.insert("ref.null", InstructionArity::exact(1, "type", 0));
-    map.insert("ref.func", InstructionArity::exact(1, "function index", 0));
-    map.insert("ref.is_null", InstructionArity::unary_op()); // ref
-    map.insert("ref.as_non_null", InstructionArity::unary_op()); // nullable ref
+    map.insert("ref.null", InstructionArity::exact(1, "type", 0, 1)); // -> null ref
+    map.insert(
+        "ref.func",
+        InstructionArity::exact(1, "function index", 0, 1),
+    ); // -> funcref
+    map.insert("ref.is_null", InstructionArity::unary_op()); // ref -> i32
+    map.insert("ref.as_non_null", InstructionArity::unary_op()); // nullable ref -> non-null ref
 
     // Saturating truncation operations
     map.insert("i32.trunc_sat_f32_s", InstructionArity::unary_op());
@@ -536,10 +601,11 @@ mod tests {
 
     #[test]
     fn test_instruction_arity_exact() {
-        let arity = InstructionArity::exact(1, "index", 0);
+        let arity = InstructionArity::exact(1, "index", 0, 1);
         assert_eq!(arity.min_params, 1);
         assert_eq!(arity.max_params, 1);
         assert_eq!(arity.operand_mode, OperandMode::Fixed(0));
+        assert_eq!(arity.produces, 1);
         assert!(arity.is_valid(1));
         assert!(!arity.is_valid(0));
         assert!(!arity.is_valid(2));
@@ -547,10 +613,10 @@ mod tests {
 
     #[test]
     fn test_expected_message() {
-        let arity_exact = InstructionArity::exact(1, "index", 0);
+        let arity_exact = InstructionArity::exact(1, "index", 0, 1);
         assert_eq!(arity_exact.expected_message(), "1 (index)");
 
-        let arity_exact_no_desc = InstructionArity::exact(0, "", 2);
+        let arity_exact_no_desc = InstructionArity::exact(0, "", 2, 1);
         assert_eq!(arity_exact_no_desc.expected_message(), "0");
     }
 
@@ -558,6 +624,7 @@ mod tests {
     fn test_binary_op() {
         let arity = InstructionArity::binary_op();
         assert_eq!(arity.operand_mode, OperandMode::Fixed(2));
+        assert_eq!(arity.produces, 1);
         assert!(arity.is_valid_operands(2));
         assert!(!arity.is_valid_operands(1));
         assert!(!arity.is_valid_operands(3));
@@ -567,9 +634,50 @@ mod tests {
     fn test_unary_op() {
         let arity = InstructionArity::unary_op();
         assert_eq!(arity.operand_mode, OperandMode::Fixed(1));
+        assert_eq!(arity.produces, 1);
         assert!(arity.is_valid_operands(1));
         assert!(!arity.is_valid_operands(0));
         assert!(!arity.is_valid_operands(2));
+    }
+
+    #[test]
+    fn test_drop_op() {
+        let arity = InstructionArity::drop_op();
+        assert_eq!(arity.operand_mode, OperandMode::Fixed(1));
+        assert_eq!(arity.produces, 0);
+    }
+
+    #[test]
+    fn test_produces_field() {
+        let map = get_instruction_arity_map();
+
+        // Constants produce 1 value
+        assert_eq!(map.get("i32.const").unwrap().produces, 1);
+        assert_eq!(map.get("f64.const").unwrap().produces, 1);
+
+        // Binary ops consume 2, produce 1
+        assert_eq!(map.get("i32.add").unwrap().produces, 1);
+
+        // drop consumes 1, produces 0
+        assert_eq!(map.get("drop").unwrap().produces, 0);
+
+        // local.get produces 1
+        assert_eq!(map.get("local.get").unwrap().produces, 1);
+
+        // local.set produces 0
+        assert_eq!(map.get("local.set").unwrap().produces, 0);
+
+        // local.tee produces 1
+        assert_eq!(map.get("local.tee").unwrap().produces, 1);
+
+        // Memory load produces 1
+        assert_eq!(map.get("i32.load").unwrap().produces, 1);
+
+        // Memory store produces 0
+        assert_eq!(map.get("i32.store").unwrap().produces, 0);
+
+        // select produces 1
+        assert_eq!(map.get("select").unwrap().produces, 1);
     }
 
     #[test]

--- a/src/diagnostics/semantic_diagnostics.rs
+++ b/src/diagnostics/semantic_diagnostics.rs
@@ -1,4 +1,4 @@
-use crate::diagnostics::instruction_metadata::get_instruction_arity_map;
+use crate::diagnostics::instruction_metadata::{get_instruction_arity_map, OperandMode};
 use crate::symbols::SymbolTable;
 use crate::utils::{
     determine_instruction_context_at_node, find_containing_function, node_to_lsp_range,
@@ -7,6 +7,566 @@ use crate::utils::{
 use std::sync::OnceLock;
 use tower_lsp::lsp_types::*;
 use tree_sitter::{Node, Tree};
+
+/// Tracks stack state during instruction list traversal for stack underflow detection
+#[derive(Debug, Clone)]
+struct StackState {
+    /// Current stack depth (number of values on the stack)
+    depth: usize,
+    /// True after unconditional branches or unreachable - subsequent code is dead
+    /// and we shouldn't report errors for it
+    uncertain: bool,
+}
+
+impl StackState {
+    fn new() -> Self {
+        Self {
+            depth: 0,
+            uncertain: false,
+        }
+    }
+
+    /// Try to consume n values from the stack
+    /// Returns Err with the actual available count if underflow occurs
+    fn consume(&mut self, n: usize) -> Result<(), usize> {
+        if self.uncertain {
+            // After unconditional control flow, we can't know the stack state
+            return Ok(());
+        }
+        if self.depth >= n {
+            self.depth -= n;
+            Ok(())
+        } else {
+            let available = self.depth;
+            self.depth = 0;
+            Err(available)
+        }
+    }
+
+    /// Push n values onto the stack
+    fn produce(&mut self, n: usize) {
+        if !self.uncertain {
+            self.depth += n;
+        }
+    }
+
+    /// Mark stack as uncertain (after unconditional branch/unreachable)
+    fn mark_uncertain(&mut self) {
+        self.uncertain = true;
+    }
+}
+
+/// Track stack state through an instruction list and report underflow errors
+fn track_stack_in_instr_list(
+    instr_list: &Node,
+    source: &str,
+    symbols: &SymbolTable,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let mut stack = StackState::new();
+    let arity_map = get_arity_map();
+
+    let mut cursor = instr_list.walk();
+    for child in instr_list.children(&mut cursor) {
+        let kind = child.kind();
+
+        match kind {
+            "instr" => {
+                // instr wraps instr_plain, instr_block, etc.
+                process_instr_node(&child, source, symbols, arity_map, &mut stack, diagnostics);
+            }
+            "instr_plain" => {
+                // Direct instr_plain (shouldn't happen but handle anyway)
+                if let Some(instr_name) = get_instruction_name(&child, source) {
+                    process_instruction(
+                        &child,
+                        &instr_name,
+                        &mut stack,
+                        symbols,
+                        source,
+                        arity_map,
+                        diagnostics,
+                    );
+                }
+            }
+            "expr" => {
+                // Folded expression - determine how many values it produces
+                let produces = count_expr_production(&child, source, symbols, arity_map);
+                stack.produce(produces);
+            }
+            "instr_block" | "instr_loop" => {
+                // Block instructions create a new stack frame
+                // After a block completes, it pushes its result values
+                let results = count_block_results(&child, source);
+                stack.produce(results);
+            }
+            "instr_if" => {
+                // if consumes condition (1 value) and produces result values
+                if let Err(available) = stack.consume(1) {
+                    let diagnostic = create_stack_underflow_diagnostic(&child, "if", 1, available);
+                    diagnostics.push(diagnostic);
+                }
+                let results = count_block_results(&child, source);
+                stack.produce(results);
+            }
+            "instr_call" => {
+                // Folded call: (call $fn args...) - handled similarly to expr
+                let produces = count_expr_production(&child, source, symbols, arity_map);
+                stack.produce(produces);
+            }
+            _ => {
+                // Other node types (comments, etc.) - ignore
+            }
+        }
+    }
+}
+
+/// Process an 'instr' wrapper node
+fn process_instr_node(
+    instr_node: &Node,
+    source: &str,
+    symbols: &SymbolTable,
+    arity_map: &std::collections::HashMap<
+        &'static str,
+        crate::diagnostics::instruction_metadata::InstructionArity,
+    >,
+    stack: &mut StackState,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let mut cursor = instr_node.walk();
+    for child in instr_node.children(&mut cursor) {
+        let kind = child.kind();
+        match kind {
+            "instr_plain" => {
+                if let Some(instr_name) = get_instruction_name(&child, source) {
+                    process_instruction(
+                        &child,
+                        &instr_name,
+                        stack,
+                        symbols,
+                        source,
+                        arity_map,
+                        diagnostics,
+                    );
+                }
+            }
+            "expr" => {
+                // Folded expression - determine how many values it produces
+                let produces = count_expr_production(&child, source, symbols, arity_map);
+                stack.produce(produces);
+            }
+            "instr_block" | "instr_loop" => {
+                let results = count_block_results(&child, source);
+                stack.produce(results);
+            }
+            "instr_if" => {
+                if let Err(available) = stack.consume(1) {
+                    let diagnostic = create_stack_underflow_diagnostic(&child, "if", 1, available);
+                    diagnostics.push(diagnostic);
+                }
+                let results = count_block_results(&child, source);
+                stack.produce(results);
+            }
+            "instr_call" => {
+                let produces = count_expr_production(&child, source, symbols, arity_map);
+                stack.produce(produces);
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Get the instruction name from an instr_plain node
+fn get_instruction_name(instr_node: &Node, source: &str) -> Option<String> {
+    let mut cursor = instr_node.walk();
+    for child in instr_node.children(&mut cursor) {
+        let kind = child.kind();
+        // Handle different instruction types
+        if kind.starts_with("op_") {
+            // For op_const, the instruction name is in the first child (pat01)
+            if kind == "op_const" {
+                let mut inner_cursor = child.walk();
+                for inner_child in child.children(&mut inner_cursor) {
+                    let inner_kind = inner_child.kind();
+                    // pat01 contains "i32.const", "i64.const", etc.
+                    if inner_kind == "pat01" || inner_kind.contains("const") {
+                        return Some(source[inner_child.byte_range()].trim().to_string());
+                    }
+                }
+                // Fallback: extract first token from the whole op_const text
+                let text = &source[child.byte_range()];
+                return text.split_whitespace().next().map(|s| s.to_string());
+            }
+            // For other op_ nodes (like op_nullary, op_index), the text is the instruction
+            return Some(source[child.byte_range()].trim().to_string());
+        }
+    }
+    // Fallback: get the text of the first token
+    let text = &source[instr_node.byte_range()];
+    text.split_whitespace().next().map(|s| s.to_string())
+}
+
+/// Process an instruction: consume operands, check for underflow, produce results
+fn process_instruction(
+    node: &Node,
+    instr_name: &str,
+    stack: &mut StackState,
+    symbols: &SymbolTable,
+    source: &str,
+    arity_map: &std::collections::HashMap<
+        &'static str,
+        crate::diagnostics::instruction_metadata::InstructionArity,
+    >,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    // Handle control flow that makes subsequent code dead
+    match instr_name {
+        "unreachable" | "return" | "br" => {
+            stack.mark_uncertain();
+            return;
+        }
+        _ => {}
+    }
+
+    // Look up instruction arity
+    if let Some(arity) = arity_map.get(instr_name) {
+        // Get the number of operands to consume
+        let consumes = match arity.operand_mode {
+            OperandMode::Fixed(n) => n,
+            OperandMode::Dynamic => {
+                // For dynamic instructions, look up the actual count
+                get_dynamic_operand_count(node, instr_name, symbols, source)
+            }
+        };
+
+        // Try to consume operands
+        if let Err(available) = stack.consume(consumes) {
+            let diagnostic =
+                create_stack_underflow_diagnostic(node, instr_name, consumes, available);
+            diagnostics.push(diagnostic);
+        }
+
+        // Produce results
+        let produces = match instr_name {
+            // Dynamic producers - look up actual result count
+            "call" => get_call_result_count(node, symbols, source),
+            "call_ref" | "return_call_ref" => get_call_ref_result_count(node, symbols, source),
+            _ => arity.produces,
+        };
+        stack.produce(produces);
+    } else {
+        // Unknown instruction - skip (might be a newer instruction we don't know about)
+    }
+}
+
+/// Get the operand count for a dynamic instruction
+fn get_dynamic_operand_count(
+    node: &Node,
+    instr_name: &str,
+    symbols: &SymbolTable,
+    source: &str,
+) -> usize {
+    match instr_name {
+        "call" => {
+            // Get function index/name and look up parameter count
+            if let Some(func_ref) = get_index_from_node(node, source) {
+                if let Some(func) = symbols.get_function_by_name(&func_ref) {
+                    return func.parameters.len();
+                } else if let Ok(idx) = func_ref.parse::<usize>() {
+                    if let Some(func) = symbols.get_function_by_index(idx) {
+                        return func.parameters.len();
+                    }
+                }
+            }
+            0
+        }
+        "call_ref" | "return_call_ref" => {
+            // Get type index and look up parameter count + 1 for funcref
+            if let Some(type_ref) = get_index_from_node(node, source) {
+                if let Some(type_def) = symbols.get_type_by_name(&type_ref) {
+                    if let crate::symbols::TypeKind::Func { params, .. } = &type_def.kind {
+                        return params.len() + 1; // params + funcref
+                    }
+                } else if let Ok(idx) = type_ref.parse::<usize>() {
+                    if let Some(type_def) = symbols.get_type_by_index(idx) {
+                        if let crate::symbols::TypeKind::Func { params, .. } = &type_def.kind {
+                            return params.len() + 1;
+                        }
+                    }
+                }
+            }
+            1 // At least the funcref
+        }
+        "struct.new" => {
+            // Get type and look up field count
+            if let Some(type_ref) = get_index_from_node(node, source) {
+                if let Some(type_def) = symbols.get_type_by_name(&type_ref) {
+                    if let crate::symbols::TypeKind::Struct { fields } = &type_def.kind {
+                        return fields.len();
+                    }
+                } else if let Ok(idx) = type_ref.parse::<usize>() {
+                    if let Some(type_def) = symbols.get_type_by_index(idx) {
+                        if let crate::symbols::TypeKind::Struct { fields } = &type_def.kind {
+                            return fields.len();
+                        }
+                    }
+                }
+            }
+            0
+        }
+        "throw" => {
+            // Get tag and look up parameter count
+            if let Some(tag_ref) = get_index_from_node(node, source) {
+                if let Some(tag) = symbols.get_tag_by_name(&tag_ref) {
+                    return tag.params.len();
+                } else if let Ok(idx) = tag_ref.parse::<usize>() {
+                    if let Some(tag) = symbols.get_tag_by_index(idx) {
+                        return tag.params.len();
+                    }
+                }
+            }
+            0
+        }
+        "br" | "br_if" => {
+            // br_if consumes condition (1) + potential multi-value args
+            // For simplicity, just handle the condition for br_if
+            if instr_name == "br_if" {
+                1 // condition
+            } else {
+                0 // br itself doesn't consume extra (but terminates)
+            }
+        }
+        _ => 0,
+    }
+}
+
+/// Get result count for a call instruction
+fn get_call_result_count(node: &Node, symbols: &SymbolTable, source: &str) -> usize {
+    if let Some(func_ref) = get_index_from_node(node, source) {
+        if let Some(func) = symbols.get_function_by_name(&func_ref) {
+            return func.results.len();
+        } else if let Ok(idx) = func_ref.parse::<usize>() {
+            if let Some(func) = symbols.get_function_by_index(idx) {
+                return func.results.len();
+            }
+        }
+    }
+    0
+}
+
+/// Get result count for a call_ref instruction
+fn get_call_ref_result_count(node: &Node, symbols: &SymbolTable, source: &str) -> usize {
+    if let Some(type_ref) = get_index_from_node(node, source) {
+        if let Some(type_def) = symbols.get_type_by_name(&type_ref) {
+            if let crate::symbols::TypeKind::Func { results, .. } = &type_def.kind {
+                return results.len();
+            }
+        } else if let Ok(idx) = type_ref.parse::<usize>() {
+            if let Some(type_def) = symbols.get_type_by_index(idx) {
+                if let crate::symbols::TypeKind::Func { results, .. } = &type_def.kind {
+                    return results.len();
+                }
+            }
+        }
+    }
+    0
+}
+
+/// Get the index/identifier from an instruction node
+fn get_index_from_node(node: &Node, source: &str) -> Option<String> {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "index" || child.kind() == "identifier" {
+            return Some(source[child.byte_range()].trim().to_string());
+        }
+        // Also check inside op_index nodes
+        if child.kind().starts_with("op_") {
+            let mut inner_cursor = child.walk();
+            for inner_child in child.children(&mut inner_cursor) {
+                if inner_child.kind() == "index" || inner_child.kind() == "identifier" {
+                    return Some(source[inner_child.byte_range()].trim().to_string());
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Count how many values a folded expression produces
+fn count_expr_production(
+    expr: &Node,
+    source: &str,
+    symbols: &SymbolTable,
+    arity_map: &std::collections::HashMap<
+        &'static str,
+        crate::diagnostics::instruction_metadata::InstructionArity,
+    >,
+) -> usize {
+    // Find the instruction inside the expression
+    let mut cursor = expr.walk();
+    for child in expr.children(&mut cursor) {
+        let kind = child.kind();
+        if kind.starts_with("expr1_") {
+            // expr1_plain, expr1_call, expr1_block, etc.
+            return count_expr1_production(&child, source, symbols, arity_map);
+        }
+    }
+    // Default: assume 1 value produced
+    1
+}
+
+/// Count production for expr1_* nodes
+fn count_expr1_production(
+    expr1: &Node,
+    source: &str,
+    symbols: &SymbolTable,
+    arity_map: &std::collections::HashMap<
+        &'static str,
+        crate::diagnostics::instruction_metadata::InstructionArity,
+    >,
+) -> usize {
+    let kind = expr1.kind();
+
+    match kind {
+        "expr1_plain" => {
+            // Get instruction name from instr_plain child
+            let mut cursor = expr1.walk();
+            for child in expr1.children(&mut cursor) {
+                if child.kind() == "instr_plain" {
+                    if let Some(instr_name) = get_instruction_name(&child, source) {
+                        // Handle dynamic result producers
+                        match instr_name.as_str() {
+                            "call" => return get_call_result_count(&child, symbols, source),
+                            "call_ref" | "return_call_ref" => {
+                                return get_call_ref_result_count(&child, symbols, source)
+                            }
+                            _ => {
+                                if let Some(arity) = arity_map.get(instr_name.as_str()) {
+                                    return arity.produces;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            1 // Default
+        }
+        "expr1_block" | "expr1_loop" => {
+            // Block produces its result type values
+            count_block_results(expr1, source)
+        }
+        "expr1_if" => {
+            // If produces its result type values
+            count_block_results(expr1, source)
+        }
+        "expr1_call" => {
+            // (call $func args...) - look up function result count
+            if let Some(func_ref) = get_index_from_expr1_call(expr1, source) {
+                if let Some(func) = symbols.get_function_by_name(&func_ref) {
+                    return func.results.len();
+                } else if let Ok(idx) = func_ref.parse::<usize>() {
+                    if let Some(func) = symbols.get_function_by_index(idx) {
+                        return func.results.len();
+                    }
+                }
+            }
+            0
+        }
+        _ => 1, // Default
+    }
+}
+
+/// Get function reference from expr1_call node
+fn get_index_from_expr1_call(node: &Node, source: &str) -> Option<String> {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "index" || child.kind() == "identifier" {
+            return Some(source[child.byte_range()].trim().to_string());
+        }
+    }
+    None
+}
+
+/// Count the number of result values a block produces
+fn count_block_results(block_node: &Node, source: &str) -> usize {
+    // Look for (result ...) in the block type
+    let mut cursor = block_node.walk();
+    for child in block_node.children(&mut cursor) {
+        if child.kind() == "block_type" {
+            return count_result_types(&child, source);
+        }
+    }
+    0
+}
+
+/// Count the number of types in a result section
+fn count_result_types(block_type: &Node, source: &str) -> usize {
+    let mut count = 0;
+    let mut cursor = block_type.walk();
+    for child in block_type.children(&mut cursor) {
+        if child.kind() == "func_type_results" {
+            // Count value types inside
+            let mut inner_cursor = child.walk();
+            for inner_child in child.children(&mut inner_cursor) {
+                if inner_child.kind() == "value_type" || inner_child.kind() == "ref_type" {
+                    count += 1;
+                }
+            }
+        }
+        // Also handle inline result types
+        if child.kind() == "value_type" || child.kind() == "ref_type" {
+            count += 1;
+        }
+    }
+    // If we found result types, return the count
+    // Also check the text for (result ...)
+    if count == 0 {
+        let text = &source[block_type.byte_range()];
+        if text.contains("result") {
+            // Count value types in the text (rough heuristic)
+            let type_keywords = [
+                "i32",
+                "i64",
+                "f32",
+                "f64",
+                "v128",
+                "funcref",
+                "externref",
+                "anyref",
+            ];
+            for kw in &type_keywords {
+                count += text.matches(kw).count();
+            }
+        }
+    }
+    count
+}
+
+/// Create a diagnostic for stack underflow
+fn create_stack_underflow_diagnostic(
+    node: &Node,
+    instr_name: &str,
+    needed: usize,
+    available: usize,
+) -> Diagnostic {
+    let range = node_to_lsp_range(node);
+    let value_word = if needed == 1 { "value" } else { "values" };
+
+    Diagnostic {
+        range,
+        severity: Some(DiagnosticSeverity::ERROR),
+        code: Some(NumberOrString::String("stack-underflow".to_string())),
+        code_description: None,
+        source: Some("wat-lsp".to_string()),
+        message: format!(
+            "Stack underflow: '{}' requires {} {} but only {} available on stack",
+            instr_name, needed, value_word, available
+        ),
+        related_information: None,
+        tags: None,
+        data: None,
+    }
+}
 
 /// Configuration for which checks to perform during tree walk
 struct DiagnosticConfig {
@@ -44,6 +604,19 @@ fn unified_tree_walk(
     diagnostics: &mut Vec<Diagnostic>,
 ) {
     let kind = node.kind();
+
+    // Check for function body instruction lists - perform stack tracking for unfolded code
+    if kind == "module_field_func" {
+        // Find the instr_list child and track stack
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            if child.kind() == "instr_list" {
+                track_stack_in_instr_list(&child, source, symbols, diagnostics);
+                break;
+            }
+        }
+        // Continue recursing for other checks (references, etc.)
+    }
 
     // Special handling for catch_clause (try_table): first index is tag, second is label
     if kind == "catch_clause" {
@@ -2853,6 +3426,292 @@ mod tests {
         assert_eq!(
             missing_operand_errors[0].code,
             Some(NumberOrString::String("missing-operands".to_string()))
+        );
+    }
+
+    // === Stack underflow tests for unfolded WAT ===
+
+    #[test]
+    fn test_stack_underflow_basic() {
+        // i32.add with completely empty stack
+        let document = r#"(module
+  (func $test
+    i32.add))"#;
+
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        let underflow_errors: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.code == Some(NumberOrString::String("stack-underflow".to_string())))
+            .collect();
+        assert_eq!(
+            underflow_errors.len(),
+            1,
+            "i32.add with empty stack should produce underflow error, got: {:?}",
+            diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+        assert!(underflow_errors[0].message.contains("i32.add"));
+        assert!(underflow_errors[0].message.contains("requires 2"));
+        assert!(underflow_errors[0].message.contains("0 available"));
+    }
+
+    #[test]
+    fn test_stack_underflow_partial() {
+        // i32.add with only 1 value on stack (needs 2)
+        let document = r#"(module
+  (func $test
+    i32.const 1
+    i32.add))"#;
+
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        let underflow_errors: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.code == Some(NumberOrString::String("stack-underflow".to_string())))
+            .collect();
+        assert_eq!(
+            underflow_errors.len(),
+            1,
+            "i32.add with 1 value should produce underflow error"
+        );
+        assert!(underflow_errors[0].message.contains("requires 2"));
+        assert!(underflow_errors[0].message.contains("1 available"));
+    }
+
+    #[test]
+    fn test_stack_no_underflow_correct_sequence() {
+        // Correct sequence: push 2 values, then add
+        let document = r#"(module
+  (func $test (result i32)
+    i32.const 1
+    i32.const 2
+    i32.add))"#;
+
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        let underflow_errors: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.code == Some(NumberOrString::String("stack-underflow".to_string())))
+            .collect();
+        assert_eq!(
+            underflow_errors.len(),
+            0,
+            "Correct stack sequence should not produce underflow"
+        );
+    }
+
+    #[test]
+    fn test_stack_underflow_drop() {
+        // drop with empty stack
+        let document = r#"(module
+  (func $test
+    drop))"#;
+
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        let underflow_errors: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.code == Some(NumberOrString::String("stack-underflow".to_string())))
+            .collect();
+        assert_eq!(
+            underflow_errors.len(),
+            1,
+            "drop with empty stack should produce underflow error"
+        );
+        assert!(underflow_errors[0].message.contains("drop"));
+    }
+
+    #[test]
+    fn test_stack_underflow_local_set() {
+        // local.set without value on stack
+        let document = r#"(module
+  (func $test (local $x i32)
+    local.set $x))"#;
+
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        let underflow_errors: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.code == Some(NumberOrString::String("stack-underflow".to_string())))
+            .collect();
+        assert_eq!(
+            underflow_errors.len(),
+            1,
+            "local.set with empty stack should produce underflow error"
+        );
+        assert!(underflow_errors[0].message.contains("local.set"));
+    }
+
+    #[test]
+    fn test_stack_no_underflow_local_get_then_set() {
+        // local.get produces 1, local.set consumes 1
+        let document = r#"(module
+  (func $test (local $x i32) (local $y i32)
+    local.get $x
+    local.set $y))"#;
+
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        let underflow_errors: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.code == Some(NumberOrString::String("stack-underflow".to_string())))
+            .collect();
+        assert_eq!(
+            underflow_errors.len(),
+            0,
+            "local.get then local.set should balance"
+        );
+    }
+
+    #[test]
+    fn test_stack_underflow_call() {
+        // call a function that takes 2 params with only 1 on stack
+        let document = r#"(module
+  (func $add (param i32 i32) (result i32)
+    local.get 0
+    local.get 1
+    i32.add)
+
+  (func $test (result i32)
+    i32.const 1
+    call $add))"#;
+
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        let underflow_errors: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.code == Some(NumberOrString::String("stack-underflow".to_string())))
+            .collect();
+        assert_eq!(
+            underflow_errors.len(),
+            1,
+            "call with insufficient args should produce underflow error"
+        );
+        assert!(underflow_errors[0].message.contains("call"));
+        assert!(underflow_errors[0].message.contains("requires 2"));
+    }
+
+    #[test]
+    fn test_stack_no_underflow_after_unreachable() {
+        // After unreachable, subsequent code is dead - don't report errors
+        let document = r#"(module
+  (func $test
+    unreachable
+    i32.add))"#;
+
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        let underflow_errors: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.code == Some(NumberOrString::String("stack-underflow".to_string())))
+            .collect();
+        assert_eq!(
+            underflow_errors.len(),
+            0,
+            "Code after unreachable should not report underflow"
+        );
+    }
+
+    #[test]
+    fn test_stack_mixed_folded_unfolded() {
+        // Folded expression pushes result, then unfolded uses it
+        let document = r#"(module
+  (func $test (result i32)
+    (i32.const 5)
+    (i32.const 3)
+    i32.add))"#;
+
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        let underflow_errors: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.code == Some(NumberOrString::String("stack-underflow".to_string())))
+            .collect();
+        assert_eq!(
+            underflow_errors.len(),
+            0,
+            "Mixed folded/unfolded should work correctly"
+        );
+    }
+
+    #[test]
+    fn test_stack_select_underflow() {
+        // select needs 3 values (val1, val2, condition)
+        let document = r#"(module
+  (func $test (result i32)
+    i32.const 1
+    i32.const 2
+    select))"#;
+
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        let underflow_errors: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.code == Some(NumberOrString::String("stack-underflow".to_string())))
+            .collect();
+        assert_eq!(
+            underflow_errors.len(),
+            1,
+            "select with 2 values should produce underflow (needs 3)"
+        );
+        assert!(underflow_errors[0].message.contains("select"));
+        assert!(underflow_errors[0].message.contains("requires 3"));
+    }
+
+    #[test]
+    fn test_stack_chain_of_operations() {
+        // Chain: const 1, const 2, add (produces 1), const 3, mul (produces 1)
+        let document = r#"(module
+  (func $test (result i32)
+    i32.const 1
+    i32.const 2
+    i32.add
+    i32.const 3
+    i32.mul))"#;
+
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        let underflow_errors: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.code == Some(NumberOrString::String("stack-underflow".to_string())))
+            .collect();
+        assert_eq!(
+            underflow_errors.len(),
+            0,
+            "Valid chain of operations should not produce underflow"
         );
     }
 }


### PR DESCRIPTION
Adds complete stack simulation for unfolded (linear) WAT programs to detect stack underflow errors.

## Changes
- Extended `InstructionArity` with `produces` field to track values pushed to stack
- Added `StackState` struct for stack depth tracking
- Implemented `track_stack_in_instr_list()` for stack validation
- New `stack-underflow` diagnostic for insufficient operands
- Added 11 new tests for stack underflow detection