### PR TITLE
fix vsce package failing in CI due to missing pnpm

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -88,10 +88,10 @@
     }
   },
   "scripts": {
-    "vscode:prepublish": "pnpm run compile",
+    "vscode:prepublish": "npm run compile",
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
-    "pretest": "pnpm run compile",
+    "pretest": "npm run compile",
     "lint": "eslint src --ext ts",
     "package": "vsce package",
     "build:server": "cd ../.. && cargo build --release",


### PR DESCRIPTION
Replace `pnpm run` with `npm run` in the vscode extension's `vscode:prepublish` and `pretest` scripts. The release workflow's `publish-vscode-extension` job uses `npm install` and doesn't have pnpm available, so `vsce package` fails when the prepublish hook tries to call `pnpm`.