### PR TITLE
flatten docs sidebar: remove collapsible groups and top-level labels

### DIFF
--- a/packages/docs/astro.config.mjs
+++ b/packages/docs/astro.config.mjs
@@ -52,11 +52,11 @@ export default defineConfig({
         {
           label: 'Guides',
           items: [
-            { label: 'Language', collapsed: true, autogenerate: { directory: 'language' } },
-            { label: 'Control Flow', collapsed: true, autogenerate: { directory: 'control' } },
-            { label: 'Stack & Memory', collapsed: true, autogenerate: { directory: 'stack' } },
-            { label: 'Numeric Ops', collapsed: true, autogenerate: { directory: 'ops' } },
-            { label: 'Extensions', collapsed: true, autogenerate: { directory: 'extensions' } },
+            { label: 'Language', autogenerate: { directory: 'language' } },
+            { label: 'Control Flow', autogenerate: { directory: 'control' } },
+            { label: 'Stack & Memory', autogenerate: { directory: 'stack' } },
+            { label: 'Numeric Ops', autogenerate: { directory: 'ops' } },
+            { label: 'Extensions', autogenerate: { directory: 'extensions' } },
           ],
         },
         { label: 'Reference', autogenerate: { directory: 'instructions' } },

--- a/packages/docs/src/components/Sidebar.astro
+++ b/packages/docs/src/components/Sidebar.astro
@@ -13,7 +13,12 @@ function hasCurrentPage(entry: any): boolean {
 }
 
 const activeGroup = sidebar.filter((entry: any) => hasCurrentPage(entry));
-const filtered = activeGroup.length > 0 ? activeGroup : sidebar;
+let filtered = activeGroup.length > 0 ? activeGroup : sidebar;
+
+// Unwrap single top-level group to remove its label
+if (filtered.length === 1 && filtered[0].type === 'group') {
+  filtered = filtered[0].entries;
+}
 ---
 
 <SidebarPersister>


### PR DESCRIPTION
## Summary

- Remove `collapsed: true` from guide sub-sections so they're permanently expanded
- Unwrap single top-level groups in the sidebar component to hide "Intro", "Guides", and "Reference" labels