### PR TITLE
Validate undefined references in exports, elem segments, and data segments

### DIFF
--- a/packages/playground/examples/exports_elems_data.wat
+++ b/packages/playground/examples/exports_elems_data.wat
@@ -1,0 +1,34 @@
+(module
+  ;; Define functions
+  (func $add (param $a i32) (param $b i32) (result i32)
+    local.get $a
+    local.get $b
+    i32.add)
+
+  (func $sub (param $a i32) (param $b i32) (result i32)
+    local.get $a
+    local.get $b
+    i32.sub)
+
+  (func $noop)
+
+  ;; Define a global
+  (global $counter (mut i32) (i32.const 0))
+
+  ;; Define a table and memory
+  (table $tbl 4 funcref)
+  (memory $mem 1)
+
+  ;; Exports referencing defined symbols
+  (export "add" (func $add))
+  (export "sub" (func $sub))
+  (export "counter" (global $counter))
+  (export "table" (table $tbl))
+  (export "memory" (memory $mem))
+
+  ;; Elem segment populating the table with function references
+  (elem (table $tbl) (i32.const 0) func $add $sub $noop)
+
+  ;; Data segment writing to memory
+  (data (memory $mem) (i32.const 0) "hello, world!")
+)

--- a/src/diagnostics/semantic_diagnostics.rs
+++ b/src/diagnostics/semantic_diagnostics.rs
@@ -140,6 +140,22 @@ fn unified_tree_walk(
         return;
     }
 
