### PR TITLE
feat(wasm): add rename, signature help, and fix diagnostic ranges

### DIFF
--- a/src/wasm/api.rs
+++ b/src/wasm/api.rs
@@ -16,7 +16,10 @@ use crate::parser::parse_document_from_tree;
 use crate::symbol_lookup::{find_symbol_definition_range, IndexContext};
 use crate::symbols::{SymbolTable, ValueType};
 use crate::ts_facade::{self, Language, Parser, Query, Tree};
-use crate::utils::{get_word_at_position, is_word_char};
+use crate::utils::{
+    format_function_signature, get_line_at_position, get_word_at_position, is_word_char,
+    node_at_position,
+};
 
 /// The highlights.scm query for syntax highlighting
 const HIGHLIGHTS_QUERY: &str =
@@ -281,6 +284,135 @@ impl WatLSP {
             js_array.push(&reference_to_js(&range));
         }
         js_array.into()
+    }
+
+    /// Prepare rename: check if position has a renamable symbol and return its range
+    /// Returns null if the symbol cannot be renamed, otherwise returns { range, placeholder }
+    #[wasm_bindgen(js_name = prepareRename)]
+    pub fn prepare_rename(&self, line: u32, col: u32) -> JsValue {
+        let symbols = match &self.symbols {
+            Some(s) => s,
+            None => return JsValue::NULL,
+        };
+
+        let tree = match &self.tree {
+            Some(t) => t,
+            None => return JsValue::NULL,
+        };
+
+        let position = Position::new(line, col);
+
+        // Get word at position
+        let word = match get_word_at_position(&self.document, position) {
+            Some(w) => w,
+            None => return JsValue::NULL,
+        };
+
+        // Only named symbols (starting with $) can be renamed
+        if !word.starts_with('$') {
+            return JsValue::NULL;
+        }
+
+        // Check if this is a valid symbol that exists in the symbol table
+        let is_valid_symbol = symbols.get_function_by_name(&word).is_some()
+            || symbols.get_global_by_name(&word).is_some()
+            || symbols.get_table_by_name(&word).is_some()
+            || symbols.get_memory_by_name(&word).is_some()
+            || symbols.get_type_by_name(&word).is_some()
+            || symbols.get_tag_by_name(&word).is_some()
+            || symbols.get_data_by_name(&word).is_some()
+            || symbols.get_elem_by_name(&word).is_some()
+            || symbols
+                .find_function_containing_line(line)
+                .map(|f| {
+                    f.parameters
+                        .iter()
+                        .any(|p| p.name.as_deref() == Some(&word))
+                        || f.locals.iter().any(|l| l.name.as_deref() == Some(&word))
+                })
+                .unwrap_or(false)
+            || symbols
+                .find_function_containing_line(line)
+                .map(|f| f.blocks.iter().any(|b| b.label == word))
+                .unwrap_or(false);
+
+        if !is_valid_symbol {
+            return JsValue::NULL;
+        }
+
+        // Find the identifier node at position to get its exact range
+        if let Some(node) = crate::utils::node_at_position(tree, &self.document, position) {
+            if node.kind() == "identifier" {
+                let range = Range::from_coords(
+                    node.start_position().row as u32,
+                    node.start_position().column as u32,
+                    node.end_position().row as u32,
+                    node.end_position().column as u32,
+                );
+
+                let obj = js_sys::Object::new();
+                js_sys::Reflect::set(&obj, &"range".into(), &range_to_js(&range)).ok();
+                js_sys::Reflect::set(&obj, &"placeholder".into(), &word.into()).ok();
+                return obj.into();
+            }
+        }
+
+        JsValue::NULL
+    }
+
+    /// Rename a symbol at the given position to a new name
+    /// Returns null if rename is not possible, otherwise returns { changes: [{ range, newText }] }
+    #[wasm_bindgen(js_name = rename)]
+    pub fn rename(&self, line: u32, col: u32, new_name: &str) -> JsValue {
+        let symbols = match &self.symbols {
+            Some(s) => s,
+            None => return JsValue::NULL,
+        };
+
+        // Validation: New name MUST start with $
+        if !new_name.starts_with('$') {
+            let error = js_sys::Object::new();
+            js_sys::Reflect::set(
+                &error,
+                &"error".into(),
+                &format!("Invalid name '{}': symbols must start with '$'", new_name).into(),
+            )
+            .ok();
+            return error.into();
+        }
+
+        let position = Position::new(line, col);
+
+        // Get word at position
+        let word = match get_word_at_position(&self.document, position) {
+            Some(w) => w,
+            None => return JsValue::NULL,
+        };
+
+        // Only named symbols can be renamed
+        if !word.starts_with('$') {
+            return JsValue::NULL;
+        }
+
+        // Find all references (including declaration)
+        let refs = find_symbol_references(&word, symbols, &self.document, true);
+
+        if refs.is_empty() {
+            return JsValue::NULL;
+        }
+
+        // Create workspace edit with text edits
+        let edits = js_sys::Array::new();
+        for range in refs {
+            let edit = js_sys::Object::new();
+            js_sys::Reflect::set(&edit, &"range".into(), &range_to_js(&range)).ok();
+            js_sys::Reflect::set(&edit, &"newText".into(), &new_name.into()).ok();
+            edits.push(&edit);
+        }
+
+        let result = js_sys::Object::new();
+        js_sys::Reflect::set(&result, &"changes".into(), &edits).ok();
+        result.into()
     }
 
     /// Get symbol table as HTML for debugging
