### PR TITLE
fix stack underflow detection for mixed folded/linear WAT (#93)

### DIFF
--- a/docs/examples/invalid/stack_underflow_mixed_folded.wat
+++ b/docs/examples/invalid/stack_underflow_mixed_folded.wat
@@ -1,0 +1,9 @@
+;; Issue #93: Stack underflow with mixed folded and linear form
+;; The folded expression (i32.add) needs 2 operands from the stack,
+;; but only 1 is available from the preceding i32.const instruction.
+(module
+  (func $partial_stack_add (result i32)
+    i32.const 42
+    (i32.add)  ;; ERROR: needs 2 values, only 1 on stack
+  )
+)

--- a/src/diagnostics/semantic_diagnostics.rs
+++ b/src/diagnostics/semantic_diagnostics.rs
@@ -90,9 +90,8 @@ fn track_stack_in_instr_list(
                 }
             }
             "expr" => {
-                // Folded expression - determine how many values it produces
-                let produces = count_expr_production(&child, source, symbols, arity_map);
-                stack.produce(produces);
+                // Folded expression - consume stack operands and produce results
+                process_folded_expr(&child, source, symbols, arity_map, &mut stack, diagnostics);
             }
             "instr_block" | "instr_loop" => {
                 // Block instructions create a new stack frame
@@ -110,9 +109,8 @@ fn track_stack_in_instr_list(
                 stack.produce(results);
             }
             "instr_call" => {
-                // Folded call: (call $fn args...) - handled similarly to expr
-                let produces = count_expr_production(&child, source, symbols, arity_map);
-                stack.produce(produces);
+                // Folded call: (call $fn args...) - consume stack operands and produce results
+                process_folded_expr(&child, source, symbols, arity_map, &mut stack, diagnostics);
             }
             _ => {
                 // Other node types (comments, etc.) - ignore
@@ -151,9 +149,8 @@ fn process_instr_node(
                 }
             }
             "expr" => {
-                // Folded expression - determine how many values it produces
-                let produces = count_expr_production(&child, source, symbols, arity_map);
-                stack.produce(produces);
+                // Folded expression - consume stack operands and produce results
+                process_folded_expr(&child, source, symbols, arity_map, stack, diagnostics);
             }
             "instr_block" | "instr_loop" => {
                 let results = count_block_results(&child, source);
@@ -168,8 +165,8 @@ fn process_instr_node(
                 stack.produce(results);
             }
             "instr_call" => {
-                let produces = count_expr_production(&child, source, symbols, arity_map);
-                stack.produce(produces);
+                // Folded call - consume stack operands and produce results
+                process_folded_expr(&child, source, symbols, arity_map, stack, diagnostics);
             }
             _ => {}
         }
@@ -474,6 +471,135 @@ fn count_expr1_production(
         }
         _ => 1, // Default
     }
