### PR TITLE
Fix call_indirect trailing instr swallowed by grammar ambiguity (#132)

### DIFF
--- a/docs/examples/call_indirect_chained.wat
+++ b/docs/examples/call_indirect_chained.wat
@@ -1,0 +1,80 @@
+;; Chained Indirect Calls
+;; Demonstrates chaining multiple linear call_indirect instructions,
+;; where the result of one feeds into the next (pipeline pattern).
+;; Related: issue #132
+
+(module
+  ;; Function type signatures
+  (type $unary (func (param i32) (result i32)))
+  (type $binary (func (param i32 i32) (result i32)))
+
+  ;; Function tables
+  (table 5 funcref)
+  (elem (i32.const 0) func $double $square $negate $inc $add)
+
+  ;; Target functions
+  (func $double (param $x i32) (result i32)
+    (i32.mul (local.get $x) (i32.const 2)))
+
+  (func $square (param $x i32) (result i32)
+    (i32.mul (local.get $x) (local.get $x)))
+
+  (func $negate (param $x i32) (result i32)
+    (i32.sub (i32.const 0) (local.get $x)))
+
+  (func $inc (param $x i32) (result i32)
+    (i32.add (local.get $x) (i32.const 1)))
+
+  (func $add (param $a i32) (param $b i32) (result i32)
+    (i32.add (local.get $a) (local.get $b)))
+
+  ;; --- Chained linear call_indirect ---
+
+  ;; Two chained unary calls: double then square
+  ;; Stack: $x -> [i32] -> [i32, i32] -> call_indirect -> [i32] -> [i32, i32] -> call_indirect -> [i32]
+  (func (export "double_then_square") (param $x i32) (result i32)
+    local.get $x
+    i32.const 0                        ;; table index -> $double
+    call_indirect (type $unary)
+    i32.const 1                        ;; table index -> $square
+    call_indirect (type $unary))
+
+  ;; Three chained unary calls: double, negate, increment
+  (func (export "pipeline3") (param $x i32) (result i32)
+    local.get $x
+    i32.const 0                        ;; table index -> $double
+    call_indirect (type $unary)
+    i32.const 2                        ;; table index -> $negate
+    call_indirect (type $unary)
+    i32.const 3                        ;; table index -> $inc
+    call_indirect (type $unary))
+
+  ;; Chain with a binary call at the end: double two values, then add them
+  (func (export "double_both_and_add") (param $a i32) (param $b i32) (result i32)
+    local.get $a
+    i32.const 0                        ;; table index -> $double
+    call_indirect (type $unary)
+    local.get $b
+    i32.const 0                        ;; table index -> $double
+    call_indirect (type $unary)
+    i32.const 4                        ;; table index -> $add
+    call_indirect (type $binary))
+
+  ;; --- Mixed folded and linear chaining ---
+
+  ;; Folded outer, linear inner: square(double(x))
+  (func (export "mixed_chain") (param $x i32) (result i32)
+    (call_indirect (type $unary)
+      (call_indirect (type $unary)
+        (local.get $x)
+        (i32.const 0))                 ;; inner: $double
+      (i32.const 1)))                  ;; outer: $square
+
+  ;; Dynamic pipeline: apply whichever operation the caller picks, twice
+  (func (export "apply_twice") (param $x i32) (param $op i32) (result i32)
+    local.get $x
+    local.get $op
+    call_indirect (type $unary)
+    local.get $op
+    call_indirect (type $unary))
+)

--- a/src/diagnostics/semantic_diagnostics.rs
+++ b/src/diagnostics/semantic_diagnostics.rs
@@ -3859,4 +3859,38 @@ mod tests {
             diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
         );
     }
+
+    #[test]
+    fn test_call_indirect_chained_linear() {
+        // Issue #132: linear call_indirect followed by another instruction should not
+        // produce false type-mismatch diagnostics. The grammar may parse the pair as
+        // a single instr_call node (swallowing the trailing instruction).
+        let document = r#"(module
+  (type $unary (func (param i32) (result i32)))
+  (table 2 funcref)
+  (elem (i32.const 0) func $double $double)
+
+  (func $double (param $x i32) (result i32)
+    (i32.mul (local.get $x) (i32.const 2)))
+
+  (func (export "chain") (param $x i32) (result i32)
+    local.get $x
+    i32.const 0
+    call_indirect (type $unary)
+    i32.const 1
+    call_indirect (type $unary))
+)"#;
+
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        assert_eq!(
+            diagnostics.len(),
+            0,
+            "Chained linear call_indirect should have no errors, got: {:?}",
+            diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+    }
 }

--- a/src/diagnostics_core/semantic.rs
+++ b/src/diagnostics_core/semantic.rs
@@ -158,8 +158,10 @@ pub fn track_stack_in_instr_list(
                 }
             }
             "instr_call" => {
-                // Folded call: (call $fn args...) - consume stack operands and produce results
-                process_folded_expr(
+                // call_indirect/return_call_indirect with trailing instr child.
+                // Handles grammar ambiguity where tree-sitter swallows the next
+                // instruction into this node (issue #132).
+                process_instr_call_node(
                     &child,
                     source,
                     symbols,
@@ -282,8 +284,8 @@ fn process_instr_node(
                 }
             }
             "instr_call" => {
-                // Folded call - consume stack operands and produce results
-                process_folded_expr(&child, source, symbols, arity_map, stack, diagnostics);
+                // call_indirect/return_call_indirect with trailing instr child (issue #132)
+                process_instr_call_node(&child, source, symbols, arity_map, stack, diagnostics);
             }
             "instr_list_call" => {
                 // Linear call_indirect/return_call_indirect
@@ -381,6 +383,36 @@ fn process_call_indirect_node(
     // Produce result types
     let result_types = get_call_indirect_result_types(node, symbols, source);
     stack.produce(result_types);
+}
+
+/// Process an instr_call node (call_indirect/return_call_indirect with trailing instr).
+/// When tree-sitter parses a linear call_indirect followed by another instruction,
+/// it may produce a single instr_call node that swallows the trailing instruction
+/// (grammar ambiguity, see issue #132). We handle this by processing the call_indirect
+/// effects first, then recursively processing the trailing instr child.
+fn process_instr_call_node(
+    node: &Node,
+    source: &str,
+    symbols: &SymbolTable,
+    arity_map: &HashMap<&'static str, InstructionArity>,
+    stack: &mut StackState,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    // Process the call_indirect/return_call_indirect stack effects
+    process_call_indirect_node(node, source, symbols, stack, diagnostics);
+
+    // Find and process the trailing instr child (the swallowed instruction)
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        #[cfg(feature = "native")]
+        let kind = child.kind();
+        #[cfg(all(feature = "wasm", not(feature = "native")))]
+        let kind = child.kind();
+
+        if kind == "instr" {
+            process_instr_node(&child, source, symbols, arity_map, stack, diagnostics);
+        }
+    }
 }
 
 /// Process an instruction: consume operands, check for underflow, produce results


### PR DESCRIPTION
When tree-sitter parses a linear `call_indirect` followed by another instruction in an `instr_list`, it may produce a single `instr_call` node that swallows the trailing instruction. The stack tracker now handles this by processing both the `call_indirect` effects and the trailing `instr` child.

- Add `process_instr_call_node` to handle `instr_call` nodes with their trailing instruction
- Add regression test for chained linear `call_indirect`
- Add `call_indirect_chained.wat` example

closes https://github.com/EmNudge/wat-lsp/issues/132