### PR TITLE
validate start directive function references and add playground example

### DIFF
--- a/packages/docs/instructions.md
+++ b/packages/docs/instructions.md
@@ -3224,7 +3224,7 @@ Declares a function to be called automatically when the module is instantiated.
 
 Example:
 
-```wat-snippet
+```wat
 (module
   (func $init
     ;; Initialization code here

--- a/packages/playground/examples/start_function.wat
+++ b/packages/playground/examples/start_function.wat
@@ -1,0 +1,56 @@
+;; Start Function
+;; Demonstrates the start directive for module initialization
+
+(module
+  ;; Shared memory for initialization state
+  (memory (export "memory") 1)
+
+  ;; Global flag set by the start function
+  (global $initialized (mut i32) (i32.const 0))
+
+  ;; Initialize memory with a magic number and set the flag.
+  ;; This runs automatically when the module is instantiated.
+  (func $init
+    ;; Write a magic header: 0x57415400 ("WAT\0" in ASCII)
+    (i32.store (i32.const 0) (i32.const 0x00544157))
+
+    ;; Store a version number at offset 4
+    (i32.store (i32.const 4) (i32.const 1))
+
+    ;; Fill offsets 8..15 with a default value
+    (call $fill_range (i32.const 8) (i32.const 0xFF) (i32.const 8))
+
+    ;; Mark as initialized
+    (global.set $initialized (i32.const 1)))
+
+  ;; Fill a range of bytes in memory
+  (func $fill_range (param $offset i32) (param $value i32) (param $len i32)
+    (local $i i32)
+    (local.set $i (i32.const 0))
+    (block $done
+      (loop $continue
+        (br_if $done (i32.ge_u (local.get $i) (local.get $len)))
+        (i32.store8
+          (i32.add (local.get $offset) (local.get $i))
+          (local.get $value))
+        (local.set $i (i32.add (local.get $i) (i32.const 1)))
+        (br $continue))))
+
+  ;; Declare the start function — $init runs at instantiation
+  (start $init)
+
+  ;; Check whether the module was initialized
+  (func (export "is_initialized") (result i32)
+    (global.get $initialized))
+
+  ;; Read the magic header
+  (func (export "magic") (result i32)
+    (i32.load (i32.const 0)))
+
+  ;; Read the version
+  (func (export "version") (result i32)
+    (i32.load (i32.const 4)))
+
+  ;; Read a byte from memory
+  (func (export "read_byte") (param $offset i32) (result i32)
+    (i32.load8_u (local.get $offset))))

--- a/src/diagnostics/semantic_diagnostics.rs
+++ b/src/diagnostics/semantic_diagnostics.rs
@@ -132,6 +132,14 @@ fn unified_tree_walk(
         // Continue recursing to check nested instructions
     }
 
+    // Special handling for start directive: index is a function reference
+    if kind == "module_field_start" {
+        let core_diags =
+            crate::diagnostics_core::references::check_start_references(&node, source, symbols);
+        diagnostics.extend(core_diags.into_iter().map(Into::into));
+        return;
+    }
+
     // Special handling for try_delegate_clause (legacy try): index is a label reference
     if kind == "try_delegate_clause" {
         let core_diags = crate::diagnostics_core::references::check_try_delegate_clause_references(
@@ -347,6 +355,52 @@ mod tests {
         );
         assert!(diagnostics[0].message.contains("Undefined function"));
         assert!(diagnostics[0].message.contains("$undefined"));
+    }
+
+    #[test]
+    fn test_undefined_start_function() {
+        let document = r#"(module
+  (start $main)
+)"#;
+
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        let undefined_diags: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.message.contains("Undefined function"))
+            .collect();
+        assert_eq!(
+            undefined_diags.len(),
+            1,
+            "Undefined start function should produce one diagnostic"
+        );
+        assert!(undefined_diags[0].message.contains("$main"));
+    }
+
+    #[test]
+    fn test_valid_start_function() {
+        let document = r#"(module
+  (func $main (nop))
+  (start $main)
+)"#;
+
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        let undefined_diags: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.message.contains("Undefined"))
+            .collect();
+        assert_eq!(
+            undefined_diags.len(),
+            0,
+            "Valid start function should not produce diagnostics"
+        );
     }
 
     #[test]

--- a/src/diagnostics_core/references.rs
+++ b/src/diagnostics_core/references.rs
@@ -209,6 +209,49 @@ pub fn check_try_delegate_clause_references(
     diagnostics
 }
 
+/// Check the function reference in a module_field_start node.
+/// The start directive takes a single function index: (start $func) or (start 0)
+pub fn check_start_references(node: &Node, source: &str, symbols: &SymbolTable) -> Vec<Diagnostic> {
+    let mut diagnostics = Vec::new();
+
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        #[cfg(feature = "native")]
+        let kind = child.kind();
+        #[cfg(all(feature = "wasm", not(feature = "native")))]
+        let kind = child.kind();
+
+        if kind == "index" {
+            let mut idx_cursor = child.walk();
+            for idx_child in child.children(&mut idx_cursor) {
+                #[cfg(feature = "native")]
+                let idx_kind = idx_child.kind();
+                #[cfg(all(feature = "wasm", not(feature = "native")))]
+                let idx_kind = idx_child.kind();
+
+                if idx_kind == "identifier" {
+                    let identifier_name = &source[idx_child.byte_range()];
+                    if !identifier_name.starts_with('$') {
+                        continue;
+                    }
+
+                    if symbols.get_function_by_name(identifier_name).is_none() {
+                        let diagnostic = create_undefined_reference_diagnostic(
+                            &idx_child,
+                            identifier_name,
+                            &InstructionContext::Call,
+                        );
+                        diagnostics.push(diagnostic);
+                    }
+                }
+            }
+            break;
+        }
+    }
+
+    diagnostics
+}
+
 /// Find and validate only the first index identifier in a node
 /// Used for instructions like struct.get where only the first index is a type
 pub fn find_first_index_identifier(

--- a/src/wasm/api.rs
+++ b/src/wasm/api.rs
@@ -1102,6 +1102,14 @@ fn walk_tree_for_diagnostics(
         }
     }
 
+    // Special handling for start directive — shared core
+    if &*kind == "module_field_start" {
+        diagnostics.extend(crate::diagnostics_core::references::check_start_references(
+            &node, source, symbols,
+        ));
+        return;
+    }
+
     // Special handling for catch clauses — shared core
     if &*kind == "catch_clause" {
         diagnostics.extend(


### PR DESCRIPTION
## Summary

- Add `check_start_references` in shared `diagnostics_core/references.rs` to validate that the function referenced in `(start $func)` actually exists
- Hook into both native `unified_tree_walk` and WASM `walk_tree_for_diagnostics`
- Add playground example demonstrating the start directive for module initialization