+}
+
+/// Get instruction info from a folded expression
+/// Returns (instruction_name, explicit_operand_count)
+fn get_folded_expr_info(expr: &Node, source: &str) -> Option<(String, usize)> {
+    let mut cursor = expr.walk();
+    for child in expr.children(&mut cursor) {
+        let kind = child.kind();
+        // Handle both expr1 wrapper and direct expr1_* nodes
+        if kind == "expr1" {
+            // expr1 wraps expr1_plain, expr1_call, etc.
+            return get_expr1_wrapper_info(&child, source);
+        } else if kind.starts_with("expr1_") {
+            return get_expr1_info(&child, source);
+        }
+    }
+    None
+}
+
+/// Get instruction info from an expr1 wrapper node (which contains expr1_plain, etc.)
+fn get_expr1_wrapper_info(expr1: &Node, source: &str) -> Option<(String, usize)> {
+    let mut cursor = expr1.walk();
+    for child in expr1.children(&mut cursor) {
+        if child.kind().starts_with("expr1_") {
+            return get_expr1_info(&child, source);
+        }
+    }
+    None
+}
+
+/// Get instruction info from an expr1_* node (expr1_plain, expr1_call, etc.)
+fn get_expr1_info(expr1: &Node, source: &str) -> Option<(String, usize)> {
+    // Count explicit expr children (these are operands provided inline)
+    let mut expr_cursor = expr1.walk();
+    let explicit_operands = expr1
+        .children(&mut expr_cursor)
+        .filter(|c| c.kind() == "expr")
+        .count();
+
+    // Get instruction name from instr_plain child
+    let mut cursor = expr1.walk();
+    for child in expr1.children(&mut cursor) {
+        if child.kind() == "instr_plain" {
+            if let Some(name) = get_instruction_name(&child, source) {
+                return Some((name, explicit_operands));
+            }
+        }
+    }
+    None
+}
+
+/// Get the expected operand count for an instruction (fixed or dynamic)
+fn get_expected_operands_by_name(
+    instr_name: &str,
+    symbols: &SymbolTable,
+    source: &str,
+    arity_map: &std::collections::HashMap<
+        &'static str,
+        crate::instruction_metadata::InstructionArity,
+    >,
+    expr: &Node,
+) -> usize {
+    if let Some(arity) = arity_map.get(instr_name) {
+        match arity.operand_mode {
+            OperandMode::Fixed(n) => n,
+            OperandMode::Dynamic => {
+                // For dynamic instructions, we need to find the instr_plain to get param info
+                get_dynamic_operand_count_from_expr(expr, instr_name, symbols, source)
+            }
+        }
+    } else {
+        0
+    }
+}
+
+/// Get dynamic operand count by finding the instr_plain inside an expr
+fn get_dynamic_operand_count_from_expr(
+    expr: &Node,
+    instr_name: &str,
+    symbols: &SymbolTable,
+    source: &str,
+) -> usize {
+    // Navigate to find instr_plain inside expr > expr1_* > instr_plain
+    let mut cursor = expr.walk();
+    for child in expr.children(&mut cursor) {
+        if child.kind().starts_with("expr1_") {
+            let mut inner_cursor = child.walk();
+            for inner_child in child.children(&mut inner_cursor) {
+                if inner_child.kind() == "instr_plain" {
+                    return get_dynamic_operand_count(&inner_child, instr_name, symbols, source);
+                }
+            }
+        }
+    }
+    0
+}
+
+/// Process a folded expression: consume implicit stack operands, check for underflow, produce results
+fn process_folded_expr(
+    expr: &Node,
+    source: &str,
+    symbols: &SymbolTable,
+    arity_map: &std::collections::HashMap<
+        &'static str,
+        crate::instruction_metadata::InstructionArity,
+    >,
+    stack: &mut StackState,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    // Get instruction info from the expression
+    if let Some((instr_name, explicit_operands)) = get_folded_expr_info(expr, source) {
+        // Calculate operands needed from the stack
+        let expected = get_expected_operands_by_name(&instr_name, symbols, source, arity_map, expr);
+        let from_stack = expected.saturating_sub(explicit_operands);
+
+        // Consume operands from stack
+        if from_stack > 0 {
+            if let Err(available) = stack.consume(from_stack) {
+                // Use the expr node for the diagnostic location
+                let diagnostic =
+                    create_stack_underflow_diagnostic(expr, &instr_name, from_stack, available);
+                diagnostics.push(diagnostic);
+            }
+        }
+    }
+
+    // Produce result values
+    let produces = count_expr_production(expr, source, symbols, arity_map);
+    stack.produce(produces);
 }
 
 /// Get function reference from expr1_call node
@@ -3478,6 +3604,106 @@ mod tests {
         );
         assert!(underflow_errors[0].message.contains("requires 2"));
         assert!(underflow_errors[0].message.contains("1 available"));
+    }
+
+    #[test]
+    fn test_stack_underflow_mixed_folded_linear() {
+        // Issue #93: folded expression with insufficient stack values
+        let document = r#"(module
+  (func $test (result i32)
+    i32.const 42
+    (i32.add)))"#;
+
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        let underflow_errors: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.code == Some(NumberOrString::String("stack-underflow".to_string())))
+            .collect();
+        assert_eq!(
+            underflow_errors.len(),
+            1,
+            "folded i32.add with only 1 stack value should produce underflow error, got: {:?}",
+            diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+        assert!(underflow_errors[0].message.contains("i32.add"));
+        assert!(underflow_errors[0].message.contains("requires 2"));
+        assert!(underflow_errors[0].message.contains("1 available"));
+    }
+
+    #[test]
+    fn test_stack_no_underflow_folded_with_inline_operands() {
+        // Folded expression with all operands provided inline - should be fine
+        let document = r#"(module
+  (func $test (result i32)
+    (i32.add (i32.const 1) (i32.const 2))))"#;
+
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        let underflow_errors: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.code == Some(NumberOrString::String("stack-underflow".to_string())))
+            .collect();
+        assert_eq!(
+            underflow_errors.len(),
+            0,
+            "folded i32.add with both operands inline should not produce underflow error"
+        );
+    }
+
+    #[test]
+    fn test_stack_no_underflow_mixed_partial_inline() {
+        // Folded expression with one operand on stack, one inline - should be fine
+        let document = r#"(module
+  (func $test (result i32)
+    i32.const 42
+    (i32.add (i32.const 1))))"#;
+
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        let underflow_errors: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.code == Some(NumberOrString::String("stack-underflow".to_string())))
+            .collect();
+        assert_eq!(
+            underflow_errors.len(),
+            0,
+            "folded i32.add with 1 inline operand and 1 stack value should not produce underflow error"
+        );
+    }
+
+    #[test]
+    fn test_stack_underflow_folded_empty_stack() {
+        // Folded expression with no operands and empty stack
+        let document = r#"(module
+  (func $test (result i32)
+    (i32.add)))"#;
+
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        let underflow_errors: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.code == Some(NumberOrString::String("stack-underflow".to_string())))
+            .collect();
+        assert_eq!(
+            underflow_errors.len(),
+            1,
+            "folded i32.add with empty stack should produce underflow error"
+        );
+        assert!(underflow_errors[0].message.contains("requires 2"));
+        assert!(underflow_errors[0].message.contains("0 available"));
     }
 
     #[test]

