### PR TITLE
fix: recognize ref.null, ref.func, ref.is_null syntax (#122)

### DIFF
--- a/docs/examples/ref_expressions.wat
+++ b/docs/examples/ref_expressions.wat
@@ -1,0 +1,84 @@
+;; Reference Expressions
+;; Demonstrates ref.null, ref.func, and ref.is_null in various contexts,
+;; including elem segment expression-form initializers (ref.func $id / ref.null func).
+
+(module
+  ;; Types
+  (type $i32_to_i32 (func (param i32) (result i32)))
+
+  ;; Functions to reference
+  (func $inc (param $x i32) (result i32)
+    (i32.add (local.get $x) (i32.const 1)))
+
+  (func $dec (param $x i32) (result i32)
+    (i32.sub (local.get $x) (i32.const 1)))
+
+  (func $negate (param $x i32) (result i32)
+    (i32.sub (i32.const 0) (local.get $x)))
+
+  ;; Table with funcref
+  (table $ops 4 funcref)
+
+  ;; === Elem with expression-form initializers ===
+  ;; Each element is a (ref.func ...) or (ref.null ...) expression
+  (elem (table $ops) (i32.const 0) funcref
+    (ref.func $inc)
+    (ref.func $dec)
+    (ref.func $negate)
+    (ref.null func))
+
+  ;; === ref.func: obtain a function reference ===
+  (func $get_inc (export "get_inc") (result funcref)
+    ref.func $inc)
+
+  (func $get_dec (export "get_dec") (result funcref)
+    ref.func $dec)
+
+  ;; === ref.null: create a null reference ===
+  ;; Using heap types (spec-correct form)
+  (func $null_func (export "null_func") (result funcref)
+    ref.null func)
+
+  (func $null_extern (export "null_extern") (result externref)
+    ref.null extern)
+
+  ;; === ref.is_null: test for null ===
+  (func $check_null (export "check_null") (param $r funcref) (result i32)
+    local.get $r
+    ref.is_null)
+
+  ;; Folded form
+  (func $check_null_folded (export "check_null_folded") (param $r funcref) (result i32)
+    (ref.is_null (local.get $r)))
+
+  ;; === Practical pattern: safe indirect call ===
+  ;; Call a function from the table if present, otherwise return a default
+  (func $safe_call (export "safe_call") (param $idx i32) (param $arg i32) (result i32)
+    (if (result i32) (ref.is_null (table.get $ops (local.get $idx)))
+      (then
+        (i32.const -1))
+      (else
+        (call_indirect $ops (type $i32_to_i32)
+          (local.get $arg)
+          (local.get $idx)))))
+
+  ;; === Global references ===
+  (global $g_func (mut funcref) (ref.null func))
+  (global $g_extern (mut externref) (ref.null extern))
+
+  ;; Store and retrieve function references via globals
+  (func $set_global_fn (export "set_global_fn") (param $fn funcref)
+    (global.set $g_func (local.get $fn)))
+
+  (func $get_global_fn (export "get_global_fn") (result funcref)
+    (global.get $g_func))
+
+  (func $has_global_fn (export "has_global_fn") (result i32)
+    (i32.eqz (ref.is_null (global.get $g_func))))
+
+  ;; === Passive elem segment with ref expressions ===
+  (elem $passive funcref
+    (ref.func $inc)
+    (ref.func $dec)
+    (ref.null func))
+)

--- a/grammars/tree-sitter-wat/grammar.js
+++ b/grammars/tree-sitter-wat/grammar.js
@@ -332,7 +332,7 @@ module.exports = grammar({
 
     _instruction_ref: $ =>
       choice(
-        seq("ref.null", choice($.ref_kind, $.index)),
+        seq("ref.null", choice($.ref_kind, $.ref_type, $.index)),
         seq("ref.func", $.index),
         seq("ref.extern", $.nat),
         $.op_func_bind,
@@ -897,7 +897,7 @@ module.exports = grammar({
     offset_value: $ => seq("offset", imm("="), $.align_offset_value),
 
     // proposal: reference-types
-    ref_kind: $ => /extern|func|struct|array|i31|any|eq|null|none|noextern|nofunc|exn|noexn/,
+    ref_kind: $ => choice("extern", "func", "struct", "array", "i31", "any", "eq", "null", "none", "noextern", "nofunc", "exn", "noexn"),
 
     // Helper for instructions that take either a heap type or (ref ...) form
     _heap_type_or_ref: $ => choice($.ref_kind, $.index, $.ref_type_ref),

--- a/src/diagnostics/tree_sitter_diagnostics.rs
+++ b/src/diagnostics/tree_sitter_diagnostics.rs
@@ -141,6 +141,95 @@ mod tests {
     }
 
     #[test]
+    fn test_ref_null_func_and_ref_is_null() {
+        let document = r#"(module
+  (func $test (result i32)
+    ref.null func
+    ref.is_null
+  )
+)"#;
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let diagnostics = provide_tree_sitter_diagnostics(&tree, document);
+        assert!(
+            diagnostics.is_empty(),
+            "ref.null func + ref.is_null should not produce syntax errors, got: {:?}",
+            diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_ref_null_funcref_lenient() {
+        let document = r#"(module
+  (func $test (result i32)
+    ref.null funcref
+    ref.is_null
+  )
+)"#;
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let diagnostics = provide_tree_sitter_diagnostics(&tree, document);
+        assert!(
+            diagnostics.is_empty(),
+            "ref.null funcref should be accepted leniently, got: {:?}",
+            diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_ref_func() {
+        let document = r#"(module
+  (func $target)
+  (func $test (result funcref)
+    ref.func $target
+  )
+)"#;
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let diagnostics = provide_tree_sitter_diagnostics(&tree, document);
+        assert!(
+            diagnostics.is_empty(),
+            "ref.func $name should not produce syntax errors, got: {:?}",
+            diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_ref_is_null_standalone() {
+        let document = r#"(module
+  (func $test (param funcref) (result i32)
+    local.get 0
+    ref.is_null
+  )
+)"#;
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let diagnostics = provide_tree_sitter_diagnostics(&tree, document);
+        assert!(
+            diagnostics.is_empty(),
+            "ref.is_null should not produce syntax errors, got: {:?}",
+            diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_elem_with_ref_func_and_ref_null() {
+        let document = r#"(module
+  (func $f1)
+  (table 2 funcref)
+  (elem (i32.const 0) funcref (ref.func $f1) (ref.null func))
+)"#;
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let diagnostics = provide_tree_sitter_diagnostics(&tree, document);
+        assert!(
+            diagnostics.is_empty(),
+            "elem with ref.func and ref.null func should not produce syntax errors, got: {:?}",
+            diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
     fn test_store8_load8_valid() {
         // These are valid WASM instructions and should not produce errors
         let document = r#"(module

--- a/src/diagnostics/wast_validator.rs
+++ b/src/diagnostics/wast_validator.rs
@@ -61,6 +61,41 @@ mod tests {
     }
 
     #[test]
+    fn test_ref_null_func_and_ref_is_null() {
+        let source = r#"(module
+  (func $test (result i32)
+    ref.null func
+    ref.is_null
+  )
+)"#;
+        let diags = validate_wat(source);
+        assert!(diags.is_empty(), "Expected no errors, got: {:?}", diags);
+    }
+
+    #[test]
+    fn test_ref_func() {
+        let source = r#"(module
+  (func $target)
+  (func $test (result funcref)
+    ref.func $target
+  )
+)"#;
+        let diags = validate_wat(source);
+        assert!(diags.is_empty(), "Expected no errors, got: {:?}", diags);
+    }
+
+    #[test]
+    fn test_elem_with_ref_expressions() {
+        let source = r#"(module
+  (func $f1)
+  (table 2 funcref)
+  (elem (i32.const 0) funcref (ref.func $f1) (ref.null func))
+)"#;
+        let diags = validate_wat(source);
+        assert!(diags.is_empty(), "Expected no errors, got: {:?}", diags);
+    }
+
+    #[test]
     fn test_try_table_exception_handling() {
         let source = r#"
 (module


### PR DESCRIPTION
## Summary

- Change `ref_kind` in tree-sitter grammar from regex to `choice()` of string literals, fixing keyword/regex tokenization conflicts that caused `ref.null func` to fail
- Add `ref_type` as lenient alternative for `ref.null` argument (accepts `ref.null funcref` without tree-sitter errors)
- Add `docs/examples/ref_expressions.wat` demonstrating ref.null, ref.func, ref.is_null in various contexts
- Add 8 new tests (5 tree-sitter + 3 wast validator)

Closes #122