### PR TITLE
Fix relaxed SIMD arity: explicit handling for all relaxed SIMD instructions

### DIFF
--- a/src/diagnostics/semantic_diagnostics.rs
+++ b/src/diagnostics/semantic_diagnostics.rs
@@ -3552,6 +3552,32 @@ mod tests {
     }
 
     #[test]
+    fn test_relaxed_simd_stack_underflow() {
+        // f32x4.relaxed_madd needs 3 v128 operands, only 2 provided
+        let document = r#"(module
+  (func $bad_madd (param $a v128) (param $b v128) (result v128)
+    local.get $a
+    local.get $b
+    f32x4.relaxed_madd)
+)"#;
+
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        let underflow = diagnostics
+            .iter()
+            .filter(|d| d.message.contains("Stack underflow"))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            underflow.len(),
+            1,
+            "relaxed_madd with 2 operands (needs 3) should produce stack underflow"
+        );
+    }
+
+    #[test]
     fn test_simd_i32x4_add_no_false_positive() {
         // Regression test: SIMD binary ops must consume 2 and produce 1 on the stack.
         // Previously i32x4.add was unknown to the arity map, so the stack tracker

--- a/src/instruction_metadata.rs
+++ b/src/instruction_metadata.rs
@@ -781,13 +781,22 @@ pub fn infer_simd_instruction_arity(name: &str) -> Option<(usize, usize)> {
         return Some((1, 1));
     }
 
-    // Relaxed SIMD ternary ops: 3 v128 → v128
-    if name.contains(".relaxed_madd")
-        || name.contains(".relaxed_nmadd")
-        || name.contains(".relaxed_laneselect")
-        || name.contains(".relaxed_dot_i8x16_i7x16_add")
-    {
-        return Some((3, 1));
+    // ── Relaxed SIMD (explicit handling for all instructions) ───────
+    if name.contains(".relaxed_") {
+        // Ternary: 3 v128 → v128
+        if name.contains(".relaxed_madd")
+            || name.contains(".relaxed_nmadd")
+            || name.contains(".relaxed_laneselect")
+            || name.contains(".relaxed_dot_i8x16_i7x16_add")
+        {
+            return Some((3, 1));
+        }
+        // Unary: 1 v128 → v128
+        if name.contains(".relaxed_trunc") {
+            return Some((1, 1));
+        }
+        // Binary: 2 v128 → v128 (swizzle, min, max, q15mulr)
+        return Some((2, 1));
     }
 
     // Unary ops: 1 v128 → 1 v128
@@ -1210,24 +1219,58 @@ mod tests {
     }
 
     #[test]
-    fn test_simd_arity_relaxed_ops() {
-        // Relaxed SIMD ternary ops: 3 → 1
-        assert_eq!(
-            infer_simd_instruction_arity("f32x4.relaxed_madd"),
-            Some((3, 1))
-        );
-        assert_eq!(
-            infer_simd_instruction_arity("f64x2.relaxed_nmadd"),
-            Some((3, 1))
-        );
-        assert_eq!(
-            infer_simd_instruction_arity("i8x16.relaxed_laneselect"),
-            Some((3, 1))
-        );
-        assert_eq!(
-            infer_simd_instruction_arity("i32x4.relaxed_dot_i8x16_i7x16_add_s"),
-            Some((3, 1))
-        );
+    fn test_relaxed_simd_full_coverage() {
+        // Ternary: madd, nmadd, laneselect (3 operands → 1 result)
+        for instr in [
+            "f32x4.relaxed_madd",
+            "f32x4.relaxed_nmadd",
+            "f64x2.relaxed_madd",
+            "f64x2.relaxed_nmadd",
+            "i8x16.relaxed_laneselect",
+            "i16x8.relaxed_laneselect",
+            "i32x4.relaxed_laneselect",
+            "i64x2.relaxed_laneselect",
+            "i32x4.relaxed_dot_i8x16_i7x16_add_s",
+        ] {
+            let arity = infer_simd_instruction_arity(instr);
+            assert_eq!(
+                arity,
+                Some((3, 1)),
+                "{instr} should be ternary (3 operands → 1 result)"
+            );
+        }
+
+        // Binary: swizzle, min, max, trunc, q15mulr (2 operands → 1 result)
+        for instr in [
+            "i8x16.relaxed_swizzle",
+            "f32x4.relaxed_min",
+            "f32x4.relaxed_max",
+            "f64x2.relaxed_min",
+            "f64x2.relaxed_max",
+            "i16x8.relaxed_q15mulr_s",
+        ] {
+            let arity = infer_simd_instruction_arity(instr);
+            assert_eq!(
+                arity,
+                Some((2, 1)),
+                "{instr} should be binary (2 operands → 1 result)"
+            );
+        }
+
+        // Unary: trunc (1 operand → 1 result)
+        for instr in [
+            "i32x4.relaxed_trunc_f32x4_s",
+            "i32x4.relaxed_trunc_f32x4_u",
+            "i32x4.relaxed_trunc_f64x2_s_zero",
+            "i32x4.relaxed_trunc_f64x2_u_zero",
+        ] {
+            let arity = infer_simd_instruction_arity(instr);
+            assert_eq!(
+                arity,
+                Some((1, 1)),
+                "{instr} should be unary (1 operand → 1 result)"
+            );
+        }
     }
 
     #[test]

--- a/tests/diagnostic_corpus/valid_relaxed_simd.expected.json
+++ b/tests/diagnostic_corpus/valid_relaxed_simd.expected.json
@@ -1,0 +1,4 @@
+{
+  "description": "Valid relaxed SIMD instructions should produce no diagnostics",
+  "diagnostics": []
+}

--- a/tests/diagnostic_corpus/valid_relaxed_simd.wat
+++ b/tests/diagnostic_corpus/valid_relaxed_simd.wat
@@ -1,0 +1,23 @@
+;; Valid relaxed SIMD — should produce no diagnostics
+(module
+  (func $madd (param $a v128) (param $b v128) (param $c v128) (result v128)
+    local.get $a
+    local.get $b
+    local.get $c
+    f32x4.relaxed_madd)
+
+  (func $swizzle (param $a v128) (param $b v128) (result v128)
+    local.get $a
+    local.get $b
+    i8x16.relaxed_swizzle)
+
+  (func $trunc (param $a v128) (result v128)
+    local.get $a
+    i32x4.relaxed_trunc_f32x4_s)
+
+  (func $laneselect (param $a v128) (param $b v128) (param $m v128) (result v128)
+    local.get $a
+    local.get $b
+    local.get $m
+    i32x4.relaxed_laneselect)
+)


### PR DESCRIPTION
Closes #155

- Fix `relaxed_trunc` variants incorrectly classified as binary (2→1) instead of unary (1→1)
- Add explicit `.relaxed_` guard routing all relaxed SIMD ops to correct arity class
- Replace `test_simd_arity_relaxed_ops` with `test_relaxed_simd_full_coverage` covering 19 instructions
- Add diagnostic corpus test for valid relaxed SIMD
- Add stack underflow test for relaxed SIMD arity enforcement