@@ -567,6 +699,395 @@ impl WatLSP {
 
         js_array.into()
     }
+
+    /// Provide signature help at the given position
+    /// Returns null if no signature help available, otherwise returns:
+    /// { signatures: [{ label, documentation?, parameters: [{ label, documentation? }] }],
+    ///   activeSignature, activeParameter }
+    #[wasm_bindgen(js_name = provideSignatureHelp)]
+    pub fn provide_signature_help(&self, line: u32, col: u32) -> JsValue {
+        let symbols = match &self.symbols {
+            Some(s) => s,
+            None => return JsValue::NULL,
+        };
+
+        let tree = match &self.tree {
+            Some(t) => t,
+            None => return JsValue::NULL,
+        };
+
+        let position = Position::new(line, col);
+
+        // Try AST-based approach first
+        let call_info = if let Some(node) = node_at_position(tree, &self.document, position) {
+            find_function_call_ast(&node, &self.document)
+        } else {
+            None
+        };
+
+        // Fall back to string-based approach for incomplete code
+        let call_info = call_info.or_else(|| {
+            let line_text = get_line_at_position(&self.document, line as usize)?;
+            let line_prefix = &line_text[..col.min(line_text.len() as u32) as usize];
+            find_function_call(line_prefix)
+        });
+
+        let call_info = match call_info {
+            Some(info) => info,
+            None => return JsValue::NULL,
+        };
+
+        match call_info.call_type {
+            CallType::Direct => provide_direct_call_signature_js(symbols, &call_info),
+            CallType::CallRef | CallType::ReturnCallRef => {
+                provide_call_ref_signature_js(symbols, &call_info)
+            }
+        }
+    }
+}
+
+// ============================================================================
+// Signature Help helpers
+// ============================================================================
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum CallType {
+    Direct,        // call $func
+    CallRef,       // call_ref $type
+    ReturnCallRef, // return_call_ref $type
+}
+
+struct CallInfo {
+    name: String,
+    arg_text: String,
+    call_type: CallType,
+}
+
+/// Find function call using AST analysis
+fn find_function_call_ast(node: &crate::ts_facade::Node, document: &str) -> Option<CallInfo> {
+    // Walk up the tree to find a call instruction
+    let mut current = node.clone();
+
+    loop {
+        let kind = current.kind();
+
+        // Check if this is a call instruction
+        if kind == "instr_plain" || kind == "expr1_plain" {
+            let instr_text = &document[current.byte_range()];
+
+            // Determine the call type based on the instruction text
+            let call_type = if instr_text.contains("return_call_ref ") {
+                Some(CallType::ReturnCallRef)
+            } else if instr_text.contains("call_ref ") {
+                Some(CallType::CallRef)
+            } else if instr_text.contains("call ") && !instr_text.contains("call_") {
+                Some(CallType::Direct)
+            } else {
+                None
+            };
+
+            if let Some(call_type) = call_type {
+                // Extract the function/type name from the call instruction
+                let mut name = None;
+                let mut arg_count = 0;
+
+                // Iterate through children to find the function name and count arguments
+                let mut cursor = current.walk();
+                for child in current.children(&mut cursor) {
+                    let child_kind = child.kind();
+
+                    // The function/type name is in an identifier or index node
+                    if child_kind == "index" || child_kind == "identifier" {
+                        if name.is_none() {
+                            // First identifier/index after the operator is the function/type name
+                            name = Some(&document[child.byte_range()]);
+                        } else {
+                            // Subsequent identifiers/indices are arguments
+                            arg_count += 1;
+                        }
+                    }
+                }
+
+                if let Some(func_name) = name {
+                    // Create arg_text with appropriate number of commas
+                    let arg_text = if arg_count > 0 {
+                        vec![","; arg_count - 1].join("")
+                    } else {
+                        String::new()
+                    };
+
+                    return Some(CallInfo {
+                        name: func_name.to_string(),
+                        arg_text,
+                        call_type,
+                    });
+                }
+            }
+        }
+
+        // Move to parent
+        if let Some(parent) = current.parent() {
+            current = parent;
+        } else {
+            break;
+        }
+    }
+
+    None
+}
+
+/// Find function call using string-based analysis (fallback for incomplete code)
+fn find_function_call(line_prefix: &str) -> Option<CallInfo> {
+    let mut depth = 0;
+    let mut paren_pos: Option<usize> = None;
+
+    let chars: Vec<char> = line_prefix.chars().collect();
+
+    // Scan backwards to find the call instruction
+    for i in (0..chars.len()).rev() {
+        match chars[i] {
+            ')' => depth += 1,
+            '(' => {
+                if depth == 0 {
+                    paren_pos = Some(i);
+                    break;
+                } else {
+                    depth -= 1;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let paren_pos = paren_pos?;
+
+    // Now look backwards from paren to find call keyword and function/type name
+    let before_paren = &line_prefix[..paren_pos];
+    let call_pattern = before_paren.trim_end();
+
+    // Try to find return_call_ref first (most specific)
+    if let Some(call_idx) = call_pattern.rfind("return_call_ref ") {
+        let after_call = call_pattern[call_idx + 16..].trim_start();
+        if let Some(name) = extract_name_from_call(after_call) {
+            let arg_text = line_prefix[paren_pos + 1..].to_string();
+            return Some(CallInfo {
+                name,
+                arg_text,
+                call_type: CallType::ReturnCallRef,
+            });
+        }
+    }
+
+    // Try call_ref next
+    if let Some(call_idx) = call_pattern.rfind("call_ref ") {
+        let after_call = call_pattern[call_idx + 9..].trim_start();
+        if let Some(name) = extract_name_from_call(after_call) {
+            let arg_text = line_prefix[paren_pos + 1..].to_string();
+            return Some(CallInfo {
+                name,
+                arg_text,
+                call_type: CallType::CallRef,
+            });
+        }
+    }
+
+    // Finally try regular call (but not call_indirect or call_ref)
+    if let Some(call_idx) = call_pattern.rfind("call ") {
+        let before_call = &call_pattern[..call_idx];
+        if !before_call.ends_with("return_") && !before_call.ends_with('_') {
+            let after_call = call_pattern[call_idx + 5..].trim_start();
+            if let Some(name) = extract_name_from_call(after_call) {
+                let arg_text = line_prefix[paren_pos + 1..].to_string();
+                return Some(CallInfo {
+                    name,
+                    arg_text,
+                    call_type: CallType::Direct,
+                });
+            }
+        }
+    }
+
+    None
+}
+
+/// Extract the function/type name from text after a call keyword
+fn extract_name_from_call(after_call: &str) -> Option<String> {
+    let name_end = after_call
+        .find(|c: char| c.is_whitespace() || c == '(')
+        .unwrap_or(after_call.len());
+
+    let name = after_call[..name_end].to_string();
+    if !name.is_empty() {
+        Some(name)
+    } else {
+        None
+    }
+}
+
+/// Provide signature help for direct function calls (call $func)
+fn provide_direct_call_signature_js(symbols: &SymbolTable, call_info: &CallInfo) -> JsValue {
+    // Look up the function in the symbol table
+    let func = if call_info.name.starts_with('$') {
+        symbols.get_function_by_name(&call_info.name)
+    } else if let Ok(index) = call_info.name.parse::<usize>() {
+        symbols.get_function_by_index(index)
+    } else {
+        None
+    };
+
+    let func = match func {
+        Some(f) => f,
+        None => return JsValue::NULL,
+    };
+
+    // Build signature information
+    let label = format_function_signature(func);
+
+    let parameters = js_sys::Array::new();
+    for param in &func.parameters {
+        let param_label = if let Some(ref name) = param.name {
+            format!("({} {})", name, param.param_type)
+        } else {
+            format!("(param {})", param.param_type)
+        };
+
+        let param_obj = js_sys::Object::new();
+        js_sys::Reflect::set(&param_obj, &"label".into(), &param_label.into()).ok();
+        parameters.push(&param_obj);
+    }
+
+    // Determine which parameter we're currently on based on comma count
+    let active_parameter = call_info.arg_text.matches(',').count() as u32;
+    let clamped_active = active_parameter.min(func.parameters.len() as u32);
+
+    // Build signature object
+    let sig_obj = js_sys::Object::new();
+    js_sys::Reflect::set(&sig_obj, &"label".into(), &label.into()).ok();
+    js_sys::Reflect::set(&sig_obj, &"parameters".into(), &parameters).ok();
+    js_sys::Reflect::set(&sig_obj, &"activeParameter".into(), &clamped_active.into()).ok();
+
+    // Add documentation if function has doc comment
+    if let Some(ref doc) = func.doc_comment {
+        js_sys::Reflect::set(&sig_obj, &"documentation".into(), &doc.clone().into()).ok();
+    }
+
+    let signatures = js_sys::Array::new();
+    signatures.push(&sig_obj);
+
+    // Build result object
+    let result = js_sys::Object::new();
+    js_sys::Reflect::set(&result, &"signatures".into(), &signatures).ok();
+    js_sys::Reflect::set(&result, &"activeSignature".into(), &0u32.into()).ok();
+    js_sys::Reflect::set(&result, &"activeParameter".into(), &clamped_active.into()).ok();
+
+    result.into()
+}
+
+/// Provide signature help for indirect calls via typed function references (call_ref $type)
+fn provide_call_ref_signature_js(symbols: &SymbolTable, call_info: &CallInfo) -> JsValue {
+    use crate::symbols::TypeKind;
+
+    // Look up the type in the symbol table
+    let type_def = if call_info.name.starts_with('$') {
+        symbols.get_type_by_name(&call_info.name)
+    } else if let Ok(index) = call_info.name.parse::<usize>() {
+        symbols.get_type_by_index(index)
+    } else {
+        None
+    };
+
+    let type_def = match type_def {
+        Some(t) => t,
+        None => return JsValue::NULL,
+    };
+
+    // The type must be a function type
+    let (params, results) = match &type_def.kind {
+        TypeKind::Func { params, results } => (params, results),
+        _ => return JsValue::NULL, // Not a function type
+    };
+
+    // Build signature label
+    let call_kind = match call_info.call_type {
+        CallType::CallRef => "call_ref",
+        CallType::ReturnCallRef => "return_call_ref",
+        _ => "call_ref",
+    };
+    let type_index_str = type_def.index.to_string();
+    let type_name = type_def.name.as_deref().unwrap_or(&type_index_str);
+    let params_str = params
+        .iter()
+        .map(|p| p.to_string())
+        .collect::<Vec<_>>()
+        .join(" ");
+    let results_str = results
+        .iter()
+        .map(|r| r.to_string())
+        .collect::<Vec<_>>()
+        .join(" ");
+    let label = format!(
+        "({} {}) (param {}) (result {}) + funcref",
+        call_kind,
+        type_name,
+        if params_str.is_empty() {
+            "none"
+        } else {
+            &params_str
+        },
+        if results_str.is_empty() {
+            "none"
+        } else {
+            &results_str
+        }
+    );
+
+    // Build parameter information
+    let parameters = js_sys::Array::new();
+    for (i, param_type) in params.iter().enumerate() {
+        let param_obj = js_sys::Object::new();
+        let param_label = format!("(param{} {})", i, param_type);
+        js_sys::Reflect::set(&param_obj, &"label".into(), &param_label.into()).ok();
+        parameters.push(&param_obj);
+    }
+
+    // The last argument is always the funcref
+    let funcref_param = js_sys::Object::new();
+    js_sys::Reflect::set(&funcref_param, &"label".into(), &"(funcref)".into()).ok();
+    js_sys::Reflect::set(
+        &funcref_param,
+        &"documentation".into(),
+        &"Function reference to call".into(),
+    )
+    .ok();
+    parameters.push(&funcref_param);
+
+    // Determine which parameter we're currently on
+    let active_parameter = call_info.arg_text.matches(',').count() as u32;
+    let param_count = (params.len() + 1) as u32; // +1 for funcref
+    let clamped_active = active_parameter.min(param_count);
+
+    // Build signature object
+    let sig_obj = js_sys::Object::new();
+    js_sys::Reflect::set(&sig_obj, &"label".into(), &label.into()).ok();
+    js_sys::Reflect::set(&sig_obj, &"parameters".into(), &parameters).ok();
+    js_sys::Reflect::set(&sig_obj, &"activeParameter".into(), &clamped_active.into()).ok();
+
+    let doc = format!(
+        "Indirect call via typed function reference. The last argument must be a function reference of type {}.",
+        type_name
+    );
+    js_sys::Reflect::set(&sig_obj, &"documentation".into(), &doc.into()).ok();
+
+    let signatures = js_sys::Array::new();
+    signatures.push(&sig_obj);
+
+    // Build result object
+    let result = js_sys::Object::new();
+    js_sys::Reflect::set(&result, &"signatures".into(), &signatures).ok();
+    js_sys::Reflect::set(&result, &"activeSignature".into(), &0u32.into()).ok();
+    js_sys::Reflect::set(&result, &"activeParameter".into(), &clamped_active.into()).ok();
+
+    result.into()
 }
 
 /// Convert a completion item to a JavaScript object


### PR DESCRIPTION
Adds missing WASM API features to reach parity with native:

- `prepareRename` and `rename` for symbol renaming
- `provideSignatureHelp` for function call signatures
- Fix diagnostic `end_line` field (was always using start line)