### PR TITLE
fix panic on multi-byte UTF-8 characters in completion and signature help

### DIFF
--- a/src/features/completion/mod.rs
+++ b/src/features/completion/mod.rs
@@ -1,7 +1,8 @@
 use crate::core::types::{CompletionItem, CompletionItemKind, InsertTextFormat, Position};
 use crate::symbols::*;
 use crate::utils::{
-    determine_context_from_line, find_containing_function, get_line_at_position, InstructionContext,
+    determine_context_from_line, find_containing_function, get_line_at_position,
+    utf16_offset_to_byte_offset, InstructionContext,
 };
 use regex::Regex;
 use std::sync::LazyLock;
@@ -23,7 +24,7 @@ pub fn provide_completion(
         None => return completions,
     };
 
-    let line_prefix = &line[..position.character.min(line.len() as u32) as usize];
+    let line_prefix = &line[..utf16_offset_to_byte_offset(line, position.character)];
 
     // Emmet-like number constant expansion (e.g., 5i32 -> (i32.const 5))
     if let Some(caps) = NUMBER_CONST_REGEX.captures(line_prefix) {

--- a/src/features/signature/mod.rs
+++ b/src/features/signature/mod.rs
@@ -4,7 +4,9 @@ pub mod call_info;
 #[cfg(feature = "native")]
 use crate::symbols::*;
 #[cfg(feature = "native")]
-use crate::utils::{format_function_signature, get_line_at_position, node_at_position};
+use crate::utils::{
+    format_function_signature, get_line_at_position, node_at_position, utf16_offset_to_byte_offset,
+};
 #[cfg(feature = "native")]
 use tower_lsp::lsp_types::*;
 #[cfg(feature = "native")]
@@ -33,7 +35,7 @@ pub fn provide_signature_help(
     // Fall back to string-based approach for incomplete code
     let call_info = call_info.or_else(|| {
         let line = get_line_at_position(document, position.line as usize)?;
-        let line_prefix = &line[..position.character.min(line.len() as u32) as usize];
+        let line_prefix = &line[..utf16_offset_to_byte_offset(line, position.character)];
         find_function_call(line_prefix)
     })?;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -440,17 +440,27 @@ pub fn get_line_at_position(document: &str, line_num: usize) -> Option<&str> {
 /// A word includes alphanumerics, underscores, dollar signs, dots, and hyphens.
 pub fn get_word_at_position(document: &str, position: Position) -> Option<String> {
     let line = get_line_at_position(document, position.line as usize)?;
-    let col = position.character as usize;
 
-    if col > line.len() {
+    let chars: Vec<char> = line.chars().collect();
+
+    // Convert UTF-16 offset to char index
+    let mut utf16_count = 0u32;
+    let mut col = 0usize;
+    for ch in &chars {
+        if utf16_count >= position.character {
+            break;
+        }
+        utf16_count += ch.len_utf16() as u32;
+        col += 1;
+    }
+
+    if col > chars.len() {
         return None;
     }
 
     // Find word boundaries
     let mut start = col;
     let mut end = col;
-
-    let chars: Vec<char> = line.chars().collect();
 
     // Move back to start of word
     while start > 0 && is_word_char(chars.get(start - 1).copied()?) {
@@ -474,20 +484,29 @@ pub fn is_word_char(c: char) -> bool {
     c.is_alphanumeric() || c == '_' || c == '$' || c == '.' || c == '-'
 }
 
+/// Convert a UTF-16 character offset to a byte offset within a line.
+/// LSP positions use UTF-16 offsets, but Rust strings are UTF-8.
+/// Clamps to end of line if the offset is beyond the line length.
+pub fn utf16_offset_to_byte_offset(line: &str, utf16_offset: u32) -> usize {
+    let mut utf16_count = 0u32;
+    let mut byte_offset = 0;
+    for ch in line.chars() {
+        if utf16_count >= utf16_offset {
+            return byte_offset;
+        }
+        utf16_count += ch.len_utf16() as u32;
+        byte_offset += ch.len_utf8();
+    }
+    byte_offset
+}
+
 /// Convert an LSP Position to a byte offset in the source text
 pub fn position_to_byte(source: &str, position: Position) -> usize {
     let mut byte_offset = 0;
 
     for (current_line, line) in source.lines().enumerate() {
         if current_line == position.line as usize {
-            // Add character offset within this line
-            let char_offset = position.character as usize;
-            let line_bytes: Vec<_> = line.char_indices().collect();
-            if char_offset < line_bytes.len() {
-                return byte_offset + line_bytes[char_offset].0;
-            } else {
-                return byte_offset + line.len();
-            }
+            return byte_offset + utf16_offset_to_byte_offset(line, position.character);
         }
         byte_offset += line.len() + 1; // +1 for newline
     }


### PR DESCRIPTION
LSP positions use UTF-16 offsets, but the code was using `position.character` directly as a byte index for Rust string slicing. When a line contains multi-byte UTF-8 characters (like ≥), slicing at a non-char-boundary causes a panic that crashes the LSP server.

Adds `utf16_offset_to_byte_offset()` and fixes all call sites in completion, signature help, `get_word_at_position`, and `position_to_byte`.