### PR TITLE
fix: export tree-sitter.wasm from package exports

### DIFF
--- a/packages/wat-lsp/package.json
+++ b/packages/wat-lsp/package.json
@@ -16,7 +16,9 @@
     "./wasm": {
       "types": "./dist/wasm/wat_lsp_rust.d.ts",
       "import": "./dist/wasm/wat_lsp_rust.js"
-    }
+    },
+    "./wasm/tree-sitter.wasm": "./dist/wasm/tree-sitter.wasm",
+    "./wasm/wat_lsp_rust_bg.wasm": "./dist/wasm/wat_lsp_rust_bg.wasm"
   },
   "files": [
     "dist",


### PR DESCRIPTION
Add `./wasm/tree-sitter.wasm` to the package.json exports map so consumers can import the tree-sitter WASM binary directly.