### PR TITLE
add control flow analysis for return type validation (#104)

### DIFF
--- a/docs/examples/trapping.wat
+++ b/docs/examples/trapping.wat
@@ -138,30 +138,20 @@
     (local.get $sum))
 
   ;; br_table (switch statement)
-  ;; Uses local variable pattern to avoid complex nested block result types
   (func $switch (param $selector i32) (result i32)
-    (local $result i32)
-    (block $default
-      (block $case3
-        (block $case2
-          (block $case1
-            (block $case0
+    (block $default (result i32)
+      (block $case3 (result i32)
+        (block $case2 (result i32)
+          (block $case1 (result i32)
+            (block $case0 (result i32)
               (br_table $case0 $case1 $case2 $case3 $default
-                (local.get $selector)))
-            ;; case 0
-            (local.set $result (i32.const 100))
-            (br $default))
-          ;; case 1
-          (local.set $result (i32.const 200))
-          (br $default))
-        ;; case 2
-        (local.set $result (i32.const 300))
-        (br $default))
-      ;; case 3
-      (local.set $result (i32.const 400))
-      (br $default))
-    ;; default case (selector >= 4)
-    (local.get $result))
+                (local.get $selector))
+              (i32.const -1))  ;; never reached
+            (return (i32.const 100)))
+          (return (i32.const 200)))
+        (return (i32.const 300)))
+      (return (i32.const 400)))
+    (i32.const 0))  ;; default case
 
   ;; Complex br_table with fallthrough simulation
   (func $complex_switch (param $x i32) (result i32)

--- a/src/diagnostics/semantic_diagnostics.rs
+++ b/src/diagnostics/semantic_diagnostics.rs
@@ -1,5 +1,5 @@
 use crate::instruction_metadata::{
-    get_instruction_arity_map, is_terminating_instruction, OperandMode,
+    get_instruction_arity_map, is_terminating_instruction, sequence_always_terminates, OperandMode,
 };
 use crate::symbols::{SymbolTable, ValueType};
 use crate::utils::{
@@ -105,8 +105,13 @@ fn track_stack_in_instr_list(
             "instr_block" | "instr_loop" => {
                 // Block instructions create a new stack frame
                 // After a block completes, it pushes its result values
-                let results = get_block_result_types(&child, source);
-                stack.produce(results);
+                // But only if the block can actually fall through
+                if !sequence_always_terminates(&child, source) {
+                    let results = get_block_result_types(&child, source);
+                    stack.produce(results);
+                } else {
+                    stack.mark_uncertain();
+                }
             }
             "instr_if" => {
                 // if consumes condition (1 value) and produces result values
@@ -114,8 +119,13 @@ fn track_stack_in_instr_list(
                     let diagnostic = create_stack_underflow_diagnostic(&child, "if", 1, available);
                     diagnostics.push(diagnostic);
                 }
-                let results = get_block_result_types(&child, source);
-                stack.produce(results);
+                // Only produce results if the if can fall through
+                if !sequence_always_terminates(&child, source) {
+                    let results = get_block_result_types(&child, source);
+                    stack.produce(results);
+                } else {
+                    stack.mark_uncertain();
+                }
             }
             "instr_call" => {
                 // Folded call: (call $fn args...) - consume stack operands and produce results
@@ -169,16 +179,24 @@ fn process_instr_node(
                 process_folded_expr(&child, source, symbols, arity_map, stack, diagnostics);
             }
             "instr_block" | "instr_loop" => {
-                let results = get_block_result_types(&child, source);
-                stack.produce(results);
+                if !sequence_always_terminates(&child, source) {
+                    let results = get_block_result_types(&child, source);
+                    stack.produce(results);
+                } else {
+                    stack.mark_uncertain();
+                }
             }
             "instr_if" => {
                 if let Err(available) = stack.consume(1) {
                     let diagnostic = create_stack_underflow_diagnostic(&child, "if", 1, available);
                     diagnostics.push(diagnostic);
                 }
-                let results = get_block_result_types(&child, source);
-                stack.produce(results);
+                if !sequence_always_terminates(&child, source) {
+                    let results = get_block_result_types(&child, source);
+                    stack.produce(results);
+                } else {
+                    stack.mark_uncertain();
+                }
             }
             "instr_call" => {
                 // Folded call - consume stack operands and produce results
@@ -493,6 +511,13 @@ fn process_folded_expr(
                 diagnostics.push(diagnostic);
             }
         }
+    }
+
+    // Check if the expression always terminates (e.g., a block where all paths return)
+    // If so, mark uncertain and don't produce values
+    if sequence_always_terminates(expr, source) {
+        stack.mark_uncertain();
+        return;
     }
 
     // Produce result values with actual types

--- a/src/instruction_metadata.rs
+++ b/src/instruction_metadata.rs
@@ -618,6 +618,232 @@ pub fn is_terminating_instruction(name: &str) -> bool {
     )
 }
 
+/// Check if a sequence of instructions always terminates (never falls through).
+/// This is used to determine whether a block's declared result types should be
+/// pushed onto the stack - if the block always terminates, it doesn't produce
+/// values via fall-through.
+///
+/// Note: This function is only available in native builds. WASM builds have a
+/// separate implementation in wasm/api.rs that uses the WASM Node type.
+#[cfg(feature = "native")]
+pub fn sequence_always_terminates(node: &tree_sitter::Node, source: &str) -> bool {
+    let kind = node.kind();
+
+    match kind {
+        // An instruction list terminates if ANY child instruction terminates
+        "instr_list" => {
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                if sequence_always_terminates(&child, source) {
+                    return true;
+                }
+            }
+            false
+        }
+
+        // Check if this is a terminating instruction
+        "instr" => {
+            // instr can contain expr (folded), instr_plain, instr_block, etc.
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                if sequence_always_terminates(&child, source) {
+                    return true;
+                }
+            }
+            false
+        }
+
+        "instr_plain" => {
+            if let Some(name) = get_instruction_name_from_node(node, source) {
+                is_terminating_instruction(&name)
+            } else {
+                false
+            }
+        }
+
+        // expr1, expr1_plain contain the actual instruction content
+        "expr1" | "expr1_plain" => {
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                if sequence_always_terminates(&child, source) {
+                    return true;
+                }
+            }
+            false
+        }
+
+        // Block: check if the block's instruction list terminates
+        "instr_block" | "block_block" => block_body_always_terminates(node, source),
+
+        // Loop: check if the body terminates (loops can run forever but body might terminate)
+        "instr_loop" | "loop_block" => block_body_always_terminates(node, source),
+
+        // If: terminates only if BOTH then AND else branches exist AND both terminate
+        "instr_if" | "if_block" => if_always_terminates(node, source),
+
+        // Expr (folded expression): check inner content
+        "expr" => {
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                if sequence_always_terminates(&child, source) {
+                    return true;
+                }
+            }
+            false
+        }
+
+        // For expr1_block, expr1_loop (folded block/loop syntax)
+        "expr1_block" | "expr1_loop" => {
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                let child_kind = child.kind();
+                // Check the body expressions/instructions
+                if (child_kind == "expr" || child_kind == "instr" || child_kind == "instr_list")
+                    && sequence_always_terminates(&child, source)
+                {
+                    return true;
+                }
+            }
+            false
+        }
+
+        // For expr1_if (folded if syntax)
+        "expr1_if" => if_always_terminates(node, source),
+
+        _ => false,
+    }
+}
+
+/// Extract the instruction name from a node (handles instr, instr_plain, etc.)
+#[cfg(feature = "native")]
+fn get_instruction_name_from_node(node: &tree_sitter::Node, source: &str) -> Option<String> {
+    let kind = node.kind();
+
+    if kind == "instr" {
+        // instr wraps other instruction types
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            if let Some(name) = get_instruction_name_from_node(&child, source) {
+                return Some(name);
+            }
+        }
+        return None;
+    }
+
+    if kind == "instr_plain" {
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            let child_kind = child.kind();
+            if child_kind.starts_with("op_") {
+                let text = &source[child.byte_range()];
+                return text.split_whitespace().next().map(|s| s.to_string());
+            }
+        }
+        // Fallback
+        let text = &source[node.byte_range()];
+        return text.split_whitespace().next().map(|s| s.to_string());
+    }
+
+    None
+}
+
+/// Check if a block/loop body always terminates
+#[cfg(feature = "native")]
+fn block_body_always_terminates(node: &tree_sitter::Node, source: &str) -> bool {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        let child_kind = child.kind();
+        if child_kind == "instr_list" {
+            return sequence_always_terminates(&child, source);
+        }
+        // For linear format blocks like block_block, loop_block
+        if (child_kind == "block_block" || child_kind == "loop_block" || child_kind == "if_block")
+            && block_body_always_terminates(&child, source)
+        {
+            return true;
+        }
+        // For folded expressions, check each expr/instr child
+        if (child_kind == "expr" || child_kind == "instr" || child_kind == "instr_plain")
+            && sequence_always_terminates(&child, source)
+        {
+            return true;
+        }
+    }
+    false
+}
+
+/// Check if an if/if_block always terminates (both branches must exist and terminate)
+#[cfg(feature = "native")]
+fn if_always_terminates(node: &tree_sitter::Node, source: &str) -> bool {
+    let kind = node.kind();
+
+    // For folded if (expr1_if), we need to find then and else expressions
+    if kind == "expr1_if" {
+        let mut then_terminates = false;
+        let mut else_terminates = false;
+        let mut has_else = false;
+
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            let child_kind = child.kind();
+            // In folded if, the structure is:
+            // (if (result ...) condition (then ...) (else ...))
+            // We need to find the then/else parts
+            if child_kind == "expr1_then" {
+                then_terminates = sequence_always_terminates(&child, source);
+            } else if child_kind == "expr1_else" {
+                has_else = true;
+                else_terminates = sequence_always_terminates(&child, source);
+            }
+        }
+
+        // If without else does not terminate unconditionally
+        return has_else && then_terminates && else_terminates;
+    }
+
+    // For linear format if (instr_if or if_block)
+    let mut then_terminates = false;
+    let mut else_terminates = false;
+    let mut has_else = false;
+
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        let child_kind = child.kind();
+
+        if child_kind == "if_block" {
+            // Recurse into if_block
+            return if_always_terminates(&child, source);
+        }
+
+        if child_kind == "instr_list" {
+            // First instr_list is the then branch
+            if !then_terminates {
+                then_terminates = sequence_always_terminates(&child, source);
+            } else {
+                // Second instr_list would be in else (but typically else has its own structure)
+                has_else = true;
+                else_terminates = sequence_always_terminates(&child, source);
+            }
+        }
+
+        // Handle explicit else
+        if child_kind == "else" || child_kind == "instr_else" {
+            has_else = true;
+            // Find the instr_list inside the else
+            let mut else_cursor = child.walk();
+            for else_child in child.children(&mut else_cursor) {
+                if else_child.kind() == "instr_list" {
+                    else_terminates = sequence_always_terminates(&else_child, source);
+                    break;
+                }
+            }
+        }
+    }
+
+    // If without else does not terminate unconditionally
+    has_else && then_terminates && else_terminates
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/wasm/api.rs
+++ b/src/wasm/api.rs
@@ -1518,8 +1518,13 @@ fn track_stack_in_instr_list(
             "instr_block" | "instr_loop" => {
                 // Block instructions create a new stack frame
                 // After a block completes, it pushes its result values
-                let results = get_block_result_types(&child, source);
-                stack.produce(results);
+                // But only if the block can actually fall through
+                if !wasm_sequence_always_terminates(&child, source) {
+                    let results = get_block_result_types(&child, source);
+                    stack.produce(results);
+                } else {
+                    stack.mark_uncertain();
+                }
             }
             "instr_if" => {
                 // if consumes condition (1 value) and produces result values
@@ -1527,8 +1532,13 @@ fn track_stack_in_instr_list(
                     let diagnostic = create_stack_underflow_diagnostic(&child, "if", 1, available);
                     diagnostics.push(diagnostic);
                 }
-                let results = get_block_result_types(&child, source);
-                stack.produce(results);
+                // Only produce results if the if can fall through
+                if !wasm_sequence_always_terminates(&child, source) {
+                    let results = get_block_result_types(&child, source);
+                    stack.produce(results);
+                } else {
+                    stack.mark_uncertain();
+                }
             }
             "instr_call" => {
                 // Folded call: (call $fn args...) - consume stack operands and produce results
@@ -1579,16 +1589,24 @@ fn process_instr_node(
                 process_folded_expr(&child, source, symbols, arity_map, stack, diagnostics);
             }
             "instr_block" | "instr_loop" => {
-                let results = get_block_result_types(&child, source);
-                stack.produce(results);
+                if !wasm_sequence_always_terminates(&child, source) {
+                    let results = get_block_result_types(&child, source);
+                    stack.produce(results);
+                } else {
+                    stack.mark_uncertain();
+                }
             }
             "instr_if" => {
                 if let Err(available) = stack.consume(1) {
                     let diagnostic = create_stack_underflow_diagnostic(&child, "if", 1, available);
                     diagnostics.push(diagnostic);
                 }
-                let results = get_block_result_types(&child, source);
-                stack.produce(results);
+                if !wasm_sequence_always_terminates(&child, source) {
+                    let results = get_block_result_types(&child, source);
+                    stack.produce(results);
+                } else {
+                    stack.mark_uncertain();
+                }
             }
             "instr_call" => {
                 // Folded call - consume stack operands and produce results
@@ -2361,6 +2379,13 @@ fn process_folded_expr(
         }
     }
 
+    // Check if the expression always terminates (e.g., a block where all paths return)
+    // If so, mark uncertain and don't produce values
+    if wasm_sequence_always_terminates(expr, source) {
+        stack.mark_uncertain();
+        return;
+    }
+
     // Produce result values with actual types
     let result_types = get_expr_result_types(expr, source, symbols, arity_map);
     stack.produce(result_types);
@@ -2543,6 +2568,210 @@ fn count_result_types(block_type: &Node, source: &str) -> usize {
         }
     }
     count
+}
+
+/// Check if a sequence of instructions always terminates (WASM version).
+/// This is a WASM-specific version that works with the WASM Node type.
+fn wasm_sequence_always_terminates(node: &Node, source: &str) -> bool {
+    let kind = node.kind();
+
+    match kind.as_str() {
+        // An instruction list terminates if ANY child instruction terminates
+        "instr_list" => {
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                if wasm_sequence_always_terminates(&child, source) {
+                    return true;
+                }
+            }
+            false
+        }
+
+        // Check if this is a terminating instruction
+        "instr" => {
+            // instr can contain expr (folded), instr_plain, instr_block, etc.
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                if wasm_sequence_always_terminates(&child, source) {
+                    return true;
+                }
+            }
+            false
+        }
+
+        "instr_plain" => {
+            if let Some(name) = wasm_get_instruction_name_from_node(node, source) {
+                is_terminating_instruction(&name)
+            } else {
+                false
+            }
+        }
+
+        // expr1, expr1_plain contain the actual instruction content
+        "expr1" | "expr1_plain" => {
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                if wasm_sequence_always_terminates(&child, source) {
+                    return true;
+                }
+            }
+            false
+        }
+
+        // Block: check if the block's instruction list terminates
+        "instr_block" | "block_block" => wasm_block_body_always_terminates(node, source),
+
+        // Loop: check if the body terminates
+        "instr_loop" | "loop_block" => wasm_block_body_always_terminates(node, source),
+
+        // If: terminates only if BOTH then AND else branches exist AND both terminate
+        "instr_if" | "if_block" => wasm_if_always_terminates(node, source),
+
+        // Expr (folded expression): check inner content
+        "expr" => {
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                if wasm_sequence_always_terminates(&child, source) {
+                    return true;
+                }
+            }
+            false
+        }
+
+        // For expr1_block, expr1_loop (folded block/loop syntax)
+        "expr1_block" | "expr1_loop" => {
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                let child_kind = child.kind();
+                if (child_kind == "expr" || child_kind == "instr" || child_kind == "instr_list")
+                    && wasm_sequence_always_terminates(&child, source)
+                {
+                    return true;
+                }
+            }
+            false
+        }
+
+        // For expr1_if (folded if syntax)
+        "expr1_if" => wasm_if_always_terminates(node, source),
+
+        _ => false,
+    }
+}
+
+/// Extract the instruction name from a node (WASM version)
+fn wasm_get_instruction_name_from_node(node: &Node, source: &str) -> Option<String> {
+    let kind = node.kind();
+
+    if kind == "instr" {
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            if let Some(name) = wasm_get_instruction_name_from_node(&child, source) {
+                return Some(name);
+            }
+        }
+        return None;
+    }
+
+    if kind == "instr_plain" {
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            let child_kind = child.kind();
+            if child_kind.starts_with("op_") {
+                let text = &source[child.byte_range()];
+                return text.split_whitespace().next().map(|s| s.to_string());
+            }
+        }
+        let text = &source[node.byte_range()];
+        return text.split_whitespace().next().map(|s| s.to_string());
+    }
+
+    None
+}
+
+/// Check if a block/loop body always terminates (WASM version)
+fn wasm_block_body_always_terminates(node: &Node, source: &str) -> bool {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        let child_kind = child.kind();
+        if child_kind == "instr_list" {
+            return wasm_sequence_always_terminates(&child, source);
+        }
+        // For linear format blocks like block_block, loop_block
+        if (child_kind == "block_block" || child_kind == "loop_block" || child_kind == "if_block")
+            && wasm_block_body_always_terminates(&child, source)
+        {
+            return true;
+        }
+        // For folded expressions, check each expr/instr child
+        if (child_kind == "expr" || child_kind == "instr" || child_kind == "instr_plain")
+            && wasm_sequence_always_terminates(&child, source)
+        {
+            return true;
+        }
+    }
+    false
+}
+
+/// Check if an if/if_block always terminates (WASM version)
+fn wasm_if_always_terminates(node: &Node, source: &str) -> bool {
+    let kind = node.kind();
+
+    // For folded if (expr1_if)
+    if kind == "expr1_if" {
+        let mut then_terminates = false;
+        let mut else_terminates = false;
+        let mut has_else = false;
+
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            let child_kind = child.kind();
+            if child_kind == "expr1_then" {
+                then_terminates = wasm_sequence_always_terminates(&child, source);
+            } else if child_kind == "expr1_else" {
+                has_else = true;
+                else_terminates = wasm_sequence_always_terminates(&child, source);
+            }
+        }
+
+        return has_else && then_terminates && else_terminates;
+    }
+
+    // For linear format if (instr_if or if_block)
+    let mut then_terminates = false;
+    let mut else_terminates = false;
+    let mut has_else = false;
+
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        let child_kind = child.kind();
+
+        if child_kind == "if_block" {
+            return wasm_if_always_terminates(&child, source);
+        }
+
+        if child_kind == "instr_list" {
+            if !then_terminates {
+                then_terminates = wasm_sequence_always_terminates(&child, source);
+            } else {
+                has_else = true;
+                else_terminates = wasm_sequence_always_terminates(&child, source);
+            }
+        }
+
+        if child_kind == "else" || child_kind == "instr_else" {
+            has_else = true;
+            let mut else_cursor = child.walk();
+            for else_child in child.children(&mut else_cursor) {
+                if else_child.kind() == "instr_list" {
+                    else_terminates = wasm_sequence_always_terminates(&else_child, source);
+                    break;
+                }
+            }
+        }
+    }
+
+    has_else && then_terminates && else_terminates
 }
 
 /// Get the result types from a block/loop/if instruction

