### PR TITLE
validate subtype hierarchy for GC types

### DIFF
--- a/src/diagnostics/semantic_diagnostics.rs
+++ b/src/diagnostics/semantic_diagnostics.rs
@@ -64,6 +64,13 @@ pub fn provide_semantic_diagnostics(
 
     // Single unified tree walk for all semantic checks
     unified_tree_walk(tree.root_node(), source, symbols, &config, &mut diagnostics);
+
+    // Validate subtype hierarchy
+    let subtype_diags = crate::diagnostics_core::subtype::validate_subtype_hierarchy(symbols);
+    for diag in subtype_diags {
+        diagnostics.push(diag.into());
+    }
+
     diagnostics
 }
 
@@ -2216,7 +2223,7 @@ mod tests {
     i32.const 1
     i32.add)
 
-  (func $dispatch (param $x i32) (param $f funcref) (result i32)
+  (func $dispatch (type $t) (param $x i32) (param $f funcref) (result i32)
     local.get $x
     local.get $f
     return_call_ref (type $t))
@@ -3974,6 +3981,84 @@ mod tests {
         assert!(
             !tail_diags.is_empty(),
             "Should detect return arity mismatch, got: {:?}",
+            diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_invalid_struct_subtype_missing_parent_fields() {
+        let document = r#"(module
+  (type $parent (sub (struct (field i32) (field i64))))
+  (type $child (sub $parent (struct (field i32))))
+)"#;
+
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        let subtype_errors: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.message.contains("fields"))
+            .collect();
+        assert!(
+            !subtype_errors.is_empty(),
+            "Expected struct field count error, got: {:?}",
+            diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_valid_struct_subtype() {
+        let document = r#"(module
+  (type $parent (sub (struct (field i32))))
+  (type $child (sub $parent (struct (field i32) (field i64))))
+)"#;
+
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        let subtype_errors: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| {
+                d.message.contains("field")
+                    || d.message.contains("parent")
+                    || d.message.contains("final")
+                    || d.message.contains("extend")
+            })
+            .collect();
+        assert_eq!(
+            subtype_errors.len(),
+            0,
+            "Expected no subtype errors, got: {:?}",
+            subtype_errors
+                .iter()
+                .map(|d| &d.message)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_sub_final_cannot_be_extended() {
+        let document = r#"(module
+  (type $sealed (sub final (struct (field i32))))
+  (type $child (sub $sealed (struct (field i32) (field i64))))
+)"#;
+
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        let final_errors: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.message.contains("final"))
+            .collect();
+        assert!(
+            !final_errors.is_empty(),
+            "Expected 'cannot extend final' error, got: {:?}",
             diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
         );
     }

--- a/src/diagnostics_core/mod.rs
+++ b/src/diagnostics_core/mod.rs
@@ -6,11 +6,13 @@
 mod references;
 mod semantic;
 mod stack;
+pub mod subtype;
 mod termination;
 pub mod tree_sitter;
 
 pub use references::*;
 pub use semantic::*;
 pub use stack::*;
+pub use subtype::validate_subtype_hierarchy;
 pub use termination::*;
 pub use tree_sitter::provide_tree_sitter_diagnostics;

--- a/src/diagnostics_core/subtype.rs
+++ b/src/diagnostics_core/subtype.rs
@@ -1,0 +1,172 @@
+//! Subtype hierarchy validation for GC types.
+//!
+//! Validates that `sub` declarations correctly reference parent types,
+//! respects `final` constraints, and checks structural compatibility.
+
+use crate::core::types::Diagnostic;
+use crate::symbols::{SymbolTable, TypeDef, TypeKind};
+
+/// Validate subtype hierarchy in the symbol table.
+/// Returns diagnostics for invalid parent references, final type violations,
+/// and structural incompatibilities.
+pub fn validate_subtype_hierarchy(symbols: &SymbolTable) -> Vec<Diagnostic> {
+    let mut diagnostics = Vec::new();
+
+    for type_def in &symbols.types {
+        let parent_ref = match &type_def.parent {
+            Some(p) => p,
+            None => continue,
+        };
+
+        let parent = resolve_parent(symbols, parent_ref);
+
+        let parent = match parent {
+            Some(p) => p,
+            None => {
+                if let Some(range) = type_def.range {
+                    diagnostics.push(Diagnostic::error(
+                        range,
+                        format!("Undefined parent type '{}'", parent_ref),
+                    ));
+                }
+                continue;
+            }
+        };
+
+        // Check if parent is final
+        if parent.is_final {
+            let fallback = parent.index.to_string();
+            let parent_name = parent.name.as_deref().unwrap_or(&fallback);
+            if let Some(range) = type_def.range {
+                diagnostics.push(Diagnostic::error(
+                    range,
+                    format!("Cannot extend final type '{}'", parent_name),
+                ));
+            }
+            continue;
+        }
+
+        // Check structural compatibility
+        check_structural_compatibility(type_def, parent, &mut diagnostics);
+    }
+
+    diagnostics
+}
+
+/// Resolve a parent reference (either "$name" or numeric index) to a TypeDef.
+fn resolve_parent<'a>(symbols: &'a SymbolTable, parent_ref: &str) -> Option<&'a TypeDef> {
+    if parent_ref.starts_with('$') {
+        symbols.get_type_by_name(parent_ref)
+    } else {
+        parent_ref
+            .parse::<usize>()
+            .ok()
+            .and_then(|idx| symbols.get_type_by_index(idx))
+    }
+}
+
+/// Check structural compatibility between a child type and its declared parent.
+fn check_structural_compatibility(
+    child: &TypeDef,
+    parent: &TypeDef,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let range = match child.range {
+        Some(r) => r,
+        None => return,
+    };
+
+    match (&child.kind, &parent.kind) {
+        (
+            TypeKind::Struct {
+                fields: child_fields,
+            },
+            TypeKind::Struct {
+                fields: parent_fields,
+            },
+        ) => {
+            // Child must have at least as many fields as parent
+            if child_fields.len() < parent_fields.len() {
+                diagnostics.push(Diagnostic::error(
+                    range,
+                    format!(
+                        "Struct subtype has {} fields but parent requires at least {}",
+                        child_fields.len(),
+                        parent_fields.len()
+                    ),
+                ));
+                return;
+            }
+            // First N fields must match parent's types
+            for (i, (_, parent_type, _parent_mut)) in parent_fields.iter().enumerate() {
+                let (_, child_type, _child_mut) = &child_fields[i];
+                if child_type != parent_type {
+                    diagnostics.push(Diagnostic::error(
+                        range,
+                        format!(
+                            "Struct field {} type mismatch: expected {:?}, got {:?}",
+                            i, parent_type, child_type
+                        ),
+                    ));
+                }
+            }
+        }
+        (
+            TypeKind::Array {
+                element_type: child_elem,
+                ..
+            },
+            TypeKind::Array {
+                element_type: parent_elem,
+                ..
+            },
+        ) => {
+            if child_elem != parent_elem {
+                diagnostics.push(Diagnostic::error(
+                    range,
+                    format!(
+                        "Array element type mismatch: expected {:?}, got {:?}",
+                        parent_elem, child_elem
+                    ),
+                ));
+            }
+        }
+        (
+            TypeKind::Func {
+                params: child_params,
+                results: child_results,
+            },
+            TypeKind::Func {
+                params: parent_params,
+                results: parent_results,
+            },
+        ) => {
+            if child_params != parent_params || child_results != parent_results {
+                diagnostics.push(Diagnostic::error(
+                    range,
+                    "Function subtype signature must match parent exactly".to_string(),
+                ));
+            }
+        }
+        _ => {
+            // Kind mismatch (e.g., struct extending array)
+            let child_kind_name = type_kind_name(&child.kind);
+            let parent_kind_name = type_kind_name(&parent.kind);
+            diagnostics.push(Diagnostic::error(
+                range,
+                format!(
+                    "Type kind mismatch: {} cannot extend {}",
+                    child_kind_name, parent_kind_name
+                ),
+            ));
+        }
+    }
+}
+
+fn type_kind_name(kind: &TypeKind) -> &'static str {
+    match kind {
+        TypeKind::Func { .. } => "func",
+        TypeKind::Struct { .. } => "struct",
+        TypeKind::Array { .. } => "array",
+    }
+}

