### PR TITLE
add command palette for file switching (Ctrl/Cmd+P)

### DIFF
--- a/packages/playground/index.html
+++ b/packages/playground/index.html
@@ -130,9 +130,23 @@
     </div>
 
     <footer>
-      <span>WAT LSP Playground - Hover, Go to Definition (F12), Find References (Shift+F12), Outline</span>
+      <span>WAT LSP Playground - Open File (Ctrl/Cmd+P), Go to Definition (F12), Find References (Shift+F12)</span>
       <span id="status">Ready</span>
     </footer>
+  </div>
+
+  <!-- Command Palette -->
+  <div id="command-palette" class="command-palette hidden">
+    <div class="command-palette-backdrop"></div>
+    <div class="command-palette-container">
+      <input type="text" id="command-palette-input" class="command-palette-input" placeholder="Type to search files..." autocomplete="off">
+      <div id="command-palette-results" class="command-palette-results"></div>
+      <div class="command-palette-hint">
+        <span><kbd>↑</kbd><kbd>↓</kbd> Navigate</span>
+        <span><kbd>Enter</kbd> Open</span>
+        <span><kbd>Esc</kbd> Close</span>
+      </div>
+    </div>
   </div>
 
   <script type="module" src="main.ts"></script>

--- a/packages/playground/main.ts
+++ b/packages/playground/main.ts
@@ -134,6 +134,9 @@ let elements: {
   testCol: HTMLInputElement;
   testHoverBtn: HTMLButtonElement;
   testResult: HTMLElement;
+  commandPalette: HTMLElement;
+  commandPaletteInput: HTMLInputElement;
+  commandPaletteResults: HTMLElement;
 };
 
 // Console output helper
@@ -1282,6 +1285,170 @@ function loadExample(id: string): void {
   setStatus('Ready');
 }
 