+    // Check module-level references (exports, elem/data segment refs)
+    {
+        let module_ref_diags = crate::diagnostics_core::references::check_module_level_references(
+            &node, source, symbols,
+        );
+        if !module_ref_diags.is_empty() {
+            diagnostics.extend(module_ref_diags.into_iter().map(Into::into));
+            // For leaf-ish nodes (export_desc_*, table_use, memory_use, elem_list),
+            // return early. For module_field_elem, continue recursing into children
+            // so that table_use, elem_list, offset, etc. get their own checks.
+            if kind != "module_field_elem" {
+                return;
+            }
+        }
+    }
+
     // Special handling for try_delegate_clause (legacy try): index is a label reference
     if kind == "try_delegate_clause" {
         let core_diags = crate::diagnostics_core::references::check_try_delegate_clause_references(
@@ -3093,6 +3109,238 @@ mod tests {
             !final_errors.is_empty(),
             "Expected 'cannot extend final' error, got: {:?}",
             diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_undefined_export_func() {
+        let document = r#"(module
+  (export "f" (func $missing))
+)"#;
+
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        let undefined_diags: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.message.contains("Undefined function"))
+            .collect();
+        assert_eq!(undefined_diags.len(), 1);
+        assert!(undefined_diags[0].message.contains("$missing"));
+    }
+
+    #[test]
+    fn test_undefined_export_global() {
+        let document = r#"(module
+  (export "g" (global $missing))
+)"#;
+
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        let undefined_diags: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.message.contains("Undefined global"))
+            .collect();
+        assert_eq!(undefined_diags.len(), 1);
+        assert!(undefined_diags[0].message.contains("$missing"));
+    }
+
+    #[test]
+    fn test_undefined_export_table() {
+        let document = r#"(module
+  (export "t" (table $missing))
+)"#;
+
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        let undefined_diags: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.message.contains("Undefined table"))
+            .collect();
+        assert_eq!(undefined_diags.len(), 1);
+        assert!(undefined_diags[0].message.contains("$missing"));
+    }
+
+    #[test]
+    fn test_undefined_export_memory() {
+        let document = r#"(module
+  (export "m" (memory $missing))
+)"#;
+
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        let undefined_diags: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.message.contains("Undefined memory"))
+            .collect();
+        assert_eq!(undefined_diags.len(), 1);
+        assert!(undefined_diags[0].message.contains("$missing"));
+    }
+
+    #[test]
+    fn test_undefined_export_tag() {
+        let document = r#"(module
+  (export "e" (tag $missing))
+)"#;
+
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        let undefined_diags: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.message.contains("Undefined tag"))
+            .collect();
+        assert_eq!(undefined_diags.len(), 1);
+        assert!(undefined_diags[0].message.contains("$missing"));
+    }
+
+    #[test]
+    fn test_valid_exports() {
+        let document = r#"(module
+  (func $f (nop))
+  (global $g i32 (i32.const 0))
+  (table $t 1 funcref)
+  (memory $m 1)
+  (tag $e (param i32))
+  (export "f" (func $f))
+  (export "g" (global $g))
+  (export "t" (table $t))
+  (export "m" (memory $m))
+  (export "e" (tag $e))
+)"#;
+
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        let undefined_diags: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.message.contains("Undefined"))
+            .collect();
+        assert_eq!(
+            undefined_diags.len(),
+            0,
+            "Valid exports should not produce diagnostics, got: {:?}",
+            undefined_diags
+        );
+    }
+
+    #[test]
+    fn test_undefined_elem_func_refs() {
+        let document = r#"(module
+  (table 1 funcref)
+  (func $defined (nop))
+  (elem (i32.const 0) $defined $missing)
+)"#;
+
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        let undefined_diags: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.message.contains("Undefined function"))
+            .collect();
+        assert_eq!(
+            undefined_diags.len(),
+            1,
+            "Undefined elem func ref should produce one diagnostic, got: {:?}",
+            diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+        assert!(undefined_diags[0].message.contains("$missing"));
+    }
+
+    #[test]
+    fn test_undefined_elem_table_use() {
+        let document = r#"(module
+  (table $t 1 funcref)
+  (func $f (nop))
+  (elem (table $missing) (i32.const 0) func $f)
+)"#;
+
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        let undefined_diags: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.message.contains("Undefined table"))
+            .collect();
+        assert_eq!(
+            undefined_diags.len(),
+            1,
+            "Undefined table_use should produce one diagnostic, got: {:?}",
+            diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+        assert!(undefined_diags[0].message.contains("$missing"));
+    }
+
+    #[test]
+    fn test_undefined_data_memory_use() {
+        let document = r#"(module
+  (memory $m 1)
+  (data (memory $missing) (i32.const 0) "hello")
+)"#;
+
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        let undefined_diags: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.message.contains("Undefined memory"))
+            .collect();
+        assert_eq!(
+            undefined_diags.len(),
+            1,
+            "Undefined memory_use should produce one diagnostic, got: {:?}",
+            diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+        assert!(undefined_diags[0].message.contains("$missing"));
+    }
+
+    #[test]
+    fn test_valid_elem_and_data() {
+        let document = r#"(module
+  (table $t 2 funcref)
+  (memory $m 1)
+  (func $f (nop))
+  (func $g (nop))
+  (elem (table $t) (i32.const 0) func $f $g)
+  (data (memory $m) (i32.const 0) "hello")
+)"#;
+
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        let undefined_diags: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.message.contains("Undefined"))
+            .collect();
+        assert_eq!(
+            undefined_diags.len(),
+            0,
+            "Valid elem and data should not produce diagnostics, got: {:?}",
+            undefined_diags
         );
     }
 }

--- a/src/diagnostics_core/references.rs
+++ b/src/diagnostics_core/references.rs
@@ -2,6 +2,7 @@
 //!
 //! This module provides platform-agnostic functions for checking undefined
 //! references in WAT code.
+#![allow(clippy::borrow_deref_ref)]
 
 use crate::core::types::{Diagnostic, Position};
 use crate::symbols::SymbolTable;
@@ -445,6 +446,90 @@ pub fn create_undefined_reference_diagnostic(
     };
 
     Diagnostic::error(range, message)
