### PR TITLE
fix: handle linear if (block_if) in stack validation

### DIFF
--- a/src/diagnostics/semantic_diagnostics.rs
+++ b/src/diagnostics/semantic_diagnostics.rs
@@ -3546,4 +3546,30 @@ mod tests {
             diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
         );
     }
+
+    #[test]
+    fn test_if_return_no_else_linear() {
+        // Linear if without else — return inside if, fallthrough produces value
+        let document = r#"(module
+  (func (param $x i32) (result i32)
+    local.get $x
+    i32.eqz
+    if
+      i32.const 0
+      return
+    end
+    i32.const 1
+  )
+)"#;
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        assert_eq!(
+            diagnostics.len(),
+            0,
+            "Valid linear if/return/end should have no diagnostics, got: {:?}",
+            diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+    }
 }

--- a/src/diagnostics_core/semantic.rs
+++ b/src/diagnostics_core/semantic.rs
@@ -96,6 +96,15 @@ pub fn track_stack_in_instr_list(
                 // Block instructions create a new stack frame
                 // After a block completes, it pushes its result values
                 // But only if the block can actually fall through
+                // Check if this is a block_if (linear if format: if ... end)
+                // which needs to consume a condition value from the stack
+                if contains_block_if(&child) {
+                    if let Err(available) = stack.consume(1) {
+                        let diagnostic =
+                            create_stack_underflow_diagnostic(&child, "if", 1, available);
+                        diagnostics.push(diagnostic);
+                    }
+                }
                 if !sequence_always_terminates(&child, source) {
                     let results = get_block_result_types(&child, source);
                     stack.produce(results);
@@ -179,6 +188,14 @@ fn process_instr_node(
                 process_folded_expr(&child, source, symbols, arity_map, stack, diagnostics);
             }
             "instr_block" | "instr_loop" => {
+                // Check if this is a block_if (linear if format: if ... end)
+                if contains_block_if(&child) {
+                    if let Err(available) = stack.consume(1) {
+                        let diagnostic =
+                            create_stack_underflow_diagnostic(&child, "if", 1, available);
+                        diagnostics.push(diagnostic);
+                    }
+                }
                 if !sequence_always_terminates(&child, source) {
                     let results = get_block_result_types(&child, source);
                     stack.produce(results);
@@ -205,6 +222,22 @@ fn process_instr_node(
             _ => {}
         }
     }
+}
+
+/// Check if an instr_block node contains a block_if child (linear if format)
+fn contains_block_if(node: &Node) -> bool {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        #[cfg(feature = "native")]
+        let kind = child.kind();
+        #[cfg(all(feature = "wasm", not(feature = "native")))]
+        let kind = child.kind();
+
+        if kind == "block_if" {
+            return true;
+        }
+    }
+    false
 }
 
 /// Get the instruction name from an instr_plain node
@@ -1109,8 +1142,9 @@ pub fn get_block_result_types(block_node: &Node, source: &str) -> Vec<ValueType>
         if kind == "block_type" {
             return parse_result_types(&child, source);
         }
-        // Handle block_block, loop_block (linear format), or if_block (both formats)
-        if kind == "block_block" || kind == "loop_block" || kind == "if_block" {
+        // Handle block_block, loop_block (linear format), if_block/block_if (both formats)
+        if kind == "block_block" || kind == "loop_block" || kind == "if_block" || kind == "block_if"
+        {
             let mut inner_cursor = child.walk();
             for inner_child in child.children(&mut inner_cursor) {
                 #[cfg(feature = "native")]

--- a/src/diagnostics_core/termination.rs
+++ b/src/diagnostics_core/termination.rs
@@ -76,7 +76,8 @@ pub fn sequence_always_terminates(node: &Node, source: &str) -> bool {
         "instr_loop" | "loop_block" => block_body_always_terminates(node, source),
 
         // If: terminates only if BOTH then AND else branches exist AND both terminate
-        "instr_if" | "if_block" => if_always_terminates(node, source),
+        // block_if is the linear format (if ... else ... end)
+        "instr_if" | "if_block" | "block_if" => if_always_terminates(node, source),
 
         // Expr (folded expression): check inner content
         "expr" => {
@@ -175,8 +176,14 @@ fn block_body_always_terminates(node: &Node, source: &str) -> bool {
             return sequence_always_terminates(&child, source);
         }
         // For linear format blocks like block_block, loop_block
-        if (child_kind == "block_block" || child_kind == "loop_block" || child_kind == "if_block")
+        if (child_kind == "block_block" || child_kind == "loop_block")
             && block_body_always_terminates(&child, source)
+        {
+            return true;
+        }
+        // block_if and if_block use if-specific termination (need both branches)
+        if (child_kind == "block_if" || child_kind == "if_block")
+            && if_always_terminates(&child, source)
         {
             return true;
         }


### PR DESCRIPTION
## Summary
- Fix false "Type mismatch" diagnostic on linear-format `if ... end` blocks (parsed as `block_if` not `instr_if`)
- Add `block_if` handling in stack condition consumption, termination analysis, and result type extraction
- Add SIMD linear-style example file and regression tests
