### PR TITLE
fix tooltip cutoff in playground by enabling fixedOverflowWidgets

### DIFF
--- a/packages/playground/main.ts
+++ b/packages/playground/main.ts
@@ -654,6 +654,7 @@ async function initMonaco(): Promise<void> {
     folding: true,
     bracketPairColorization: { enabled: false },
     'semanticHighlighting.enabled': true,
+    fixedOverflowWidgets: true,
   });
 
   // Expose editor and monaco for testing


### PR DESCRIPTION
Enables `fixedOverflowWidgets: true` in Monaco editor options so hover tooltips can escape `overflow: hidden` containers and flip direction when near viewport edges.