### PR TITLE
remove duplicate playground preview PR comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -580,7 +580,6 @@ jobs:
     permissions:
       contents: read
       deployments: write
-      pull-requests: write
     steps:
       - name: Download playground build
         uses: actions/download-artifact@v7
@@ -595,41 +594,6 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: pages deploy dist --project-name=wat-lsp --branch=${{ github.head_ref || github.ref_name }}
-
-      - name: Comment preview URL on PR
-        if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const url = '${{ steps.deploy.outputs.deployment-url }}';
-            const sha = context.payload.pull_request.head.sha.substring(0, 7);
-            const body = `## 🚀 Playground Preview\n\nDeployed to Cloudflare Pages:\n${url} (\`${sha}\`)`;
-
-            // Find existing bot comment
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-            const botComment = comments.find(c =>
-              c.user.type === 'Bot' && c.body.includes('Playground Preview')
-            );
-
-            if (botComment) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: botComment.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body,
-              });
-            }
 
   docs-lint:
     name: Docs Lint


### PR DESCRIPTION
Remove the separate "Playground Preview" PR comment from the deploy-pages job. The docs comment already includes a playground link, so only one comment is needed. Also removes the now-unnecessary pull-requests:write permission.