### PR TITLE
fix: resolve type references in parser so `(type $t)` functions get return-type validation

### DIFF
--- a/docs/examples/invalid/return_type_use_mismatch.wat
+++ b/docs/examples/invalid/return_type_use_mismatch.wat
@@ -1,0 +1,27 @@
+;; Return type mismatch when using (type $t) syntax
+;; Functions that reference a type definition via (type $t) instead of inline
+;; (result ...) clauses are now validated against the referenced type's signature.
+;;
+;; Expected error: Type mismatch: function returns i32 but declared as i64
+
+(module
+  ;; Define a function type that takes no params and returns i64
+  (type $returns_i64 (func (result i64)))
+
+  ;; This function references the type but returns the wrong type
+  (func $wrong_return (type $returns_i64)
+    i32.const 42  ;; ERROR: returns i32 but type $returns_i64 declares i64
+  )
+
+  ;; For comparison: this function correctly satisfies the type
+  (func $correct_return (type $returns_i64)
+    i64.const 42  ;; OK: returns i64 as declared
+  )
+
+  ;; Also works with numeric type indices
+  (type $binary_op (func (param i32 i32) (result i32)))
+
+  (func $bad_binary (type $binary_op)
+    i64.const 1  ;; ERROR: returns i64 but type $binary_op declares i32
+  )
+)