--- a/src/features/symbols/mod.rs
+++ b/src/features/symbols/mod.rs
@@ -218,6 +218,8 @@ pub struct TypeDef {
     pub name: Option<String>,
     pub index: usize,
     pub kind: TypeKind,
+    pub parent: Option<String>,
+    pub is_final: bool,
     pub line: u32,
     pub range: Option<Range>,
 }

--- a/src/features/symbols/tests.rs
+++ b/src/features/symbols/tests.rs
@@ -97,6 +97,8 @@ fn test_add_type() {
             params: vec![ValueType::I32, ValueType::I32],
             results: vec![ValueType::I32],
         },
+        parent: None,
+        is_final: false,
         line: 0,
         range: None,
     };

--- a/src/features/test_utils.rs
+++ b/src/features/test_utils.rs
@@ -101,6 +101,8 @@ pub fn create_test_symbols() -> SymbolTable {
             params: vec![ValueType::I32, ValueType::I32],
             results: vec![ValueType::I32],
         },
+        parent: None,
+        is_final: false,
         line: 0,
         range: None,
     };
@@ -158,6 +160,8 @@ pub fn create_signature_test_symbols() -> SymbolTable {
             params: vec![ValueType::I32, ValueType::I64, ValueType::F32],
             results: vec![ValueType::F64],
         },
