### PR TITLE
fix: count call_indirect argument values as stack operands

### DIFF
--- a/docs/examples/call_indirect.wat
+++ b/docs/examples/call_indirect.wat
@@ -1,0 +1,67 @@
+;; Indirect Calls (call_indirect)
+;; Demonstrates call_indirect in both linear and folded style,
+;; with varying parameter counts.
+
+(module
+  ;; Function type signatures
+  (type $void_to_i32 (func (result i32)))
+  (type $unary (func (param i32) (result i32)))
+  (type $binary (func (param i32 i32) (result i32)))
+
+  ;; A table of functions
+  (table 4 funcref)
+
+  ;; Populate the table
+  (elem (i32.const 0) func $forty_two $double $add $square)
+
+  ;; Target functions
+  (func $forty_two (result i32)
+    i32.const 42)
+
+  (func $double (param $x i32) (result i32)
+    (i32.mul (local.get $x) (i32.const 2)))
+
+  (func $add (param $a i32) (param $b i32) (result i32)
+    (i32.add (local.get $a) (local.get $b)))
+
+  (func $square (param $x i32) (result i32)
+    (i32.mul (local.get $x) (local.get $x)))
+
+  ;; --- Linear (unfolded) style ---
+
+  ;; No-param call: just the table index on the stack
+  (func $linear_nullary (export "linear_nullary") (result i32)
+    i32.const 0                        ;; table index -> $forty_two
+    call_indirect (type $void_to_i32))
+
+  ;; One-param call: arg + table index
+  (func $linear_unary (export "linear_unary") (param $x i32) (result i32)
+    local.get $x                       ;; argument
+    i32.const 1                        ;; table index -> $double
+    call_indirect (type $unary))
+
+  ;; Two-param call: arg, arg, table index
+  (func $linear_binary (export "linear_binary") (param $a i32) (param $b i32) (result i32)
+    local.get $a
+    local.get $b
+    i32.const 2                        ;; table index -> $add
+    call_indirect (type $binary))
+
+  ;; --- Folded (S-expression) style ---
+
+  (func $folded_nullary (export "folded_nullary") (result i32)
+    (call_indirect (type $void_to_i32)
+      (i32.const 0)))                  ;; table index -> $forty_two
+
+  (func $folded_unary (export "folded_unary") (param $x i32) (result i32)
+    (call_indirect (type $unary)
+      (local.get $x)                   ;; argument
+      (i32.const 3)))                  ;; table index -> $square
+
+  (func $folded_binary (export "folded_binary") (param $a i32) (param $b i32) (result i32)
+    (call_indirect (type $binary)
+      (local.get $a)
+      (local.get $b)
+      (i32.const 2)))                  ;; table index -> $add
+
+)

--- a/src/diagnostics/semantic_diagnostics.rs
+++ b/src/diagnostics/semantic_diagnostics.rs
@@ -3780,4 +3780,83 @@ mod tests {
             "Block with insufficient outer stack values should produce underflow error"
         );
     }
+
+    #[test]
+    fn test_call_indirect_pops_args_and_table_index() {
+        // Issue #121: call_indirect should pop N params + 1 table index
+        let document = r#"(module
+  (type $sig (func (param i32) (result i32)))
+  (func $f (type $sig) (param $x i32) (result i32) local.get $x)
+  (table 1 funcref)
+  (elem (i32.const 0) $f)
+
+  (func (export "go") (param $n i32) (result i32)
+    i32.const 0
+    local.get $n
+    call_indirect (type $sig))
+)"#;
+
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        assert_eq!(
+            diagnostics.len(),
+            0,
+            "call_indirect with correct stack should have no errors, got: {:?}",
+            diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_call_indirect_folded_pops_args_and_table_index() {
+        // Folded form of call_indirect should also count operands correctly
+        let document = r#"(module
+  (type $sig (func (param i32) (result i32)))
+  (table 1 funcref)
+
+  (func (export "go") (param $n i32) (result i32)
+    (call_indirect (type $sig) (i32.const 0) (local.get $n)))
+)"#;
+
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        assert_eq!(
+            diagnostics.len(),
+            0,
+            "Folded call_indirect with correct operands should have no errors, got: {:?}",
+            diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_call_indirect_multi_param() {
+        // call_indirect with multi-param type should pop all params + table index
+        let document = r#"(module
+  (type $binop (func (param i32 i32) (result i32)))
+  (table 1 funcref)
+
+  (func (export "go") (result i32)
+    i32.const 10
+    i32.const 20
+    i32.const 0
+    call_indirect (type $binop))
+)"#;
+
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        assert_eq!(
+            diagnostics.len(),
+            0,
+            "call_indirect with 2 params + table index should have no errors, got: {:?}",
+            diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+    }
 }

--- a/src/diagnostics_core/semantic.rs
+++ b/src/diagnostics_core/semantic.rs
@@ -168,6 +168,10 @@ pub fn track_stack_in_instr_list(
                     &mut diagnostics,
                 );
             }