--- a/src/wasm/api.rs
+++ b/src/wasm/api.rs
@@ -1056,9 +1056,8 @@ fn track_stack_in_instr_list(
                 }
             }
             "expr" => {
-                // Folded expression - determine how many values it produces
-                let produces = count_expr_production(&child, source, symbols, &arity_map);
-                stack.produce(produces);
+                // Folded expression - consume stack operands and produce results
+                process_folded_expr(&child, source, symbols, &arity_map, &mut stack, diagnostics);
             }
             "instr_block" | "instr_loop" => {
                 // Block instructions create a new stack frame
@@ -1076,9 +1075,8 @@ fn track_stack_in_instr_list(
                 stack.produce(results);
             }
             "instr_call" => {
-                // Folded call: (call $fn args...) - handled similarly to expr
-                let produces = count_expr_production(&child, source, symbols, &arity_map);
-                stack.produce(produces);
+                // Folded call: (call $fn args...) - consume stack operands and produce results
+                process_folded_expr(&child, source, symbols, &arity_map, &mut stack, diagnostics);
             }
             _ => {
                 // Other node types (comments, etc.) - ignore
@@ -1114,9 +1112,8 @@ fn process_instr_node(
                 }
             }
             "expr" => {
-                // Folded expression - determine how many values it produces
-                let produces = count_expr_production(&child, source, symbols, arity_map);
-                stack.produce(produces);
+                // Folded expression - consume stack operands and produce results
+                process_folded_expr(&child, source, symbols, arity_map, stack, diagnostics);
             }
             "instr_block" | "instr_loop" => {
                 let results = count_block_results(&child, source);
@@ -1131,8 +1128,8 @@ fn process_instr_node(
                 stack.produce(results);
             }
             "instr_call" => {
-                let produces = count_expr_production(&child, source, symbols, arity_map);
-                stack.produce(produces);
+                // Folded call - consume stack operands and produce results
+                process_folded_expr(&child, source, symbols, arity_map, stack, diagnostics);
             }
             _ => {}
         }
@@ -1438,6 +1435,129 @@ fn get_index_from_expr1_call(node: &Node, source: &str) -> Option<String> {
         }
     }
     None