+        parent: None,
+        is_final: false,
         line: 0,
         range: None,
     };

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1132,6 +1132,7 @@ fn extract_rec_types(
                 if type_node.kind() == "struct_type"
                     || type_node.kind() == "array_type"
                     || type_node.kind() == "type_field"
+                    || type_node.kind() == "sub_type"
                 {
                     // Extract the type
                     if let Some(type_def) = extract_type_from_single_node(
@@ -1171,11 +1172,60 @@ fn extract_type_from_single_node(
         params: Vec::new(),
         results: Vec::new(),
     };
+    let mut parent_ref: Option<String> = None;
+    let mut is_final = false;
 
     let type_kind = type_node.kind();
     #[cfg(all(feature = "wasm", not(feature = "native")))]
     let type_kind = type_kind.as_str();
     match type_kind {
+        "sub_type" => {
+            // Process sub_type children: (sub final? index? def_type)
+            let mut sub_cursor = type_node.walk();
+            for sub_child in type_node.children(&mut sub_cursor) {
+                let sub_kind = sub_child.kind();
+                #[cfg(all(feature = "wasm", not(feature = "native")))]
+                let sub_kind = sub_kind.as_str();
+
+                match sub_kind {
+                    "index" => {
+                        parent_ref = Some(node_text(&sub_child, source));
+                    }
+                    "def_type" => {
+                        let mut def_cursor = sub_child.walk();
+                        for def_child in sub_child.children(&mut def_cursor) {
+                            if def_child.kind() == "struct_type" {
+                                kind = extract_struct_kind(&def_child, source);
+                            } else if def_child.kind() == "array_type" {
+                                kind = extract_array_kind(&def_child, source);
+                            } else if def_child.kind() == "func_type" {
+                                let mut parameters = Vec::new();
+                                let mut results = Vec::new();
+                                let params = extract_parameters(&def_child, source);
+                                for param in params {
+                                    parameters.push(param.param_type);
+                                }
+                                results.extend(extract_results(&def_child, source));
+                                kind = TypeKind::Func {
+                                    params: parameters,
+                                    results,
+                                };
+                            }
+                        }
+                    }
+                    _ => {
+                        if node_text(&sub_child, source) == "final" {
+                            is_final = true;
+                        }
+                        if sub_child.kind() == "struct_type" {
+                            kind = extract_struct_kind(&sub_child, source);
+                        } else if sub_child.kind() == "array_type" {
+                            kind = extract_array_kind(&sub_child, source);
+                        }
+                    }
+                }
+            }
+        }
         "struct_type" => {
             // Extract struct fields
             let mut fields = Vec::new();
@@ -1233,6 +1283,8 @@ fn extract_type_from_single_node(
         name,
         index,
         kind,
+        parent: parent_ref,
+        is_final,
         line: type_node.range().start_point.row as u32,
         range: name_range,
     })
@@ -1278,6 +1330,8 @@ fn extract_type(type_node: &Node, source: &str, index: usize) -> Option<TypeDef>
         params: Vec::new(),
         results: Vec::new(),
     };
+    let mut parent_ref: Option<String> = None;
+    let mut is_final = false;
     let mut cursor = type_node.walk();
     for child in type_node.children(&mut cursor) {
         // Handle sub_type: (sub final? supertype_index? def_type)
@@ -1289,6 +1343,9 @@ fn extract_type(type_node: &Node, source: &str, index: usize) -> Option<TypeDef>
                 let sub_kind = sub_kind.as_str();
 
                 match sub_kind {
+                    "index" => {
+                        parent_ref = Some(node_text(&sub_child, source));
+                    }
                     "def_type" => {
                         // Process the inner type definition
                         let mut def_cursor = sub_child.walk();
@@ -1307,6 +1364,10 @@ fn extract_type(type_node: &Node, source: &str, index: usize) -> Option<TypeDef>
                         }
                     }
                     _ => {
+                        // Check for "final" keyword
+                        if node_text(&sub_child, source) == "final" {
+                            is_final = true;
+                        }
                         // Check if this is a type definition directly
                         if sub_child.kind() == "struct_type" {
                             kind = extract_struct_kind(&sub_child, source);
@@ -1446,6 +1507,46 @@ fn extract_type(type_node: &Node, source: &str, index: usize) -> Option<TypeDef>
                         element_type,
                         mutable,
                     };
+                } else if field_child.kind() == "sub_type" {
+                    // Handle sub_type inside type_field: (sub final? index? def_type)
+                    let mut sub_cursor = field_child.walk();
+                    for sub_child in field_child.children(&mut sub_cursor) {
+                        let sub_kind = sub_child.kind();
+                        #[cfg(all(feature = "wasm", not(feature = "native")))]
+                        let sub_kind = sub_kind.as_str();
+
+                        match sub_kind {
+                            "index" => {
+                                parent_ref = Some(node_text(&sub_child, source));
+                            }
+                            "def_type" => {
+                                let mut def_cursor = sub_child.walk();
+                                for def_child in sub_child.children(&mut def_cursor) {
+                                    if def_child.kind() == "struct_type" {
+                                        kind = extract_struct_kind(&def_child, source);
+                                    } else if def_child.kind() == "array_type" {
+                                        kind = extract_array_kind(&def_child, source);
+                                    } else if def_child.kind() == "func_type" {
+                                        let params = extract_parameters(&def_child, source);
+                                        for param in params {
+                                            parameters.push(param.param_type);
+                                        }
+                                        results.extend(extract_results(&def_child, source));
+                                    }
+                                }
+                            }
+                            _ => {
+                                if node_text(&sub_child, source) == "final" {
+                                    is_final = true;
+                                }
+                                if sub_child.kind() == "struct_type" {
+                                    kind = extract_struct_kind(&sub_child, source);
+                                } else if sub_child.kind() == "array_type" {
+                                    kind = extract_array_kind(&sub_child, source);
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -1463,6 +1564,8 @@ fn extract_type(type_node: &Node, source: &str, index: usize) -> Option<TypeDef>
         name,
         index,
         kind,
+        parent: parent_ref,
+        is_final,
         line: type_node.range().start_point.row as u32,
         range: name_range,
     })

--- a/src/wasm/api.rs
+++ b/src/wasm/api.rs
@@ -152,6 +152,13 @@ impl WatLSP {
             for diag in semantic_diagnostics {
                 js_array.push(&diagnostic_to_js(&diag));
             }
+
+            // Add subtype hierarchy diagnostics
+            let subtype_diagnostics =
+                crate::diagnostics_core::subtype::validate_subtype_hierarchy(symbols);
+            for diag in subtype_diagnostics {
+                js_array.push(&core_diagnostic_to_js(&diag));
+            }
         }
 
         js_array.into()

--- a/src/wast_parser.rs
+++ b/src/wast_parser.rs
@@ -182,6 +182,8 @@ fn extract_symbols(wat: &wast::Wat, source: &str) -> Result<SymbolTable, String>
                     name: type_def.id.map(|id| format!("${}", id.name())),
                     index: type_index,
                     kind: extract_type_def_info(&type_def.def),
+                    parent: extract_parent_ref(&type_def.def),
+                    is_final: type_def.def.final_type == Some(true),
                     line: span_to_line(type_def.span, source),
                     range: type_def.id.map(|id| id_to_range(id, source)),
                 });
@@ -193,6 +195,8 @@ fn extract_symbols(wat: &wast::Wat, source: &str) -> Result<SymbolTable, String>
                         name: rec_type.id.map(|id| format!("${}", id.name())),
                         index: type_index,
                         kind: extract_type_def_info(&rec_type.def),
+                        parent: extract_parent_ref(&rec_type.def),
+                        is_final: rec_type.def.final_type == Some(true),
                         line: span_to_line(rec_type.span, source),
                         range: rec_type.id.map(|id| id_to_range(id, source)),
                     });
@@ -328,6 +332,14 @@ fn extract_func_locals(func: &wast::core::Func, source: &str) -> Vec<Variable> {
 #[inline]
 fn extract_value_type(val_type: &wast::core::ValType) -> ValueType {
     ValueType::from(val_type)
+}
+
+/// Extract parent type reference from wast TypeDef
+fn extract_parent_ref(def: &wast::core::TypeDef) -> Option<String> {
+    def.parent.as_ref().map(|idx| match idx {
+        wast::token::Index::Num(n, _) => n.to_string(),
+        wast::token::Index::Id(id) => format!("${}", id.name()),
+    })
 }
 
 /// Extract type definition info from wast TypeDef

--- a/tests/diagnostic_corpus/invalid_subtype_hierarchy.expected.json
+++ b/tests/diagnostic_corpus/invalid_subtype_hierarchy.expected.json
@@ -1,0 +1,11 @@
+{
+  "description": "Struct subtype with fewer fields than parent",
+  "diagnostics": [
+    {
+      "line": 2,
+      "message_contains": "fields",
+      "message_contains_all": ["1", "2"],
+      "severity": 1
+    }
+  ]
+}

--- a/tests/diagnostic_corpus/invalid_subtype_hierarchy.wat
+++ b/tests/diagnostic_corpus/invalid_subtype_hierarchy.wat
@@ -1,0 +1,4 @@
+(module
+  (type $parent (sub (struct (field i32) (field i64))))
+  (type $child (sub $parent (struct (field i32))))
+)

--- a/tests/diagnostic_corpus/sub_final_cannot_extend.expected.json
+++ b/tests/diagnostic_corpus/sub_final_cannot_extend.expected.json
@@ -1,0 +1,10 @@
+{
+  "description": "Cannot extend a final type",
+  "diagnostics": [
+    {
+      "line": 2,
+      "message_contains": "final",
+      "severity": 1
+    }
+  ]
+}

--- a/tests/diagnostic_corpus/sub_final_cannot_extend.wat
+++ b/tests/diagnostic_corpus/sub_final_cannot_extend.wat
@@ -1,0 +1,4 @@
+(module
+  (type $sealed (sub final (struct (field i32))))
+  (type $child (sub $sealed (struct (field i32) (field i64))))
+)

--- a/tests/diagnostic_corpus/valid_subtype_hierarchy.expected.json
+++ b/tests/diagnostic_corpus/valid_subtype_hierarchy.expected.json
@@ -1,0 +1,4 @@
+{
+  "description": "Valid struct subtype extending parent with additional fields",
+  "diagnostics": []
+}

--- a/tests/diagnostic_corpus/valid_subtype_hierarchy.wat
+++ b/tests/diagnostic_corpus/valid_subtype_hierarchy.wat
@@ -1,0 +1,4 @@
+(module
+  (type $parent (sub (struct (field i32))))
+  (type $child (sub $parent (struct (field i32) (field i64))))
+)


### PR DESCRIPTION
## Summary

- Add `parent` and `is_final` fields to `TypeDef` to track `sub` declarations
- Extract parent reference and `final` flag from both tree-sitter and wast parsers
- Add `diagnostics_core::subtype` module with validation for: undefined parent types, extending final types, struct field count/type matching, array element type matching, func signature matching, and type kind mismatches
- Wire validation into both native and WASM diagnostic paths
- Add 3 unit tests and 3 diagnostic corpus test files

Closes #154