### PR TITLE
fix: recognize `call_ref (type $t)` syntax from Typed Function References proposal

### DIFF
--- a/docs/examples/call_ref_type_annotation.wat
+++ b/docs/examples/call_ref_type_annotation.wat
@@ -1,0 +1,67 @@
+;; call_ref / return_call_ref with (type $t) annotation
+;; The Typed Function References proposal allows both forms:
+;;   call_ref $type         - bare index
+;;   call_ref (type $type)  - type annotation
+;; Both are equivalent. The annotation form mirrors call_indirect (type $t).
+
+(module
+  (type $unary (func (param i32) (result i32)))
+  (type $binary (func (param i32 i32) (result i32)))
+
+  ;; --- Basic functions ---
+
+  (func $double (param $x i32) (result i32)
+    (i32.mul (local.get $x) (i32.const 2)))
+
+  (func $add (param $a i32) (param $b i32) (result i32)
+    (i32.add (local.get $a) (local.get $b)))
+
+  ;; --- call_ref with (type ...) annotation (s-expression style) ---
+
+  (func $apply_unary (param $fn (ref $unary)) (param $x i32) (result i32)
+    (call_ref (type $unary) (local.get $x) (local.get $fn)))
+
+  (func $apply_binary (param $fn (ref $binary)) (param $a i32) (param $b i32) (result i32)
+    (call_ref (type $binary) (local.get $a) (local.get $b) (local.get $fn)))
+
+  ;; --- call_ref with (type ...) annotation (linear/stack style) ---
+
+  (func $apply_unary_linear (param $fn (ref $unary)) (param $x i32) (result i32)
+    local.get $x
+    local.get $fn
+    call_ref (type $unary))
+
+  (func $apply_binary_linear (param $fn (ref $binary)) (param $a i32) (param $b i32) (result i32)
+    local.get $a
+    local.get $b
+    local.get $fn
+    call_ref (type $binary))
+
+  ;; --- return_call_ref with (type ...) annotation (tail call) ---
+
+  (func $tail_apply (param $fn (ref $unary)) (param $x i32) (result i32)
+    local.get $x
+    local.get $fn
+    return_call_ref (type $unary))
+
+  ;; --- Mixing both forms in the same module ---
+
+  (func $double_then_add (param $x i32) (param $y i32) (result i32)
+    ;; bare form producing i32, then annotation form consuming it
+    (call_ref (type $binary)
+      (call_ref $unary (local.get $x) (ref.func $double))
+      (local.get $y)
+      (ref.func $add)))
+
+  ;; --- Numeric index works with annotation form ---
+
+  (func $call_by_index (param $fn (ref $unary)) (param $x i32) (result i32)
+    (call_ref (type 0) (local.get $x) (local.get $fn)))
+
+  ;; Exports
+  (export "apply_unary" (func $apply_unary))
+  (export "apply_binary" (func $apply_binary))
+  (export "apply_unary_linear" (func $apply_unary_linear))
+  (export "apply_binary_linear" (func $apply_binary_linear))
+  (export "tail_apply" (func $tail_apply))
+  (export "double_then_add" (func $double_then_add)))