+}
+
+/// Get instruction info from a folded expression
+/// Returns (instruction_name, explicit_operand_count)
+fn get_folded_expr_info(expr: &Node, source: &str) -> Option<(String, usize)> {
+    let mut cursor = expr.walk();
+    for child in expr.children(&mut cursor) {
+        let kind = child.kind();
+        // Handle both expr1 wrapper and direct expr1_* nodes
+        if kind == "expr1" {
+            // expr1 wraps expr1_plain, expr1_call, etc.
+            return get_expr1_wrapper_info(&child, source);
+        } else if kind.starts_with("expr1_") {
+            return get_expr1_info(&child, source);
+        }
+    }
+    None
+}
+
+/// Get instruction info from an expr1 wrapper node (which contains expr1_plain, etc.)
+fn get_expr1_wrapper_info(expr1: &Node, source: &str) -> Option<(String, usize)> {
+    let mut cursor = expr1.walk();
+    for child in expr1.children(&mut cursor) {
+        if child.kind().starts_with("expr1_") {
+            return get_expr1_info(&child, source);
+        }
+    }
+    None
+}
+
+/// Get instruction info from an expr1_* node (expr1_plain, expr1_call, etc.)
+fn get_expr1_info(expr1: &Node, source: &str) -> Option<(String, usize)> {
+    // Count explicit expr children (these are operands provided inline)
+    let mut expr_cursor = expr1.walk();
+    let explicit_operands = expr1
+        .children(&mut expr_cursor)
+        .filter(|c| c.kind() == "expr")
+        .count();
+
+    // Get instruction name from instr_plain child
+    let mut cursor = expr1.walk();
+    for child in expr1.children(&mut cursor) {
+        if child.kind() == "instr_plain" {
+            if let Some(name) = get_instruction_name(&child, source) {
+                return Some((name, explicit_operands));
+            }
+        }
+    }
+    None
+}
+
+/// Get the expected operand count for an instruction (fixed or dynamic)
+fn get_expected_operands_by_name(
+    instr_name: &str,
+    symbols: &SymbolTable,
+    source: &str,
+    arity_map: &HashMap<&'static str, InstructionArity>,
+    expr: &Node,
+) -> usize {
+    if let Some(arity) = arity_map.get(instr_name) {
+        match arity.operand_mode {
+            OperandMode::Fixed(n) => n,
+            OperandMode::Dynamic => {
+                // For dynamic instructions, we need to find the instr_plain to get param info
+                get_dynamic_operand_count_from_expr(expr, instr_name, symbols, source)
+            }
+        }
+    } else {
+        0
+    }
+}
+
+/// Get dynamic operand count by finding the instr_plain inside an expr
+fn get_dynamic_operand_count_from_expr(
+    expr: &Node,
+    instr_name: &str,
+    symbols: &SymbolTable,
+    source: &str,
+) -> usize {
+    // Navigate to find instr_plain inside expr > expr1_* > instr_plain
+    let mut cursor = expr.walk();
+    for child in expr.children(&mut cursor) {
+        if child.kind().starts_with("expr1_") {
+            let mut inner_cursor = child.walk();
+            for inner_child in child.children(&mut inner_cursor) {
+                if inner_child.kind() == "instr_plain" {
+                    return get_dynamic_operand_count(&inner_child, instr_name, symbols, source);
+                }
+            }
+        }
+    }
+    0
+}
+
+/// Process a folded expression: consume implicit stack operands, check for underflow, produce results
+fn process_folded_expr(
+    expr: &Node,
+    source: &str,
+    symbols: &SymbolTable,
+    arity_map: &HashMap<&'static str, InstructionArity>,
+    stack: &mut StackState,
+    diagnostics: &mut Vec<WasmDiagnostic>,
+) {
+    // Get instruction info from the expression
+    if let Some((instr_name, explicit_operands)) = get_folded_expr_info(expr, source) {
+        // Calculate operands needed from the stack
+        let expected = get_expected_operands_by_name(&instr_name, symbols, source, arity_map, expr);
+        let from_stack = expected.saturating_sub(explicit_operands);
+
+        // Consume operands from stack
+        if from_stack > 0 {
+            if let Err(available) = stack.consume(from_stack) {
+                // Use the expr node for the diagnostic location
+                let diagnostic =
+                    create_stack_underflow_diagnostic(expr, &instr_name, from_stack, available);
+                diagnostics.push(diagnostic);
+            }
+        }
+    }
+
+    // Produce result values
+    let produces = count_expr_production(expr, source, symbols, arity_map);
+    stack.produce(produces);
 }
 
 /// Count the number of result values a block produces

--- a/tests/diagnostic_corpus/stack_underflow_mixed_folded.expected.json
+++ b/tests/diagnostic_corpus/stack_underflow_mixed_folded.expected.json
@@ -1,0 +1,10 @@
+{
+  "description": "Stack underflow with mixed folded and linear form",
+  "diagnostics": [
+    {
+      "line": 6,
+      "message_contains": "i32.add",
+      "severity": 1
+    }
+  ]
+}

--- a/tests/diagnostic_corpus/stack_underflow_mixed_folded.wat
+++ b/tests/diagnostic_corpus/stack_underflow_mixed_folded.wat
@@ -1,0 +1,9 @@
+;; Stack underflow with mixed folded and linear form
+;; Expected error: Stack underflow: 'i32.add' requires 2 values but only 1 available on stack
+
+(module
+  (func $partial_stack_add (result i32)
+    i32.const 42
+    (i32.add)  ;; ERROR: needs 2 values, only 1 on stack
+  )
+)


### PR DESCRIPTION
Fixes #93: Stack underflow detection now correctly handles mixed folded and linear WAT syntax.

When a folded expression like `(i32.add)` appears in an instruction list, the code now properly checks that enough values exist on the stack for operands not provided inline.

## Changes
- Added `process_folded_expr()` to handle stack consumption for folded expressions
- Added helper functions to extract instruction info and operand counts
- Added 4 new tests covering various mixed folded/linear scenarios
- Added example file for the new error case