### PR TITLE
fix: handle try_table catch clause branches in control flow analysis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,9 +103,9 @@ checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"

--- a/src/diagnostics/semantic_diagnostics.rs
+++ b/src/diagnostics/semantic_diagnostics.rs
@@ -3366,4 +3366,124 @@ mod tests {
             "Functions should have correct return values on stack"
         );
     }
+
+    #[test]
+    fn test_try_table_catch_branch_to_outer_block() {
+        // Regression test for issue #108:
+        // Control flow analysis should handle try_table catch clauses that branch to outer blocks.
+        // Even though the try_table body always terminates (return), the catch clause can
+        // branch to $outer_catch, so the enclosing block doesn't "always terminate".
+        //
+        // Pattern: catch branches to outer block, block result IS the function result
+        let document = r#"(module
+  (tag $error (param i32))
+
+  (func $safe_op (param $x i32) (result i32)
+    (block $catch_block (result i32)
+      (try_table (result i32) (catch $error $catch_block)
+        (if (i32.lt_s (local.get $x) (i32.const 0))
+          (then (throw $error (i32.const -1))))
+        (return (local.get $x)))))
+)"#;
+        // Normal path: body returns $x
+        // Exception path: catch branches to $catch_block with error payload (i32), block produces i32
+
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+
+        let return_errors: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| {
+                d.code == Some(NumberOrString::String("return-arity-mismatch".to_string()))
+                    || d.code == Some(NumberOrString::String("return-type-mismatch".to_string()))
+            })
+            .collect();
+
+        assert_eq!(
+            return_errors.len(),
+            0,
+            "try_table with catch branch to outer block should not cause false positive errors, got: {:?}",
+            return_errors.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_try_table_body_terminates_with_catch() {
+        // Another test for issue #108:
+        // When try_table body terminates but has catch clauses, the outer block
+        // doesn't "always terminate" because catch can branch out.
+        //
+        // Pattern: body always terminates (unreachable), but catch provides exit path
+        let document = r#"(module
+  (tag $error (param i32))
+
+  (func $test (result i32)
+    (block $catch_handler (result i32)
+      (try_table (result i32) (catch $error $catch_handler)
+        (unreachable))))
+)"#;
+        // Only path: exception caught, branches to $catch_handler with i32 payload
+
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+
+        let type_errors: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| {
+                d.code == Some(NumberOrString::String("return-arity-mismatch".to_string()))
+                    || d.code == Some(NumberOrString::String("return-type-mismatch".to_string()))
+            })
+            .collect();
+
+        assert_eq!(
+            type_errors.len(),
+            0,
+            "try_table with unreachable body but catch clause should not cause false positives, got: {:?}",
+            type_errors.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_try_table_with_code_after_block() {
+        // Test pattern from issue #108 where code after block is only reached via catch
+        // The catch branches to an outer block with no result type
+        let document = r#"(module
+  (tag $error)
+
+  (func $test (result i32)
+    (block $on_error
+      (try_table (catch $error $on_error)
+        (return (i32.const 42))))
+    (i32.const -1))
+)"#;
+        // Normal path: body returns 42
+        // Exception path: catch branches to $on_error (no result), continues to i32.const -1
+
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+
+        let type_errors: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| {
+                d.code == Some(NumberOrString::String("return-arity-mismatch".to_string()))
+                    || d.code == Some(NumberOrString::String("return-type-mismatch".to_string()))
+            })
+            .collect();
+
+        assert_eq!(
+            type_errors.len(),
+            0,
+            "try_table with code after block (reached via catch) should not cause false positives, got: {:?}",
+            type_errors.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+    }
 }

--- a/src/diagnostics_core/termination.rs
+++ b/src/diagnostics_core/termination.rs
@@ -111,6 +111,14 @@ pub fn sequence_always_terminates(node: &Node, source: &str) -> bool {
         // For expr1_if (folded if syntax)
         "expr1_if" => if_always_terminates(node, source),
 
+        // For try_table (folded and linear formats)
+        // A try_table with catch clauses can exit via catch branches to outer labels,
+        // so it doesn't "always terminate" in the control flow sense.
+        // Even if the body terminates (return/unreachable), catch clauses provide
+        // alternative paths that branch to outer labels.
+        // See: https://github.com/EmNudge/wat-lsp/issues/108
+        "expr1_try_table" | "block_try_table" => try_table_always_terminates(node, source),
+
         _ => false,
     }
 }
@@ -180,6 +188,41 @@ fn block_body_always_terminates(node: &Node, source: &str) -> bool {
         }
     }
     false
+}
+
+/// Check if a try_table always terminates.
+///
+/// A try_table with catch clauses NEVER "always terminates" in the control flow sense,
+/// because catch clauses can branch to outer labels, providing alternative exit paths.
+/// Even if the try_table body always terminates (return/unreachable), the catch clause
+/// can still branch to an outer block, allowing code after that block to be reached.
+///
+/// For example:
+/// ```wat
+/// (block $outer (result i32)
+///   (try_table (result i32) (catch $tag $outer)
+///     (return)))  ;; body terminates, but catch branches to $outer
+/// (i32.const -1)  ;; reachable via catch branch to $outer
+/// ```
+fn try_table_always_terminates(node: &Node, source: &str) -> bool {
+    // Check if this try_table has any catch clauses
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        #[cfg(feature = "native")]
+        let child_kind = child.kind();
+        #[cfg(all(feature = "wasm", not(feature = "native")))]
+        let child_kind = child.kind();
+
+        // If we find any catch clause, the try_table doesn't "always terminate"
+        // because the catch can branch to an outer label
+        if child_kind == "catch_clause" {
+            return false;
+        }
+    }
+
+    // No catch clauses found - check if the body terminates
+    // (This is an edge case; try_table without catch clauses is unusual)
+    block_body_always_terminates(node, source)
 }
 
 /// Check if an if/if_block always terminates (both branches must exist and terminate)


### PR DESCRIPTION
Control flow analysis now correctly handles `try_table` with catch clauses that branch to outer blocks.

**The Problem**
When a `try_table` body always terminates (e.g., with `return` or `unreachable`), the previous analysis didn't account for catch clauses that could branch to outer labels. This caused false positive errors.

**The Solution**
A `try_table` with catch clauses never "always terminates" because catch clauses provide alternative exit paths via branches to outer labels.

**Changes**
- Add `try_table_always_terminates()` function in `termination.rs`
- Handle both `expr1_try_table` (folded) and `block_try_table` (linear) formats
- Add 3 regression tests

Fixes #108