+}
+
+/// Check module-level references: export descriptors, table_use, memory_use, elem_list,
+/// and abbreviated elem segments (module_field_elem with bare index children).
+///
+/// These are module-level constructs that reference symbols (functions, globals, tables,
+/// memories, tags) but aren't inside instructions, so the normal instruction-context
+/// checking doesn't cover them.
+pub fn check_module_level_references(
+    node: &Node,
+    source: &str,
+    symbols: &SymbolTable,
+) -> Vec<Diagnostic> {
+    #[cfg(feature = "native")]
+    let kind = node.kind();
+    #[cfg(all(feature = "wasm", not(feature = "native")))]
+    let kind = node.kind();
+
+    let context = match &*kind {
+        "export_desc_func" => InstructionContext::Call,
+        "export_desc_global" => InstructionContext::Global,
+        "export_desc_table" => InstructionContext::Table,
+        "export_desc_memory" => InstructionContext::Memory,
+        "export_desc_tag" => InstructionContext::Tag,
+        "table_use" => InstructionContext::Table,
+        "memory_use" => InstructionContext::Memory,
+        "elem_list" | "module_field_elem" => {
+            // elem_list: contains index nodes (func $a $b variant) or elem_expr children
+            //   (elem_expr contain instructions checked by the tree walk — skip those).
+            // module_field_elem: in the abbreviated form `(elem (offset) $a $b)`, bare
+            //   index nodes appear directly under module_field_elem without an elem_list.
+            //   The first index child (before offset) is the elem segment's own name — skip it.
+            let mut diagnostics = Vec::new();
+            let mut cursor = node.walk();
+            let is_field = &*kind == "module_field_elem";
+            let mut seen_offset = false;
+            for child in node.children(&mut cursor) {
+                #[cfg(feature = "native")]
+                let child_kind = child.kind();
+                #[cfg(all(feature = "wasm", not(feature = "native")))]
+                let child_kind = child.kind();
+
+                if is_field {
+                    // Track when we pass the offset — only index nodes after
+                    // offset/table_use/elem_list are function references.
+                    if child_kind == "offset" {
+                        seen_offset = true;
+                        continue;
+                    }
+                    // Skip non-index children and the optional name index before offset
+                    if child_kind != "index" || !seen_offset {
+                        continue;
+                    }
+                } else if child_kind != "index" {
+                    continue;
+                }
+
+                diagnostics.extend(find_undefined_identifiers(
+                    &child,
+                    source,
+                    symbols,
+                    &InstructionContext::Call,
+                ));
+            }
+            return diagnostics;
+        }
+        _ => return vec![],
+    };
+
+    // For export descriptors and table_use/memory_use, find the index child
+    // and validate its identifier
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        #[cfg(feature = "native")]
+        let child_kind = child.kind();
+        #[cfg(all(feature = "wasm", not(feature = "native")))]
+        let child_kind = child.kind();
+
+        if child_kind == "index" {
+            return find_undefined_identifiers(&child, source, symbols, &context);
+        }
+    }
+
+    vec![]
 }
 
 /// Check if a node is nested inside another expr (meaning it can't use stack values)

--- a/src/wasm/api.rs
+++ b/src/wasm/api.rs
@@ -1110,6 +1110,19 @@ fn walk_tree_for_diagnostics(
         return;
     }
 
+    // Check module-level references (exports, elem/data segment refs) — shared core
+    {
+        let module_ref_diags = crate::diagnostics_core::references::check_module_level_references(
+            &node, source, symbols,
+        );
+        if !module_ref_diags.is_empty() {
+            diagnostics.extend(module_ref_diags);
+            if &*kind != "module_field_elem" {
+                return;
+            }
+        }
+    }
+
     // Special handling for catch clauses — shared core
     if &*kind == "catch_clause" {
         diagnostics.extend(


### PR DESCRIPTION
Closes #168.

Adds `check_module_level_references()` to the shared diagnostics core, detecting undefined references in:
- Export descriptors (func, global, table, memory, tag)
- Elem segment function refs (both `elem_list` and abbreviated `(elem (offset) $a $b)` form)
- Elem segment `table_use` refs
- Data segment `memory_use` refs

Wired into both native and WASM tree walks. Includes 10 new unit tests and a playground example.