+// Command Palette
+let commandPaletteSelectedIndex = 0;
+let commandPaletteFilteredItems: typeof examples = [];
+
+function openCommandPalette(): void {
+  elements.commandPalette.classList.remove('hidden');
+  elements.commandPaletteInput.value = '';
+  elements.commandPaletteInput.focus();
+  commandPaletteSelectedIndex = 0;
+  updateCommandPaletteResults('');
+}
+
+function closeCommandPalette(): void {
+  elements.commandPalette.classList.add('hidden');
+  elements.commandPaletteInput.value = '';
+  editor?.focus();
+}
+
+function updateCommandPaletteResults(query: string): void {
+  const lowerQuery = query.toLowerCase().trim();
+
+  // Filter examples by fuzzy matching on id and label
+  if (lowerQuery === '') {
+    commandPaletteFilteredItems = [...examples];
+  } else {
+    commandPaletteFilteredItems = examples.filter(ex => {
+      const searchText = `${ex.id} ${ex.label}`.toLowerCase();
+      // Simple fuzzy match: all query characters appear in order
+      let searchIndex = 0;
+      for (const char of lowerQuery) {
+        const foundIndex = searchText.indexOf(char, searchIndex);
+        if (foundIndex === -1) return false;
+        searchIndex = foundIndex + 1;
+      }
+      return true;
+    });
+  }
+
+  // Ensure selected index is in bounds
+  if (commandPaletteSelectedIndex >= commandPaletteFilteredItems.length) {
+    commandPaletteSelectedIndex = Math.max(0, commandPaletteFilteredItems.length - 1);
+  }
+
+  renderCommandPaletteResults();
+}
+
+function renderCommandPaletteResults(): void {
+  if (commandPaletteFilteredItems.length === 0) {
+    elements.commandPaletteResults.innerHTML = '<div class="command-palette-empty">No matching files</div>';
+    return;
+  }
+
+  const html = commandPaletteFilteredItems.map((ex, index) => {
+    const isInvalid = ex.id.startsWith('invalid_');
+    const icon = isInvalid ? '⚠️' : '📄';
+    const folder = isInvalid ? 'invalid/' : 'examples/';
+    const selected = index === commandPaletteSelectedIndex ? ' selected' : '';
+
+    return `<div class="command-palette-item${selected}" data-id="${ex.id}" data-index="${index}">
+      <span class="command-palette-item-icon">${icon}</span>
+      <span class="command-palette-item-label">${escapeHtml(ex.label)}</span>
+      <span class="command-palette-item-path">${folder}${ex.id}.wat</span>
+    </div>`;
+  }).join('');
+
+  elements.commandPaletteResults.innerHTML = html;
+
+  // Scroll selected item into view
+  const selectedEl = elements.commandPaletteResults.querySelector('.command-palette-item.selected');
+  if (selectedEl) {
+    selectedEl.scrollIntoView({ block: 'nearest' });
+  }
+}
+
+function selectCommandPaletteItem(index: number): void {
+  if (index < 0 || index >= commandPaletteFilteredItems.length) return;
+
+  const item = commandPaletteFilteredItems[index];
+  closeCommandPalette();
+  loadExample(item.id);
+
+  // Update file tree selection
+  elements.fileTree.querySelectorAll('.tree-item').forEach(el => el.classList.remove('selected'));
+  const treeItem = elements.fileTree.querySelector(`[data-id="${item.id}"]`);
+  if (treeItem) {
+    treeItem.classList.add('selected');
+    // Expand parent folder if collapsed
+    const folder = treeItem.closest('.tree-folder');
+    if (folder) {
+      const children = folder.querySelector('.tree-folder-children') as HTMLElement;
+      if (children && children.style.display === 'none') {
+        children.style.display = 'block';
+        const chevron = folder.querySelector('.tree-chevron');
+        if (chevron) chevron.textContent = '▼';
+      }
+    }
+  }
+}
+
+function handleCommandPaletteKeydown(e: KeyboardEvent): void {
+  switch (e.key) {
+    case 'Escape':
+      e.preventDefault();
+      closeCommandPalette();
+      break;
+    case 'ArrowDown':
+      e.preventDefault();
+      if (commandPaletteSelectedIndex < commandPaletteFilteredItems.length - 1) {
+        commandPaletteSelectedIndex++;
+        renderCommandPaletteResults();
+      }
+      break;
+    case 'ArrowUp':
+      e.preventDefault();
+      if (commandPaletteSelectedIndex > 0) {
+        commandPaletteSelectedIndex--;
+        renderCommandPaletteResults();
+      }
+      break;
+    case 'Enter':
+      e.preventDefault();
+      selectCommandPaletteItem(commandPaletteSelectedIndex);
+      break;
+  }
+}
+
+function initCommandPalette(): void {
+  // Input handler for filtering
+  elements.commandPaletteInput.addEventListener('input', () => {
+    commandPaletteSelectedIndex = 0;
+    updateCommandPaletteResults(elements.commandPaletteInput.value);
+  });
+
+  // Keyboard navigation
+  elements.commandPaletteInput.addEventListener('keydown', handleCommandPaletteKeydown);
+
+  // Click on backdrop to close
+  const backdrop = elements.commandPalette.querySelector('.command-palette-backdrop');
+  if (backdrop) {
+    backdrop.addEventListener('click', closeCommandPalette);
+  }
+
+  // Click on result item
+  elements.commandPaletteResults.addEventListener('click', (e) => {
+    const item = (e.target as HTMLElement).closest('.command-palette-item');
+    if (item) {
+      const index = parseInt(item.getAttribute('data-index') || '0', 10);
+      selectCommandPaletteItem(index);
+    }
+  });
+
+  // Hover to select
+  elements.commandPaletteResults.addEventListener('mousemove', (e) => {
+    const item = (e.target as HTMLElement).closest('.command-palette-item');
+    if (item) {
+      const index = parseInt(item.getAttribute('data-index') || '0', 10);
+      if (index !== commandPaletteSelectedIndex) {
+        commandPaletteSelectedIndex = index;
+        renderCommandPaletteResults();
+      }
+    }
+  });
+}
+
 // Tab switching
 function initTabs(): void {
   const tabs = document.querySelectorAll<HTMLButtonElement>('.tab');
@@ -1419,6 +1586,9 @@ function initElements(): void {
       'test-hover-btn'
     ) as HTMLButtonElement,
     testResult: document.getElementById('test-result')!,
+    commandPalette: document.getElementById('command-palette')!,
+    commandPaletteInput: document.getElementById('command-palette-input') as HTMLInputElement,
+    commandPaletteResults: document.getElementById('command-palette-results')!,
   };
 }
 
