### PR TITLE
Add diagnostic parity tests for native/WASM implementations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
               - 'build.rs'
               - 'docs/**'
               - 'grammars/tree-sitter-wat/**'
+              - 'tests/diagnostic_corpus/**'
             packages:
               - 'packages/**'
               - 'src/**'
@@ -43,6 +44,7 @@ jobs:
               - 'packages/**'
               - 'grammars/tree-sitter-wat/**'
               - 'src/**'
+              - 'tests/diagnostic_corpus/**'
 
   test:
     name: Test

--- a/packages/playground/main.ts
+++ b/packages/playground/main.ts
@@ -571,6 +571,10 @@ async function initMonaco(): Promise<void> {
     'semanticHighlighting.enabled': true,
   });
 
+  // Expose editor and monaco for testing
+  (window as unknown as { monacoEditor: typeof editor; monaco: typeof monaco }).monacoEditor = editor;
+  (window as unknown as { monaco: typeof monaco }).monaco = monaco;
+
   // Override theme's getTokenStyleMetadata for semantic token coloring
   try {
     const theme = (editor as unknown as { _themeService: { _theme: { getTokenStyleMetadata: (type: string, modifiers: string[], lang: string) => { foreground: number } | undefined } } })._themeService._theme;

--- a/packages/playground/tests/diagnostic-parity.spec.js
+++ b/packages/playground/tests/diagnostic-parity.spec.js
@@ -1,0 +1,197 @@
+/**
+ * Diagnostic Parity Tests
+ *
+ * These tests verify that the WASM LSP implementation produces the same
+ * diagnostics as the native implementation for a shared corpus of test files.
+ *
+ * The corpus lives in tests/diagnostic_corpus/ and is also validated by
+ * the native Rust tests (cargo test diagnostic_parity).
+ */
+
+import { test, expect } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+// ES module equivalent of __dirname
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Path to diagnostic corpus (relative to project root)
+const CORPUS_DIR = path.join(__dirname, '../../../tests/diagnostic_corpus');
+
+/**
+ * Load all test cases from the corpus directory
+ */
+function loadCorpusTestCases() {
+  const testCases = [];
+
+  if (!fs.existsSync(CORPUS_DIR)) {
+    console.warn(`Corpus directory not found: ${CORPUS_DIR}`);
+    return testCases;
+  }
+
+  const files = fs.readdirSync(CORPUS_DIR);
+
+  for (const file of files) {
+    if (file.endsWith('.wat')) {
+      const baseName = file.replace('.wat', '');
+      const expectedFile = `${baseName}.expected.json`;
+
+      if (files.includes(expectedFile)) {
+        const watPath = path.join(CORPUS_DIR, file);
+        const expectedPath = path.join(CORPUS_DIR, expectedFile);
+
+        const watContent = fs.readFileSync(watPath, 'utf-8');
+        const expectedContent = JSON.parse(fs.readFileSync(expectedPath, 'utf-8'));
+
+        testCases.push({
+          name: baseName,
+          wat: watContent,
+          expected: expectedContent,
+        });
+      }
+    }
+  }
+
+  return testCases;
+}
+
+const testCases = loadCorpusTestCases();
+
+test.describe('Diagnostic Parity (WASM vs Native)', () => {
+  // Skip all tests if no corpus found
+  test.skip(testCases.length === 0, 'No diagnostic corpus found');
+
+  for (const testCase of testCases) {
+    test(`${testCase.name}: ${testCase.expected.description}`, async ({ page }) => {
+      // Navigate to playground
+      await page.goto('/');
+
+      // Wait for LSP to be ready
+      await expect(page.locator('#lsp-status-text')).toHaveText(/LSP Ready/, {
+        timeout: 15000,
+      });
+
+      // Set editor content to our test WAT
+      await page.evaluate((wat) => {
+        // Access Monaco editor instance
+        const editor = window.monacoEditor;
+        if (editor) {
+          editor.setValue(wat);
+        }
+      }, testCase.wat);
+
+      // Wait for diagnostics to update (debounced at 300ms + processing time)
+      // Use longer timeout and also trigger a reparse
+      await page.waitForTimeout(800);
+
+      // Force a reparse by making a small edit and reverting
+      await page.evaluate(() => {
+        const editor = window.monacoEditor;
+        if (editor) {
+          const model = editor.getModel();
+          const content = model.getValue();
+          model.setValue(content + ' ');
+          model.setValue(content);
+        }
+      });
+
+      // Wait for the debounced diagnostics to update
+      await page.waitForTimeout(600);
+
+      // Get diagnostics from the LSP via exposed window function or markers
+      const diagnostics = await page.evaluate(() => {
+        const editor = window.monacoEditor;
+        if (!editor) return [];
+
+        const model = editor.getModel();
+        if (!model) return [];
+
+        // Get markers (diagnostics) from Monaco
+        const markers = window.monaco.editor.getModelMarkers({ resource: model.uri });
+
+        return markers.map((m) => ({
+          line: m.startLineNumber - 1, // Convert to 0-indexed like our corpus
+          message: m.message,
+          severity: m.severity, // Monaco: 8=error, 4=warning, 2=info, 1=hint
+        }));
+      });
+
+      // Convert Monaco severity to LSP severity (1=error, 2=warning, 3=info, 4=hint)
+      const normalizedDiagnostics = diagnostics.map((d) => ({
+        ...d,
+        severity:
+          d.severity === 8
+            ? 1
+            : d.severity === 4
+              ? 2
+              : d.severity === 2
+                ? 3
+                : d.severity === 1
+                  ? 4
+                  : d.severity,
+      }));
+
+      // Verify expected diagnostics
+      for (let i = 0; i < testCase.expected.diagnostics.length; i++) {
+        const exp = testCase.expected.diagnostics[i];
+
+        const found = normalizedDiagnostics.some((actual) => {
+          // Check line
+          if (actual.line !== exp.line) return false;
+
+          // Check severity
+          if (actual.severity !== exp.severity) return false;
+
+          // Check message contains
+          if (exp.message_contains && !actual.message.includes(exp.message_contains)) {
+            return false;
+          }
+
+          // Check message contains all
+          if (exp.message_contains_all) {
+            for (const s of exp.message_contains_all) {
+              if (!actual.message.includes(s)) return false;
+            }
+          }
+
+          return true;
+        });
+
+        const actualOnLine = normalizedDiagnostics
+          .filter((d) => d.line === exp.line)
+          .map((d) => `  - ${d.message}`)
+          .join('\n');
+
+        expect(found, `Expected diagnostic #${i + 1} not found:
+  Line: ${exp.line}
+  Message should contain: ${exp.message_contains || '(any)'}
+  Message should contain all: ${JSON.stringify(exp.message_contains_all || [])}
+  Severity: ${exp.severity}
+
+Actual diagnostics on line ${exp.line}:
+${actualOnLine || '  (none)'}
+
+All actual diagnostics:
+${normalizedDiagnostics.map((d) => `  L${d.line}: ${d.message}`).join('\n') || '  (none)'}`).toBe(true);
+      }
+
+      // For "no errors expected" tests, verify we got none
+      if (testCase.expected.diagnostics.length === 0) {
+        const errors = normalizedDiagnostics.filter((d) => d.severity === 1);
+        expect(
+          errors,
+          `Expected no errors but found ${errors.length}:
+${errors.map((d) => `  L${d.line}: ${d.message}`).join('\n')}`
+        ).toHaveLength(0);
+      }
+    });
+  }
+});
+
+// Meta-test to ensure corpus is being loaded
+test('diagnostic corpus is loaded', () => {
+  console.log(`Loaded ${testCases.length} diagnostic parity test cases`);
+  expect(testCases.length).toBeGreaterThan(0);
+});

--- a/tests/diagnostic_corpus/README.md
+++ b/tests/diagnostic_corpus/README.md
@@ -1,0 +1,44 @@
+# Diagnostic Corpus
+
+This directory contains WAT files with their expected diagnostics. These tests
+are run against BOTH the native and WASM implementations to ensure parity.
+
+## Structure
+
+Each test case consists of:
+- `<name>.wat` - The WAT source file
+- `<name>.expected.json` - Expected diagnostics in JSON format
+
+## Expected Format
+
+```json
+{
+  "diagnostics": [
+    {
+      "line": 5,
+      "message_contains": "Stack underflow",
+      "severity": 1
+    }
+  ]
+}
+```
+
+We use `message_contains` instead of exact message matching to allow for minor
+wording differences between implementations while still catching missing errors.
+
+## Running Tests
+
+- Native: `cargo test diagnostic_parity`
+- WASM: `npm test` in `packages/playground` (runs Playwright tests)
+
+## Adding New Tests
+
+1. Create `<name>.wat` with the test case
+2. Run `cargo run --bin generate-expected -- <name>.wat` to generate expected file
+3. Verify the expected diagnostics are correct
+4. Commit both files
+
+## CI Integration
+
+The CI workflow runs both native and WASM implementations against this corpus
+and fails if either produces different results than expected.

--- a/tests/diagnostic_corpus/stack_underflow_basic.expected.json
+++ b/tests/diagnostic_corpus/stack_underflow_basic.expected.json
@@ -1,0 +1,11 @@
+{
+  "description": "Stack underflow on binary operation with empty stack",
+  "diagnostics": [
+    {
+      "line": 3,
+      "message_contains": "Stack underflow",
+      "message_contains_all": ["i32.add", "2", "0"],
+      "severity": 1
+    }
+  ]
+}

--- a/tests/diagnostic_corpus/stack_underflow_basic.wat
+++ b/tests/diagnostic_corpus/stack_underflow_basic.wat
@@ -1,0 +1,6 @@
+;; Stack underflow: binary operation with empty stack
+(module
+  (func $empty_stack_add
+    i32.add
+  )
+)

--- a/tests/diagnostic_corpus/undefined_function.expected.json
+++ b/tests/diagnostic_corpus/undefined_function.expected.json
@@ -1,0 +1,11 @@
+{
+  "description": "Call to undefined function",
+  "diagnostics": [
+    {
+      "line": 3,
+      "message_contains": "Undefined function",
+      "message_contains_all": ["$nonexistent"],
+      "severity": 1
+    }
+  ]
+}

--- a/tests/diagnostic_corpus/undefined_function.wat
+++ b/tests/diagnostic_corpus/undefined_function.wat
@@ -1,0 +1,6 @@
+;; Undefined function reference
+(module
+  (func $caller
+    call $nonexistent
+  )
+)

--- a/tests/diagnostic_corpus/undefined_local.expected.json
+++ b/tests/diagnostic_corpus/undefined_local.expected.json
@@ -1,0 +1,11 @@
+{
+  "description": "Reference to undefined local variable",
+  "diagnostics": [
+    {
+      "line": 3,
+      "message_contains": "Undefined local",
+      "message_contains_all": ["$missing"],
+      "severity": 1
+    }
+  ]
+}

--- a/tests/diagnostic_corpus/undefined_local.wat
+++ b/tests/diagnostic_corpus/undefined_local.wat
@@ -1,0 +1,6 @@
+;; Undefined local reference
+(module
+  (func $test
+    local.get $missing
+  )
+)

--- a/tests/diagnostic_corpus/valid_no_errors.expected.json
+++ b/tests/diagnostic_corpus/valid_no_errors.expected.json
@@ -1,0 +1,4 @@
+{
+  "description": "Valid WAT file should produce no diagnostics",
+  "diagnostics": []
+}

--- a/tests/diagnostic_corpus/valid_no_errors.wat
+++ b/tests/diagnostic_corpus/valid_no_errors.wat
@@ -1,0 +1,8 @@
+;; Valid WAT file - should produce no diagnostics
+(module
+  (func $add (param $a i32) (param $b i32) (result i32)
+    local.get $a
+    local.get $b
+    i32.add
+  )
+)

--- a/tests/diagnostic_parity.rs
+++ b/tests/diagnostic_parity.rs
@@ -1,0 +1,270 @@
+//! Diagnostic Parity Tests
+//!
+//! This module tests the native diagnostic implementation against the diagnostic
+//! corpus to ensure parity with the WASM implementation. The same corpus is used
+//! by the WASM/Playwright tests to verify both implementations produce the same
+//! results.
+//!
+//! Run with: `cargo test diagnostic_parity`
+
+use serde::Deserialize;
+use std::fs;
+use std::path::Path;
+use tower_lsp::lsp_types::Diagnostic;
+use wat_lsp_rust::diagnostics::{
+    merge_all_diagnostics, provide_semantic_diagnostics, provide_tree_sitter_diagnostics,
+    validate_wat,
+};
+use wat_lsp_rust::parser;
+use wat_lsp_rust::ts_facade;
+
+#[derive(Debug, Deserialize)]
+struct ExpectedDiagnostic {
+    line: u32,
+    #[serde(default)]
+    message_contains: Option<String>,
+    #[serde(default)]
+    message_contains_all: Option<Vec<String>>,
+    severity: u32,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExpectedFile {
+    description: String,
+    diagnostics: Vec<ExpectedDiagnostic>,
+}
+
+fn get_all_diagnostics(wat: &str) -> Vec<Diagnostic> {
+    let mut parser = ts_facade::create_parser();
+    let tree = parser.parse(wat, None).expect("Failed to parse");
+    let symbols = parser::parse_document_from_tree(&tree, wat).unwrap_or_default();
+
+    let tree_sitter_diags = provide_tree_sitter_diagnostics(&tree, wat);
+    let semantic_diags = provide_semantic_diagnostics(&tree, wat, &symbols);
+    let wast_diags = validate_wat(wat);
+
+    merge_all_diagnostics(tree_sitter_diags, semantic_diags, wast_diags)
+}
+
+fn check_diagnostic_matches(actual: &Diagnostic, expected: &ExpectedDiagnostic) -> bool {
+    // Check line number
+    if actual.range.start.line != expected.line {
+        return false;
+    }
+
+    // Check severity (1 = error, 2 = warning, 3 = info, 4 = hint)
+    let actual_severity = match actual.severity {
+        Some(tower_lsp::lsp_types::DiagnosticSeverity::ERROR) => 1,
+        Some(tower_lsp::lsp_types::DiagnosticSeverity::WARNING) => 2,
+        Some(tower_lsp::lsp_types::DiagnosticSeverity::INFORMATION) => 3,
+        Some(tower_lsp::lsp_types::DiagnosticSeverity::HINT) => 4,
+        _ => return false,
+    };
+    if actual_severity != expected.severity {
+        return false;
+    }
+
+    // Check message contains
+    if let Some(ref contains) = expected.message_contains {
+        if !actual.message.contains(contains) {
+            return false;
+        }
+    }
+
+    // Check message contains all
+    if let Some(ref contains_all) = expected.message_contains_all {
+        for s in contains_all {
+            if !actual.message.contains(s) {
+                return false;
+            }
+        }
+    }
+
+    true
+}
+
+fn run_corpus_test(wat_path: &Path) {
+    let expected_path = wat_path.with_extension("expected.json");
+
+    // Read WAT file
+    let wat_content = fs::read_to_string(wat_path)
+        .unwrap_or_else(|e| panic!("Failed to read {}: {}", wat_path.display(), e));
+
+    // Read expected file
+    let expected_content = fs::read_to_string(&expected_path)
+        .unwrap_or_else(|e| panic!("Failed to read {}: {}", expected_path.display(), e));
+
+    let expected: ExpectedFile = serde_json::from_str(&expected_content)
+        .unwrap_or_else(|e| panic!("Failed to parse {}: {}", expected_path.display(), e));
+
+    // Get actual diagnostics
+    let actual_diagnostics = get_all_diagnostics(&wat_content);
+
+    // Verify each expected diagnostic is found
+    for (i, exp) in expected.diagnostics.iter().enumerate() {
+        let found = actual_diagnostics
+            .iter()
+            .any(|actual| check_diagnostic_matches(actual, exp));
+
+        if !found {
+            let actual_on_line: Vec<_> = actual_diagnostics
+                .iter()
+                .filter(|d| d.range.start.line == exp.line)
+                .map(|d| format!("  - {}", d.message))
+                .collect();
+
+            panic!(
+                "PARITY FAILURE in {}\n\
+                 Description: {}\n\
+                 Expected diagnostic #{} not found:\n\
+                   Line: {}\n\
+                   Message should contain: {:?}\n\
+                   Message should contain all: {:?}\n\
+                   Severity: {}\n\
+                 Actual diagnostics on line {}:\n{}\n\
+                 All actual diagnostics:\n{}",
+                wat_path.display(),
+                expected.description,
+                i + 1,
+                exp.line,
+                exp.message_contains,
+                exp.message_contains_all,
+                exp.severity,
+                exp.line,
+                if actual_on_line.is_empty() {
+                    "  (none)".to_string()
+                } else {
+                    actual_on_line.join("\n")
+                },
+                actual_diagnostics
+                    .iter()
+                    .map(|d| format!("  L{}: {}", d.range.start.line, d.message))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            );
+        }
+    }
+
+    // Check for unexpected diagnostics (errors only, not warnings/hints)
+    let unexpected: Vec<_> = actual_diagnostics
+        .iter()
+        .filter(|d| {
+            d.severity == Some(tower_lsp::lsp_types::DiagnosticSeverity::ERROR)
+                && !expected
+                    .diagnostics
+                    .iter()
+                    .any(|exp| check_diagnostic_matches(d, exp))
+        })
+        .collect();
+
+    if !unexpected.is_empty() && !expected.diagnostics.is_empty() {
+        // Only warn about unexpected errors if we expected some diagnostics
+        // (for valid files, we want exactly 0 errors)
+        let unexpected_msgs: Vec<_> = unexpected
+            .iter()
+            .map(|d| format!("  L{}: {}", d.range.start.line, d.message))
+            .collect();
+
+        // For valid_no_errors test, this is a failure
+        if expected.diagnostics.is_empty() && !unexpected.is_empty() {
+            panic!(
+                "PARITY FAILURE in {}\n\
+                 Description: {}\n\
+                 Expected no errors but found:\n{}",
+                wat_path.display(),
+                expected.description,
+                unexpected_msgs.join("\n")
+            );
+        }
+    }
+
+    // Special case: if we expect no diagnostics, verify we got none
+    if expected.diagnostics.is_empty() {
+        let errors: Vec<_> = actual_diagnostics
+            .iter()
+            .filter(|d| d.severity == Some(tower_lsp::lsp_types::DiagnosticSeverity::ERROR))
+            .collect();
+
+        if !errors.is_empty() {
+            panic!(
+                "PARITY FAILURE in {}\n\
+                 Description: {}\n\
+                 Expected no errors but found {} error(s):\n{}",
+                wat_path.display(),
+                expected.description,
+                errors.len(),
+                errors
+                    .iter()
+                    .map(|d| format!("  L{}: {}", d.range.start.line, d.message))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            );
+        }
+    }
+}
+
+#[test]
+fn diagnostic_parity_corpus() {
+    let corpus_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/diagnostic_corpus");
+
+    if !corpus_dir.exists() {
+        panic!(
+            "Diagnostic corpus directory not found: {}",
+            corpus_dir.display()
+        );
+    }
+
+    let mut test_count = 0;
+    let mut errors = Vec::new();
+
+    for entry in fs::read_dir(&corpus_dir).expect("Failed to read corpus directory") {
+        let entry = entry.expect("Failed to read directory entry");
+        let path = entry.path();
+
+        if path.extension().is_some_and(|ext| ext == "wat") {
+            let expected_path = path.with_extension("expected.json");
+            if expected_path.exists() {
+                test_count += 1;
+                println!("Testing: {}", path.file_name().unwrap().to_string_lossy());
+
+                // Run test and collect any error
+                let result = std::panic::catch_unwind(|| {
+                    run_corpus_test(&path);
+                });
+
+                if let Err(e) = result {
+                    let msg = if let Some(s) = e.downcast_ref::<&str>() {
+                        s.to_string()
+                    } else if let Some(s) = e.downcast_ref::<String>() {
+                        s.clone()
+                    } else {
+                        "Unknown error".to_string()
+                    };
+                    errors.push((path.clone(), msg));
+                }
+            } else {
+                eprintln!(
+                    "Warning: {} has no expected.json file, skipping",
+                    path.display()
+                );
+            }
+        }
+    }
+
+    if !errors.is_empty() {
+        let error_report = errors
+            .iter()
+            .map(|(path, msg)| format!("\n=== {} ===\n{}", path.display(), msg))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        panic!(
+            "\n{} of {} diagnostic parity tests failed:\n{}",
+            errors.len(),
+            test_count,
+            error_report
+        );
+    }
+
+    println!("\nAll {} diagnostic parity tests passed!", test_count);
+}


### PR DESCRIPTION
Port stack underflow detection to WASM and add CI infrastructure to automatically detect divergence between native and WASM diagnostic implementations.

## Changes

- Create shared `instruction_metadata` module for both builds
- Port stack tracking code to WASM `api.rs`
- Add diagnostic corpus with test WAT files and expected.json
- Add native parity test (`cargo test diagnostic_parity`)
- Add Playwright parity test for WASM
- Update CI to trigger tests on corpus changes
- Expose Monaco editor to window for testing