### PR TITLE
add cfg guards to native-only tests and extract shared test helper

### DIFF
--- a/src/features/completion/mod.rs
+++ b/src/features/completion/mod.rs
@@ -6,7 +6,7 @@ use crate::utils::{
 use once_cell::sync::Lazy;
 use regex::Regex;
 
-#[cfg(test)]
+#[cfg(all(test, feature = "native"))]
 mod tests;
 
 /// Provide completion items at the given position in the document.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -13,7 +13,7 @@ use crate::tree_sitter_bindings::create_parser;
 #[cfg(all(feature = "wasm", not(feature = "native")))]
 use crate::ts_facade::{Node, Tree};
 
-#[cfg(test)]
+#[cfg(all(test, feature = "native"))]
 mod tests;
 
 /// Parse a WAT document and extract symbols (PUBLIC API - unchanged)

--- a/tests/diagnostic_parity.rs
+++ b/tests/diagnostic_parity.rs
@@ -1,4 +1,4 @@
-//! Diagnostic Parity Tests
+//! Diagnostic Parity Tests (native only)
 //!
 //! This module tests the native diagnostic implementation against the diagnostic
 //! corpus to ensure parity with the WASM implementation. The same corpus is used
@@ -6,6 +6,8 @@
 //! results.
 //!
 //! Run with: `cargo test diagnostic_parity`
+
+#![cfg(feature = "native")]
 
 use serde::Deserialize;
 use std::fs;

--- a/tests/incremental_parsing.rs
+++ b/tests/incremental_parsing.rs
@@ -1,31 +1,22 @@
+//! Incremental parsing tests (native only)
+//!
+//! Tests tree-sitter incremental parsing functionality.
+
+#![cfg(feature = "native")]
+
+mod test_helpers;
+
 use std::time::Instant;
+use test_helpers::generate_large_wat;
 use tower_lsp::lsp_types::Position;
 use wat_lsp_rust::diagnostics::provide_tree_sitter_diagnostics;
 use wat_lsp_rust::tree_sitter_bindings::create_parser;
 use wat_lsp_rust::utils::apply_text_edit;
 
-/// Generate a large WAT document for performance testing
-fn generate_large_wat(num_functions: usize) -> String {
-    let mut wat = String::from("(module\n");
-
-    for i in 0..num_functions {
-        wat.push_str(&format!(
-            "  (func $func{} (param $x i32) (param $y i32) (result i32)\n",
-            i
-        ));
-        wat.push_str("    (local $temp i32)\n");
-        wat.push_str("    (local.set $temp\n");
-        wat.push_str("      (i32.add (local.get $x) (local.get $y)))\n");
-        wat.push_str("    (i32.mul (local.get $temp) (i32.const 2)))\n");
-    }
-
-    wat.push_str(")\n");
-    wat
-}
-
 #[test]
 fn test_incremental_vs_full_parsing() {
-    let document = generate_large_wat(100);
+    // Generate ~1500 lines (100 functions * ~15 lines each)
+    let document = generate_large_wat(1500);
     let mut parser = create_parser();
 
     // Initial parse
@@ -85,7 +76,11 @@ fn test_incremental_vs_full_parsing() {
     let incremental_time = start.elapsed();
 
     println!("\n=== Performance Comparison ===");
-    println!("Document size: {} functions, {} bytes", 100, document.len());
+    println!(
+        "Document size: {} lines, {} bytes",
+        document.lines().count(),
+        document.len()
+    );
     println!("Full reparse time: {:?}", full_time);
     println!("Incremental reparse time: {:?}", incremental_time);
     println!(

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,3 +1,7 @@
+//! Integration tests for WAT LSP features (native only)
+
+#![cfg(feature = "native")]
+
 use tower_lsp::lsp_types::*;
 use tree_sitter::Tree;
 use wat_lsp_rust::{

--- a/tests/large_file_performance.rs
+++ b/tests/large_file_performance.rs
@@ -1,68 +1,24 @@
+//! Large file performance tests (native only)
+//!
+//! Tests performance characteristics with large WAT files (~15k lines).
+//! These tests use native-only features (tree-sitter, tower-lsp).
+
+#![cfg(feature = "native")]
+
+mod test_helpers;
+
 use std::time::Instant;
+use test_helpers::generate_large_wat;
 use tower_lsp::lsp_types::Position;
 use wat_lsp_rust::core::types::Position as CorePosition;
 use wat_lsp_rust::tree_sitter_bindings::create_parser;
 use wat_lsp_rust::utils::apply_text_edit;
 use wat_lsp_rust::{diagnostics, parser};
 
-/// Generate a large WAT document (approximately 15k lines)
-fn generate_large_wat_15k() -> String {
-    let mut wat = String::from("(module\n");
-
-    // Add 10 globals (10 lines)
-    for i in 0..10 {
-        wat.push_str(&format!(
-            "  (global $global{} (mut i32) (i32.const {}))\n",
-            i, i
-        ));
-    }
-
-    // Add 5 tables (5 lines)
-    for i in 0..5 {
-        wat.push_str(&format!("  (table $table{} 100 funcref)\n", i));
-    }
-
-    // Add 10 type definitions (30 lines)
-    for i in 0..10 {
-        wat.push_str(&format!(
-            "  (type $type{} (func (param i32 i32) (result i32)))\n",
-            i
-        ));
-    }
-
-    // Add 1000 functions with ~15 lines each = ~15,000 lines
-    for i in 0..1000 {
-        wat.push_str(&format!(
-            "  (func $func{} (param $x i32) (param $y i32) (result i32)\n",
-            i
-        ));
-        wat.push_str("    (local $temp i32)\n");
-        wat.push_str("    (local $result i32)\n");
-        wat.push_str("    ;; Initialize local\n");
-        wat.push_str("    (local.set $temp (i32.const 0))\n");
-        wat.push_str("    ;; Calculate sum\n");
-        wat.push_str("    (local.set $temp\n");
-        wat.push_str("      (i32.add (local.get $x) (local.get $y)))\n");
-        wat.push_str("    ;; Double the result\n");
-        wat.push_str("    (local.set $result\n");
-        wat.push_str("      (i32.mul (local.get $temp) (i32.const 2)))\n");
-        wat.push_str("    ;; Add global value\n");
-        wat.push_str("    (local.set $result\n");
-        wat.push_str(&format!(
-            "      (i32.add (local.get $result) (global.get $global{})))\n",
-            i % 10
-        ));
-        wat.push_str("    (local.get $result))\n");
-    }
-
-    wat.push_str(")\n");
-    wat
-}
-
 #[test]
 fn test_15k_line_initial_parse_performance() {
     println!("\n=== Generating 15k line document ===");
-    let document = generate_large_wat_15k();
+    let document = generate_large_wat(15000);
     let line_count = document.lines().count();
     let byte_count = document.len();
 
@@ -97,7 +53,6 @@ fn test_15k_line_initial_parse_performance() {
     println!("Symbol extraction time: {:?}", symbol_time);
     println!("Functions found: {}", symbols.functions.len());
     println!("Globals found: {}", symbols.globals.len());
-    println!("Tables found: {}", symbols.tables.len());
 
     // Test diagnostics generation
     println!("\n=== Testing Diagnostics ===");
@@ -127,7 +82,7 @@ fn test_15k_line_initial_parse_performance() {
 #[test]
 fn test_15k_line_incremental_edit_performance() {
     println!("\n=== Testing Incremental Edits on 15k Line Document ===");
-    let document = generate_large_wat_15k();
+    let document = generate_large_wat(15000);
     let line_count = document.lines().count();
 
     println!("Document: {} lines", line_count);
@@ -312,7 +267,7 @@ fn test_15k_line_incremental_edit_performance() {
 #[test]
 fn test_15k_line_completion_latency() {
     println!("\n=== Testing Completion Latency on 15k Line Document ===");
-    let document = generate_large_wat_15k();
+    let document = generate_large_wat(15000);
 
     // Parse document
     let mut parser = create_parser();

--- a/tests/phase5_grammar_test.rs
+++ b/tests/phase5_grammar_test.rs
@@ -1,3 +1,10 @@
+//! WasmGC and type system parsing tests (native only)
+//!
+//! Tests for parsing WasmGC types (structs, arrays), recursive types,
+//! and subtyping features.
+
+#![cfg(feature = "native")]
+
 use wat_lsp_rust::parser::parse_document;
 use wat_lsp_rust::symbols::TypeKind;
 

--- a/tests/rename_tests.rs
+++ b/tests/rename_tests.rs
@@ -1,3 +1,7 @@
+//! Rename functionality tests (native only)
+
+#![cfg(feature = "native")]
+
 use tower_lsp::lsp_types::*;
 use wat_lsp_rust::{
     parser,

--- a/tests/test_helpers.rs
+++ b/tests/test_helpers.rs
@@ -1,0 +1,73 @@
+//! Shared test utilities for WAT LSP tests and benchmarks.
+//!
+//! This module provides common helpers used across integration tests and benchmarks.
+
+/// Generate a synthetic WAT file with the specified approximate line count.
+///
+/// The generated file contains:
+/// - Globals (10 or num_lines/1500, whichever is smaller)
+/// - Type definitions (5 or num_lines/3000, whichever is smaller)
+/// - Functions (~15 lines each)
+///
+/// # Arguments
+/// * `target_lines` - Approximate target line count for the generated file
+///
+/// # Example
+/// ```
+/// let wat = generate_large_wat(15000);
+/// assert!(wat.lines().count() > 14000);
+/// ```
+pub fn generate_large_wat(target_lines: usize) -> String {
+    let mut wat = String::from("(module\n");
+
+    // Calculate how many functions we need (each function is ~15 lines)
+    let num_functions = target_lines / 15;
+    let num_globals = 10.min(num_functions / 10);
+    let num_types = 5.min(num_functions / 20);
+
+    // Add globals
+    for i in 0..num_globals {
+        wat.push_str(&format!(
+            "  (global $global{} (mut i32) (i32.const {}))\n",
+            i, i
+        ));
+    }
+
+    // Add types
+    for i in 0..num_types {
+        wat.push_str(&format!(
+            "  (type $type{} (func (param i32 i32) (result i32)))\n",
+            i
+        ));
+    }
+
+    // Add functions
+    for i in 0..num_functions {
+        wat.push_str(&format!(
+            "  (func $func{} (param $x i32) (param $y i32) (result i32)\n",
+            i
+        ));
+        wat.push_str("    (local $temp i32)\n");
+        wat.push_str("    (local $result i32)\n");
+        wat.push_str("    ;; Initialize local\n");
+        wat.push_str("    (local.set $temp (i32.const 0))\n");
+        wat.push_str("    ;; Calculate sum\n");
+        wat.push_str("    (local.set $temp\n");
+        wat.push_str("      (i32.add (local.get $x) (local.get $y)))\n");
+        wat.push_str("    ;; Double the result\n");
+        wat.push_str("    (local.set $result\n");
+        wat.push_str("      (i32.mul (local.get $temp) (i32.const 2)))\n");
+        if num_globals > 0 {
+            wat.push_str("    ;; Add global value\n");
+            wat.push_str("    (local.set $result\n");
+            wat.push_str(&format!(
+                "      (i32.add (local.get $result) (global.get $global{})))\n",
+                i % num_globals
+            ));
+        }
+        wat.push_str("    (local.get $result))\n");
+    }
+
+    wat.push_str(")\n");
+    wat
+}

--- a/tests/wat_docs_cli.rs
+++ b/tests/wat_docs_cli.rs
@@ -1,6 +1,8 @@
-//! Integration tests for the wat-docs CLI binary
+//! Integration tests for the wat-docs CLI binary (native only)
 //!
 //! These tests verify the CLI behavior including output formatting and colorization.
+
+#![cfg(feature = "native")]
 
 use std::process::Command;
 


### PR DESCRIPTION
- Add `#[cfg(feature = "native")]` guards to integration tests that use native-only dependencies
- Extract shared `generate_large_wat` test helper to eliminate code duplication
- Fix WASM build failures by properly gating test modules in parser and completion