--- a/tests/diagnostic_corpus/block_terminates_valid.expected.json
+++ b/tests/diagnostic_corpus/block_terminates_valid.expected.json
@@ -1,0 +1,4 @@
+{
+  "description": "Valid blocks where all paths terminate should produce no errors",
+  "diagnostics": []
+}

--- a/tests/diagnostic_corpus/block_terminates_valid.wat
+++ b/tests/diagnostic_corpus/block_terminates_valid.wat
@@ -1,0 +1,19 @@
+;; Valid: blocks with complex control flow that always terminates
+(module
+  ;; All paths through if terminate with return
+  (func $if_terminates (param $cond i32) (result i32)
+    (if (result i32) (local.get $cond)
+      (then (return (i32.const 1)))
+      (else (return (i32.const 0)))))
+
+  ;; Block with br that always branches - the i32.const after is dead code
+  (func $block_br_terminates (result i32)
+    (block $exit (result i32)
+      (br $exit (i32.const 42))
+      (i32.const 0)))  ;; never reached, but provides fallthrough value
+
+  ;; Loop that always returns (doesn't fall through)
+  (func $loop_terminates (result i32)
+    (loop $again (result i32)
+      (return (i32.const 99))))
+)


### PR DESCRIPTION
Adds `sequence_always_terminates()` to detect blocks that never fall through, preventing false positive stack errors for valid code with terminating control flow.

- Native implementation in instruction_metadata.rs (cfg-gated)
- WASM implementation in wasm/api.rs for parity
- Test corpus for blocks with terminating control flow

Closes #104