### PR TITLE
ci: separate wrong results into dedicated summary section

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,14 +108,13 @@ jobs:
         shell: bash
         run: |
           cargo build --features native --release --bin wat-check
-          failed=0
+          wrong=()
 
           echo "=== Checking valid examples (should pass) ==="
           for file in docs/examples/*.wat; do
             echo "Checking $file..."
             if ! ./target/release/wat-check "$file"; then
-              echo "ERROR: $file has diagnostics (expected none)"
-              failed=1
+              wrong+=("FAIL $file (expected pass, got fail)")
             fi
           done
 
@@ -124,19 +123,22 @@ jobs:
           for file in docs/examples/invalid/*.wat; do
             echo "Checking $file..."
             if ./target/release/wat-check "$file" 2>/dev/null; then
-              echo "ERROR: $file passed validation (expected diagnostics)"
-              failed=1
+              wrong+=("PASS $file (expected fail, got pass)")
             else
               echo "OK: $file correctly rejected"
             fi
           done
 
-          if [ $failed -eq 1 ]; then
+          echo ""
+          if [ ${#wrong[@]} -gt 0 ]; then
+            echo "=== Wrong results (${#wrong[@]}) ==="
+            for entry in "${wrong[@]}"; do
+              echo "  $entry"
+            done
             echo ""
             echo "Example validation failed"
             exit 1
           fi
-          echo ""
           echo "All example files validated correctly"
 
   clippy:
@@ -437,14 +439,13 @@ jobs:
       - name: Validate example files with wat-check-wasm
         shell: bash
         run: |
-          failed=0
+          wrong=()
 
           echo "=== Checking valid examples (should pass) ==="
           for file in docs/examples/*.wat; do
             echo "Checking $file..."
             if ! node packages/wat-lsp/bin/wat-check-wasm.js "$file" 2>/dev/null; then
-              echo "ERROR: $file has diagnostics (expected none)"
-              failed=1
+              wrong+=("FAIL $file (expected pass, got fail)")
             fi
           done
 
@@ -453,19 +454,22 @@ jobs:
           for file in docs/examples/invalid/*.wat; do
             echo "Checking $file..."
             if node packages/wat-lsp/bin/wat-check-wasm.js "$file" 2>/dev/null; then
-              echo "ERROR: $file passed validation (expected diagnostics)"
-              failed=1
+              wrong+=("PASS $file (expected fail, got pass)")
             else
               echo "OK: $file correctly rejected"
             fi
           done
 
-          if [ $failed -eq 1 ]; then
+          echo ""
+          if [ ${#wrong[@]} -gt 0 ]; then
+            echo "=== Wrong results (${#wrong[@]}) ==="
+            for entry in "${wrong[@]}"; do
+              echo "  $entry"
+            done
             echo ""
             echo "WASM example validation failed"
             exit 1
           fi
-          echo ""
           echo "All example files validated correctly (WASM)"
 
   playground:


### PR DESCRIPTION
Collect mismatched validation results into a dedicated "Wrong results" section in both `wat-check` and `wat-check-wasm` CI steps, making it easy to spot which files gave unexpected results (pass-but-should-fail or fail-but-should-pass).