--- a/grammars/tree-sitter-wat/grammar.js
+++ b/grammars/tree-sitter-wat/grammar.js
@@ -378,8 +378,8 @@ module.exports = grammar({
         seq("br_on_cast", $.index, $._heap_type_or_ref, $._heap_type_or_ref),
         seq("br_on_cast_fail", $.index, $._heap_type_or_ref, $._heap_type_or_ref),
         // typed function references
-        seq("call_ref", $.index),
-        seq("return_call_ref", $.index),
+        seq("call_ref", choice($.type_use, $.index)),
+        seq("return_call_ref", choice($.type_use, $.index)),
       ),
 
     _instruction_exception: $ =>

--- a/src/diagnostics/semantic_diagnostics.rs
+++ b/src/diagnostics/semantic_diagnostics.rs
@@ -2182,6 +2182,75 @@ mod tests {
         assert!(operand_errors[0].message.contains("at most 2 operands"));
     }
 
+    #[test]
+    fn test_call_ref_type_use_syntax() {
+        // Issue #124: call_ref (type $t) syntax should be recognized
+        let document = r#"(module
+  (type $t (func (param i32) (result i32)))
+  (func $inc (type $t) (param $x i32) (result i32)
+    local.get $x
+    i32.const 1
+    i32.add)
+  (table 1 funcref)
+  (elem (i32.const 0) $inc)
+
+  (func (export "dispatch") (param $i i32) (param $x i32) (result i32)
+    local.get $i
+    ref.func $inc
+    drop
+    local.get $x
+    call_ref (type $t))
+)"#;
+
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        let errors: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.message.contains("call_ref") || d.message.contains("type"))
+            .collect();
+        assert_eq!(
+            errors.len(),
+            0,
+            "call_ref (type $t) should produce no errors, got: {:?}",
+            errors.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_return_call_ref_type_use_syntax() {
+        // return_call_ref (type $t) should also be recognized
+        let document = r#"(module
+  (type $t (func (param i32) (result i32)))
+  (func $inc (type $t) (param $x i32) (result i32)
+    local.get $x
+    i32.const 1
+    i32.add)
+
+  (func $dispatch (type $t) (param $x i32) (result i32)
+    local.get $x
+    return_call_ref (type $t))
+)"#;
+
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        let errors: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.message.contains("return_call_ref") || d.message.contains("Syntax error"))
+            .collect();
+        assert_eq!(
+            errors.len(),
+            0,
+            "return_call_ref (type $t) should produce no errors, got: {:?}",
+            errors.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+    }
+
     // Atomic operations validation tests
 
     #[test]

--- a/src/diagnostics_core/semantic.rs
+++ b/src/diagnostics_core/semantic.rs
@@ -419,6 +419,20 @@ pub fn get_index_from_node(node: &Node, source: &str) -> Option<String> {
         if kind == "index" || kind == "identifier" {
             return Some(source[child.byte_range()].trim().to_string());
         }
+        // Also check inside type_use nodes (e.g. call_ref (type $t))
+        if kind == "type_use" {
+            let mut inner_cursor = child.walk();
+            for inner_child in child.children(&mut inner_cursor) {
+                #[cfg(feature = "native")]
+                let inner_kind = inner_child.kind();
+                #[cfg(all(feature = "wasm", not(feature = "native")))]
+                let inner_kind = inner_child.kind();
+
+                if inner_kind == "index" || inner_kind == "identifier" {
+                    return Some(source[inner_child.byte_range()].trim().to_string());
+                }
+            }
+        }
         // Also check inside op_index nodes
         if kind.starts_with("op_") {
             let mut inner_cursor = child.walk();

--- a/src/features/signature/mod.rs
+++ b/src/features/signature/mod.rs
@@ -224,6 +224,16 @@ fn find_function_call_ast(node: tree_sitter::Node, document: &str) -> Option<Cal
                             arg_count += 1;
                         }
                     }