+            "instr_list_call" => {
+                // Linear call_indirect/return_call_indirect - consume args + table index, produce results
+                process_call_indirect_node(&child, source, symbols, &mut stack, &mut diagnostics);
+            }
             _ => {
                 // Other node types (comments, etc.) - ignore
             }
@@ -281,6 +285,10 @@ fn process_instr_node(
                 // Folded call - consume stack operands and produce results
                 process_folded_expr(&child, source, symbols, arity_map, stack, diagnostics);
             }
+            "instr_list_call" => {
+                // Linear call_indirect/return_call_indirect
+                process_call_indirect_node(&child, source, symbols, stack, diagnostics);
+            }
             _ => {}
         }
     }
@@ -340,6 +348,39 @@ pub fn get_instruction_name(instr_node: &Node, source: &str) -> Option<String> {
     // Fallback: get the text of the first token
     let text = &source[instr_node.byte_range()];
     text.split_whitespace().next().map(|s| s.to_string())
+}
+
+/// Process a linear call_indirect/return_call_indirect node (instr_list_call)
+/// Consumes N params + 1 table index from the stack and produces result types
+fn process_call_indirect_node(
+    node: &Node,
+    source: &str,
+    symbols: &SymbolTable,
+    stack: &mut StackState,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    // Determine instruction name from the first token
+    let text = &source[node.byte_range()];
+    let instr_name = text.split_whitespace().next().unwrap_or("call_indirect");
+
+    if is_terminating_instruction(instr_name) {
+        stack.mark_uncertain();
+        return;
+    }
+
+    // Get operand count: N params + 1 table index
+    let operand_count = get_dynamic_operand_count(node, instr_name, symbols, source);
+    if operand_count > 0 {
+        if let Err(available) = stack.consume(operand_count) {
+            let diagnostic =
+                create_stack_underflow_diagnostic(node, instr_name, operand_count, available);
+            diagnostics.push(diagnostic);
+        }
+    }
+
+    // Produce result types
+    let result_types = get_call_indirect_result_types(node, symbols, source);
+    stack.produce(result_types);
 }
 
 /// Process an instruction: consume operands, check for underflow, produce results
@@ -425,6 +466,23 @@ pub fn get_dynamic_operand_count(
                 }
             }
             1 // At least the funcref
+        }
+        "call_indirect" | "return_call_indirect" => {
+            // Get type index and look up parameter count + 1 for table index
+            if let Some(type_ref) = get_index_from_node(node, source) {
+                if let Some(type_def) = symbols.get_type_by_name(&type_ref) {
+                    if let TypeKind::Func { params, .. } = &type_def.kind {
+                        return params.len() + 1; // params + table index
+                    }
+                } else if let Ok(idx) = type_ref.parse::<usize>() {
+                    if let Some(type_def) = symbols.get_type_by_index(idx) {
+                        if let TypeKind::Func { params, .. } = &type_def.kind {
+                            return params.len() + 1;
+                        }
+                    }
+                }
+            }
+            1 // At least the table index
         }
         "struct.new" => {
             // Get type and look up field count

--- a/src/instruction_metadata.rs
+++ b/src/instruction_metadata.rs
@@ -174,7 +174,15 @@ pub fn get_instruction_arity_map() -> HashMap<&'static str, InstructionArity> {
         InstructionArity::dynamic(1, usize::MAX, "label indices", 0),
     ); // terminates - always branches
     map.insert("call", InstructionArity::dynamic(1, 1, "function index", 0)); // produces depend on function signature (set to 0, handled dynamically)
-                                                                              // return can pass values for functions with result types
+    map.insert(
+        "call_indirect",
+        InstructionArity::dynamic(1, 1, "type index", 0),
+    ); // args + table index -> dynamic results
+    map.insert(
+        "return_call_indirect",
+        InstructionArity::dynamic(1, 1, "type index", 0),
+    ); // args + table index -> dynamic results
+       // return can pass values for functions with result types
     map.insert("return", InstructionArity::dynamic(0, 0, "", 0)); // terminates
     map.insert("unreachable", InstructionArity::nullary()); // terminates
     map.insert("nop", InstructionArity::nullary());


### PR DESCRIPTION
## Summary

`call_indirect` was not popping argument values from the stack, only the table index. This caused false type-mismatch errors on any nontrivial `call_indirect` usage.

- Add `instr_list_call` node handling in both stack tracking code paths
- Add `call_indirect`/`return_call_indirect` to dynamic operand count logic (params + 1 table index)
- Add arity map entries for both instructions
- Add example file and tests covering linear, folded, and multi-param forms

Fixes #121