@@ -1433,6 +1603,7 @@ async function init(): Promise<void> {
   initTabs();
   initResizablePanel();
   initFileTreeResize();
+  initCommandPalette();
 
   // Initialize Monaco, wabt, and LSP in parallel
   await Promise.all([initMonaco(), initWabt(), initLSP()]);
@@ -1467,10 +1638,18 @@ async function init(): Promise<void> {
 
   // Keyboard shortcuts
   document.addEventListener('keydown', (e) => {
+    // Cmd/Ctrl+P: Open command palette
+    if ((e.ctrlKey || e.metaKey) && e.key === 'p' && !e.shiftKey) {
+      e.preventDefault();
+      openCommandPalette();
+      return;
+    }
+    // Cmd/Ctrl+Enter: Compile
     if ((e.ctrlKey || e.metaKey) && e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       compile();
     }
+    // Cmd/Ctrl+Shift+Enter: Compile and Run
     if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key === 'Enter') {
       e.preventDefault();
       compile().then((success) => {
@@ -1481,8 +1660,9 @@ async function init(): Promise<void> {
 
   consoleOutput.log('Playground ready!');
   consoleOutput.info('Keyboard shortcuts:');
-  consoleOutput.info('  Ctrl+Enter: Compile');
-  consoleOutput.info('  Ctrl+Shift+Enter: Compile and Run');
+  consoleOutput.info('  Ctrl/Cmd+P: Open file (Command Palette)');
+  consoleOutput.info('  Ctrl/Cmd+Enter: Compile');
+  consoleOutput.info('  Ctrl/Cmd+Shift+Enter: Compile and Run');
   consoleOutput.info('  F12: Go to Definition');
   consoleOutput.info('  Shift+F12: Find References');
   setStatus('Ready');

--- a/packages/playground/style.css
+++ b/packages/playground/style.css
@@ -796,6 +796,130 @@ footer {
   margin-left: 12px;
 }
 
+/* Command Palette */
+.command-palette {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  justify-content: center;
+  padding-top: 15vh;
+}
+
+.command-palette.hidden {
+  display: none;
+}
+
+.command-palette-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+}
+
+.command-palette-container {
+  position: relative;
+  width: 500px;
+  max-width: 90vw;
+  max-height: 400px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.command-palette-input {
+  width: 100%;
+  padding: 14px 16px;
+  background: var(--bg-tertiary);
+  border: none;
+  border-bottom: 1px solid var(--border-color);
+  color: var(--text-primary);
+  font-size: 1rem;
+  font-family: inherit;
+  outline: none;
+}
+
+.command-palette-input::placeholder {
+  color: var(--text-secondary);
+}
+
+.command-palette-results {
+  flex: 1;
+  overflow-y: auto;
+  max-height: 340px;
+}
+
+.command-palette-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 16px;
+  cursor: pointer;
+  transition: background 0.1s ease;
+}
+
+.command-palette-item:hover,
+.command-palette-item.selected {
+  background: var(--bg-hover);
+}
+
+.command-palette-item.selected {
+  background: var(--accent-blue);
+}
+
+.command-palette-item.selected .command-palette-item-label,
+.command-palette-item.selected .command-palette-item-path {
+  color: white;
+}
+
+.command-palette-item-icon {
+  font-size: 1rem;
+  flex-shrink: 0;
+}
+
+.command-palette-item-label {
+  color: var(--text-primary);
+  font-size: 0.9rem;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.command-palette-item-path {
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  flex-shrink: 0;
+}
+
+.command-palette-empty {
+  padding: 20px 16px;
+  color: var(--text-secondary);
+  text-align: center;
+  font-style: italic;
+}
+
+.command-palette-hint {
+  padding: 8px 16px;
+  background: var(--bg-tertiary);
+  border-top: 1px solid var(--border-color);
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  display: flex;
+  gap: 16px;
+}
+
+.command-palette-hint kbd {
+  background: var(--bg-hover);
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-family: inherit;
+  font-size: 0.7rem;
+}
+
 /* Responsive */
 @media (max-width: 900px) {
   .main-content {


### PR DESCRIPTION
Adds a VS Code-style command palette to the playground for quickly switching between example files.

**Features:**
- Open with Ctrl/Cmd+P
- Fuzzy search by filename or label
- Keyboard navigation (arrows, Enter, Escape)
- Mouse hover and click support
- Auto-expands collapsed folders in file tree