--- a/src/diagnostics/semantic_diagnostics.rs
+++ b/src/diagnostics/semantic_diagnostics.rs
@@ -86,19 +86,6 @@ fn unified_tree_walk(
             .map(|f| f.results.as_slice())
             .unwrap_or(&[]);
 
-        // Check if function uses (type $ref) syntax - if so, the symbol table might not
-        // have resolved the return types from the type definition
-        let mut cursor = node.walk();
-        let has_type_use = node.children(&mut cursor).any(|c| c.kind() == "type_use");
-
-        // For return type validation: use Some(results) when we know them, None otherwise
-        let expected_for_validation = if has_type_use && expected_results.is_empty() {
-            // Function uses type reference but symbol table didn't resolve it - skip validation
-            None
-        } else {
-            Some(expected_results)
-        };
-
         let mut cursor = node.walk();
         let mut found_instr_list = false;
         for child in node.children(&mut cursor) {
@@ -107,7 +94,7 @@ fn unified_tree_walk(
                     &child,
                     source,
                     symbols,
-                    expected_for_validation,
+                    Some(expected_results),
                     diagnostics,
                 );
                 found_instr_list = true;
@@ -116,8 +103,7 @@ fn unified_tree_walk(
         }
 
         // If no instr_list but function expects return values, report error
-        // Skip this check if function uses type_use (we don't know the expected results)
-        if !found_instr_list && !expected_results.is_empty() && !has_type_use {
+        if !found_instr_list && !expected_results.is_empty() {
             let range = node_to_lsp_range(&node);
             diagnostics.push(Diagnostic {
                 range,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -508,7 +508,9 @@ fn extract_functions_with_offset(
                     let mut field_cursor = module_child.walk();
                     for field_child in module_child.children(&mut field_cursor) {
                         if field_child.kind() == "module_field_func" {
-                            if let Some(func) = extract_function(&field_child, source, func_index) {
+                            if let Some(func) =
+                                extract_function(&field_child, source, func_index, symbol_table)
+                            {
                                 // Skip duplicates from error recovery
                                 let is_duplicate = if let Some(ref name) = func.name {
                                     seen_names.contains(name)
@@ -536,7 +538,9 @@ fn extract_functions_with_offset(
             let mut field_cursor = child.walk();
             for field_child in child.children(&mut field_cursor) {
                 if field_child.kind() == "module_field_func" {
-                    if let Some(func) = extract_function(&field_child, source, func_index) {
+                    if let Some(func) =
+                        extract_function(&field_child, source, func_index, symbol_table)
+                    {
                         let is_duplicate = if let Some(ref name) = func.name {
                             seen_names.contains(name)
                         } else {
@@ -670,7 +674,12 @@ fn extract_doc_comment(node: &Node, source: &str) -> Option<String> {
 }
 
 /// Extract a single function from a func node
-fn extract_function(func_node: &Node, source: &str, index: usize) -> Option<Function> {
+fn extract_function(
+    func_node: &Node,
+    source: &str,
+    index: usize,
+    symbol_table: &SymbolTable,
+) -> Option<Function> {
     let range = func_node.range();
 
     // Try to find function name and its range
@@ -684,10 +693,21 @@ fn extract_function(func_node: &Node, source: &str, index: usize) -> Option<Func
     };
 
     // Extract parameters, results, locals, and blocks
-    let parameters = extract_parameters(func_node, source);
-    let results = extract_results(func_node, source);
+    let mut parameters = extract_parameters(func_node, source);
+    let mut results = extract_results(func_node, source);
     let locals = extract_locals(func_node, source);
     let blocks = extract_blocks(func_node, source);
+
+    // If results (and/or params) are empty but there's a (type $t) reference, resolve from the type
+    if results.is_empty() {
+        if let Some((type_params, type_results)) = resolve_type_use(func_node, source, symbol_table)
+        {
+            results = type_results;
+            if parameters.is_empty() {
+                parameters = type_params;
+            }
+        }
+    }
 
     // Extract doc comment from preceding comments
     let doc_comment = extract_doc_comment(func_node, source);
@@ -785,6 +805,55 @@ fn extract_results(func_node: &Node, source: &str) -> Vec<ValueType> {
     }
 
     results
+}
+
+/// Resolve params and results from a `(type $t)` reference on a function node.
+/// Returns `Some((params, results))` if a type_use was found and resolved.
+fn resolve_type_use(
+    func_node: &Node,
+    source: &str,
+    symbol_table: &SymbolTable,
+) -> Option<(Vec<Parameter>, Vec<ValueType>)> {
+    let mut cursor = func_node.walk();
+    for child in func_node.children(&mut cursor) {
+        if child.kind() == "type_use" {
+            let mut type_cursor = child.walk();
+            for type_child in child.children(&mut type_cursor) {
+                #[cfg(feature = "native")]
+                let kind = type_child.kind();
+                #[cfg(all(feature = "wasm", not(feature = "native")))]
+                let kind = type_child.kind();
+
+                if kind == "index" || kind == "identifier" {
+                    let type_ref = source[type_child.byte_range()].trim();
+                    let type_def = if let Some(td) = symbol_table.get_type_by_name(type_ref) {
+                        Some(td)
+                    } else if let Ok(idx) = type_ref.parse::<usize>() {
+                        symbol_table.get_type_by_index(idx)
+                    } else {
+                        None
+                    };
+
+                    if let Some(td) = type_def {
+                        if let TypeKind::Func { params, results } = &td.kind {
+                            let parameters = params
+                                .iter()
+                                .enumerate()
+                                .map(|(i, vt)| Parameter {
+                                    name: None,
+                                    param_type: vt.clone(),
+                                    index: i,
+                                    range: None,
+                                })
+                                .collect();
+                            return Some((parameters, results.clone()));
+                        }
+                    }
+                }
+            }
+        }
+    }
+    None
 }
 
 /// Extract local variables from a function node

--- a/src/wasm/api.rs
+++ b/src/wasm/api.rs
@@ -1404,31 +1404,14 @@ fn walk_tree_for_diagnostics(
             .map(|f| f.results.as_slice())
             .unwrap_or(&[]);
 
-        // Check if function uses (type $ref) syntax - if so, the symbol table might not
-        // have resolved the return types from the type definition
-        let mut cursor = node.walk();
-        let has_type_use = node.children(&mut cursor).any(|c| c.kind() == "type_use");
-
-        // For return type validation: use Some(results) when we know them, None otherwise
-        let expected_for_validation = if has_type_use && expected_results.is_empty() {
-            // Function uses type reference but symbol table didn't resolve it - skip validation
-            None
-        } else {
-            Some(expected_results)
-        };
-
         // Find the instr_list child and track stack using shared core
         let mut cursor = node.walk();
         let mut found_instr_list = false;
         for child in node.children(&mut cursor) {
             if child.kind() == "instr_list" {
                 // Use shared core function and convert diagnostics
-                let core_diagnostics = core_track_stack_in_instr_list(
-                    &child,
-                    source,
-                    symbols,
-                    expected_for_validation,
-                );
+                let core_diagnostics =
+                    core_track_stack_in_instr_list(&child, source, symbols, Some(expected_results));
                 for diag in core_diagnostics {
                     diagnostics.push(diag.into());
                 }
@@ -1438,8 +1421,7 @@ fn walk_tree_for_diagnostics(
         }
 
         // If no instr_list but function expects return values, report error
-        // Skip this check if function uses type_use (we don't know the expected results)
-        if !found_instr_list && !expected_results.is_empty() && !has_type_use {
+        if !found_instr_list && !expected_results.is_empty() {
             diagnostics.push(WasmDiagnostic {
                 line: node.start_position().row as u32,
                 character: node.start_position().column as u32,

--- a/tests/diagnostic_corpus/type_use_return_mismatch.expected.json
+++ b/tests/diagnostic_corpus/type_use_return_mismatch.expected.json
@@ -1,0 +1,11 @@
+{
+  "description": "Return type mismatch when function uses (type $t) syntax",
+  "diagnostics": [
+    {
+      "line": 4,
+      "message_contains": "Type mismatch",
+      "message_contains_all": ["i32", "i64"],
+      "severity": 1
+    }
+  ]
+}

--- a/tests/diagnostic_corpus/type_use_return_mismatch.wat
+++ b/tests/diagnostic_corpus/type_use_return_mismatch.wat
@@ -1,0 +1,5 @@
+;; Function using (type $t) should still validate return types
+(module
+  (type $t (func (result i64)))
+  (func $f (type $t)
+    (i32.const 42)))


### PR DESCRIPTION
Fixes #126. When a function uses `(type $t)` without explicit `(result ...)` clauses, the parser now resolves the type reference to populate params/results from the type definition. This removes the workarounds that were skipping return-type validation for type-use functions.

- Add `resolve_type_use()` in `parser.rs` to look up type definitions from the symbol table
- Remove `has_type_use` skip-validation workarounds in both native and WASM diagnostic paths
- Add diagnostic corpus test for the type-use return mismatch case