+                    // Also check inside type_use nodes (e.g. call_ref (type $t))
+                    if child_kind == "type_use" && name.is_none() {
+                        let mut inner_cursor = child.walk();
+                        for inner_child in child.children(&mut inner_cursor) {
+                            if inner_child.kind() == "index" || inner_child.kind() == "identifier" {
+                                name = Some(&document[inner_child.byte_range()]);
+                                break;
+                            }
+                        }
+                    }
                 }
 
                 if let Some(func_name) = name {
@@ -335,6 +345,18 @@ fn find_function_call(line_prefix: &str) -> Option<CallInfo> {
 
 /// Extract the function/type name from text after a call keyword
 fn extract_name_from_call(after_call: &str) -> Option<String> {
+    let trimmed = after_call.trim_start();
+    // Handle (type $t) annotation form
+    if trimmed.starts_with("(type ") || trimmed.starts_with("(type\t") {
+        let inner = &trimmed[6..]; // skip "(type "
+        let name_end = inner
+            .find(|c: char| c == ')' || c.is_whitespace())
+            .unwrap_or(inner.len());
+        let name = inner[..name_end].trim().to_string();
+        if !name.is_empty() {
+            return Some(name);
+        }
+    }
     // Extract function name/index (stop at whitespace or paren)
     let name_end = after_call
         .find(|c: char| c.is_whitespace() || c == '(')

--- a/src/features/signature/tests.rs
+++ b/src/features/signature/tests.rs
@@ -411,3 +411,38 @@ fn test_call_type_enum() {
     };
     assert_eq!(call_info_return_ref.call_type, CallType::ReturnCallRef);
 }
+
+// Tests for (type $t) annotation form
+
+#[test]
+fn test_find_function_call_call_ref_type_use() {
+    let line = "call_ref (type $binop)(";
+    let info = find_function_call(line);
+    assert!(info.is_some());
+
+    let call = info.unwrap();
+    assert_eq!(call.name, "$binop");
+    assert_eq!(call.call_type, CallType::CallRef);
+}
+
+#[test]
+fn test_find_function_call_return_call_ref_type_use() {
+    let line = "return_call_ref (type $binop)(";
+    let info = find_function_call(line);
+    assert!(info.is_some());
+
+    let call = info.unwrap();
+    assert_eq!(call.name, "$binop");
+    assert_eq!(call.call_type, CallType::ReturnCallRef);
+}
+
+#[test]
+fn test_extract_name_from_call_type_use() {
+    assert_eq!(
+        extract_name_from_call("(type $binop)"),
+        Some("$binop".to_string())
+    );
+    assert_eq!(extract_name_from_call("(type 0)"), Some("0".to_string()));
+    // Bare index form should still work
+    assert_eq!(extract_name_from_call("$binop"), Some("$binop".to_string()));
+}

--- a/src/wasm/api.rs
+++ b/src/wasm/api.rs
@@ -806,6 +806,16 @@ fn find_function_call_ast(node: &crate::ts_facade::Node, document: &str) -> Opti
                             arg_count += 1;
                         }
                     }
+                    // Also check inside type_use nodes (e.g. call_ref (type $t))
+                    if child_kind == "type_use" && name.is_none() {
+                        let mut inner_cursor = child.walk();
+                        for inner_child in child.children(&mut inner_cursor) {
+                            if inner_child.kind() == "index" || inner_child.kind() == "identifier" {
+                                name = Some(&document[inner_child.byte_range()]);
+                                break;
+                            }
+                        }
+                    }
                 }
 
                 if let Some(func_name) = name {
@@ -912,6 +922,19 @@ fn find_function_call(line_prefix: &str) -> Option<CallInfo> {
 
 /// Extract the function/type name from text after a call keyword
 fn extract_name_from_call(after_call: &str) -> Option<String> {
+    let trimmed = after_call.trim_start();
+    // Handle (type $t) annotation form
+    if trimmed.starts_with("(type ") || trimmed.starts_with("(type\t") {
+        let inner = &trimmed[6..]; // skip "(type "
+        let name_end = inner
+            .find(|c: char| c == ')' || c.is_whitespace())
+            .unwrap_or(inner.len());
+        let name = inner[..name_end].trim().to_string();
+        if !name.is_empty() {
+            return Some(name);
+        }
+    }
+    // Extract function name/index (stop at whitespace or paren)
     let name_end = after_call
         .find(|c: char| c.is_whitespace() || c == '(')
         .unwrap_or(after_call.len());


### PR DESCRIPTION
## Summary

Fixes #124. The Typed Function References proposal (Phase 4) specifies `call_ref (type $t)` and `return_call_ref (type $t)` syntax, but the grammar only accepted the bare-index form `call_ref $t`.

- Update tree-sitter grammar to accept `type_use` for `call_ref` / `return_call_ref`
- Handle `type_use` nodes in index extraction, signature help (AST + text-based)
- Add 5 new tests including the exact reproduction from the issue
