### PR TITLE
fix false positive diagnostics: grammar, arity, and reference validation (#173)

### DIFF
--- a/grammars/tree-sitter-wat/grammar.js
+++ b/grammars/tree-sitter-wat/grammar.js
@@ -333,11 +333,11 @@ module.exports = grammar({
         seq("ref.extern", $.nat),
         $.op_func_bind,
         $.op_let,
-        seq("table.get", $.index),
-        seq("table.set", $.index),
-        seq("table.size", $.index),
-        seq("table.grow", $.index),
-        seq("table.fill", $.index),
+        seq("table.get", optional($.index)),
+        seq("table.set", optional($.index)),
+        seq("table.size", optional($.index)),
+        seq("table.grow", optional($.index)),
+        seq("table.fill", optional($.index)),
       ),
 
     _instruction_atomic: $ =>
@@ -619,7 +619,7 @@ module.exports = grammar({
       token(
         new RegExp(
           [
-            "br(_(if|on_null))?",
+            "br(_(if|on_(non_)?null))?",
             "call",
             "data\\.drop",
             "elem\\.drop",
@@ -831,7 +831,7 @@ module.exports = grammar({
       ),
 
     module_field_rec: $ =>
-      seq("(", "rec", repeat1(seq("(", "type", optional(field("identifier", $.identifier)), $.type_field, ")")), ")"),
+      seq("(", "rec", repeat(seq("(", "type", optional(field("identifier", $.identifier)), $.type_field, ")")), ")"),
 
     module_field_tag: $ =>
       seq(
@@ -926,7 +926,7 @@ module.exports = grammar({
     table_fields_elem: $ =>
       seq($.ref_type, "(", "elem", choice(repeat($.index), seq($.elem_expr, repeat($.elem_expr))), ")"),
 
-    table_fields_type: $ => seq(optional($.import), $.table_type),
+    table_fields_type: $ => seq(optional($.import), $.table_type, optional($.expr)),
 
     // proposal: table64
     // Table type can optionally include 'i64' keyword for 64-bit indexing
@@ -956,7 +956,7 @@ module.exports = grammar({
 
     array_type: $ => seq("(", "array", $.storage_type, ")"),
 
-    field_type: $ => seq("(", "field", optional(field("identifier", $.identifier)), $.storage_type, ")"),
+    field_type: $ => seq("(", "field", optional(field("identifier", $.identifier)), repeat1($.storage_type), ")"),
 
     // Storage type can be mutable or immutable
     storage_type: $ => choice($.value_type, $.mut_storage_type),

--- a/src/diagnostics_core/folded_checks.rs
+++ b/src/diagnostics_core/folded_checks.rs
@@ -86,7 +86,11 @@ pub fn check_folded_operand_count(
                             instr_name, expected, operand_count
                         ),
                     ));
-                } else if operand_count > 0 && operand_count < expected && is_nested_in_expr(node) {
+                } else if operand_count > 0
+                    && operand_count < expected
+                    && is_nested_in_expr(node)
+                    && !has_unreachable_child(node, source)
+                {
                     diagnostics.push(Diagnostic::error(
                         node_to_range(node),
                         format!(
@@ -143,6 +147,7 @@ fn validate_dynamic_operands(
                             expected,
                             Some(&format!("fields of struct {}", type_display)),
                             diagnostics,
+                            source,
                         );
                     }
                 }
@@ -167,6 +172,7 @@ fn validate_dynamic_operands(
                         expected,
                         Some(&format!("params of function {}", func_display)),
                         diagnostics,
+                        source,
                     );
                 }
             }
@@ -190,6 +196,7 @@ fn validate_dynamic_operands(
                         expected,
                         Some(&format!("params of tag {}", tag_display)),
                         diagnostics,
+                        source,
                     );
                 }
             }
@@ -219,6 +226,7 @@ fn validate_dynamic_operands(
                                 type_display
                             )),
                             diagnostics,
+                            source,
                         );
                     }
                 }
@@ -236,6 +244,7 @@ fn emit_operand_diagnostic(
     expected: usize,
     context_msg: Option<&str>,
     diagnostics: &mut Vec<Diagnostic>,
+    source: &str,
 ) {
     if actual > expected {
         let msg = if let Some(ctx) = context_msg {
@@ -250,7 +259,11 @@ fn emit_operand_diagnostic(
             )
         };
         diagnostics.push(Diagnostic::error(node_to_range(node), msg));
-    } else if actual > 0 && actual < expected && is_nested_in_expr(node) {
+    } else if actual > 0
+        && actual < expected
+        && is_nested_in_expr(node)
+        && !has_unreachable_child(node, source)
+    {
         diagnostics.push(Diagnostic::error(
             node_to_range(node),
             format!(
@@ -286,4 +299,71 @@ fn extract_instruction_index(node: &Node, source: &str) -> Option<String> {
         }
     }
     None
+}
+
+/// Check if the instruction is in an unreachable context — either one of its
+/// child operands contains `unreachable`, or a preceding sibling expression
+/// in any ancestor scope is `unreachable`.
+fn has_unreachable_child(node: &Node, source: &str) -> bool {
+    // Check direct children
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "expr" && contains_unreachable(&child, source) {
+            return true;
+        }
+    }
+    // Check if any preceding sibling in ancestor scopes is unreachable
+    is_preceded_by_unreachable(node, source)
+}
+
+/// Walk up the tree checking if any preceding sibling contains `unreachable`.
+fn is_preceded_by_unreachable(node: &Node, source: &str) -> bool {
+    let node_start = node.byte_range().start;
+    let mut current_opt = node.parent();
+    while let Some(parent) = current_opt {
+        let kind = parent.kind();
+        // Stop at function/module level
+        if kind == "module_field_func" || kind == "func" || kind == "module" {
+            break;
+        }
+        // Check preceding siblings for unreachable
+        let mut cursor = parent.walk();
+        for child in parent.children(&mut cursor) {
+            if child.byte_range().start >= node_start {
+                break;
+            }
+            if contains_unreachable(&child, source) {
+                return true;
+            }
+        }
+        current_opt = parent.parent();
+    }
+    false
+}
+
+/// Recursively check if a node contains a non-returning instruction
+/// (`unreachable`, `br`, `br_table`, `return`, `throw`).
+fn contains_unreachable(node: &Node, source: &str) -> bool {
+    let kind = node.kind();
+    if kind == "op_nullary" {
+        let text = &source[node.byte_range()];
+        return text == "unreachable" || text == "return";
+    }
+    if kind == "op_index" {
+        let text = &source[node.byte_range()];
+        // br, br_table, throw, return_call — unconditionally transfer control
+        // br_on_null, br_on_non_null — may push multiple values, suppress arity check
+        let first = text.split_whitespace().next().unwrap_or("");
+        return matches!(
+            first,
+            "br" | "br_table" | "return_call" | "br_on_null" | "br_on_non_null"
+        );
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if contains_unreachable(&child, source) {
+            return true;
+        }
+    }
+    false
 }

--- a/src/diagnostics_core/references.rs
+++ b/src/diagnostics_core/references.rs
@@ -410,13 +410,61 @@ pub fn check_references(
         return find_first_index_identifier(node, source, symbols, context);
     }
 
-    // memory.init takes a data segment index, not a memory index
-    // Skip validation since we don't track data segments yet
-    if *context == InstructionContext::Memory && first_token == "memory.init" {
-        return vec![];
+    // Multi-index instructions: table.init takes (elem_idx, table_idx),
+    // memory.init takes (data_idx, memory_idx). The context from
+    // determine_instruction_context_at_node applies only to the first index.
+    if first_token == "table.init" || first_token == "memory.init" {
+        let second_context = if first_token == "table.init" {
+            InstructionContext::Table
+        } else {
+            InstructionContext::Memory
+        };
+        return check_multi_index_instruction(node, source, symbols, context, &second_context);
     }
 
     find_undefined_identifiers(node, source, symbols, context)
+}
+
+/// Check a multi-index instruction where the first and second index have different contexts.
+/// E.g. `table.init $elem $table` or `memory.init $data $memory`.
+fn check_multi_index_instruction(
+    node: &Node,
+    source: &str,
+    symbols: &SymbolTable,
+    first_context: &InstructionContext,
+    second_context: &InstructionContext,
+) -> Vec<Diagnostic> {
+    let mut diagnostics = Vec::new();
+    let mut index_count = 0;
+
+    // Walk the node tree to find index nodes. They may be nested several
+    // levels deep: expr1_plain → instr_plain → op_table_init → index
+    find_indices_recursive(node, &mut |index_node| {
+        let ctx = if index_count == 0 {
+            first_context
+        } else {
+            second_context
+        };
+        diagnostics.extend(find_undefined_identifiers(index_node, source, symbols, ctx));
+        index_count += 1;
+    });
+
+    diagnostics
+}
+
+/// Recursively find all `index` nodes within instruction wrapper nodes.
+/// Recurses into `instr_plain` and `op_*` nodes but stops at `expr` nodes
+/// (which are operand sub-expressions, not part of the instruction itself).
+fn find_indices_recursive(node: &Node, callback: &mut impl FnMut(&Node)) {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        let kind = child.kind();
+        if kind == "index" {
+            callback(&child);
+        } else if kind == "instr_plain" || kind.starts_with("op_") {
+            find_indices_recursive(&child, callback);
+        }
+    }
 }
 
 /// Create a diagnostic for an undefined reference

--- a/src/instruction_metadata.rs
+++ b/src/instruction_metadata.rs
@@ -516,14 +516,15 @@ pub fn get_instruction_arity_map() -> HashMap<&'static str, InstructionArity> {
         InstructionArity::dynamic(1, 1, "type index", 0), // args + funcref -> terminates (tail call)
     );
 
-    // Null-checking branches
+    // Null-checking branches — operand count depends on branch target arity
+    // (branch args + ref to test), so use dynamic mode
     map.insert(
         "br_on_null",
-        InstructionArity::exact(1, "label index", 1, 1),
-    ); // ref -> non-null ref (or branches)
+        InstructionArity::dynamic(1, 1, "label index", 1),
+    );
     map.insert(
         "br_on_non_null",
-        InstructionArity::exact(1, "label index", 1, 0), // ref -> (branches with non-null or continues with nothing)
+        InstructionArity::dynamic(1, 1, "label index", 0),
     );
 
     // Reference equality

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1256,24 +1256,45 @@ fn extract_type_from_single_node(
             };
         }
         "type_field" => {
-            // This is a func type inside a type_field wrapper
-            let mut parameters = Vec::new();
-            let mut results = Vec::new();
+            // type_field wraps a def_type: func_type, struct_type, array_type, or sub_type
             let mut cursor = type_node.walk();
             for child in type_node.children(&mut cursor) {
-                if child.kind() == "func_type" {
-                    let params = extract_parameters(&child, source);
-                    for param in params {
-                        parameters.push(param.param_type);
+                let child_kind = child.kind();
+                #[cfg(all(feature = "wasm", not(feature = "native")))]
+                let child_kind = child_kind.as_str();
+                match child_kind {
+                    "func_type" => {
+                        let mut parameters = Vec::new();
+                        let mut results = Vec::new();
+                        let params = extract_parameters(&child, source);
+                        for param in params {
+                            parameters.push(param.param_type);
+                        }
+                        results.extend(extract_results(&child, source));
+                        if !parameters.is_empty() || !results.is_empty() {
+                            kind = TypeKind::Func {
+                                params: parameters,
+                                results,
+                            };
+                        }
+                        break;
                     }
-                    results.extend(extract_results(&child, source));
+                    "struct_type" => {
+                        kind = extract_struct_kind(&child, source);
+                        break;
+                    }
+                    "array_type" => {
+                        kind = extract_array_kind(&child, source);
+                        break;
+                    }
+                    "sub_type" => {
+                        // Delegate to extract_type_from_single_node for sub_type
+                        return extract_type_from_single_node(
+                            &child, source, index, name, name_range,
+                        );
+                    }
+                    _ => {}
                 }
-            }
-            if !parameters.is_empty() || !results.is_empty() {
-                kind = TypeKind::Func {
-                    params: parameters,
-                    results,
-                };
             }
         }
         _ => return None,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -57,7 +57,13 @@ pub const BLOCK_KINDS_STATEMENT: &[&str] = &[
 ];
 
 /// All block-related node kinds (expression form)
-pub const BLOCK_KINDS_EXPR: &[&str] = &["expr1_block", "expr1_loop", "expr1_if", "expr1_try"];
+pub const BLOCK_KINDS_EXPR: &[&str] = &[
+    "expr1_block",
+    "expr1_loop",
+    "expr1_if",
+    "expr1_try",
+    "expr1_try_table",
+];
 
 /// All block-related node kinds (instruction form used in some contexts)
 pub const BLOCK_KINDS_INSTR: &[&str] = &["instr_block", "instr_loop"];
@@ -91,7 +97,7 @@ pub fn block_type_from_kind(kind: &str) -> &'static str {
         "block_loop" | "expr1_loop" | "instr_loop" => "loop",
         "block_if" | "expr1_if" => "if",
         "block_try" | "expr1_try" => "try",
-        "block_try_table" => "try_table",
+        "block_try_table" | "expr1_try_table" => "try_table",
         _ => "unknown",
     }
 }


### PR DESCRIPTION
## Summary

Improves valid module pass rate from 982/1038 (94.6%) to 1011/1038 (97.4%) against the WebAssembly spec test suite.

- **Grammar fixes**: Added `br_on_non_null` instruction, made table op indices optional, added table init expressions, allowed empty `(rec)` groups, multi-field abbreviated syntax
- **Reference validation**: `table.init` and `memory.init` now correctly validate first index as elem/data and second as table/memory
- **Type extraction**: `type_field` in rec groups now handles `struct_type`, `array_type`, and `sub_type` children
- **Arity checks**: Skip "too few operands" diagnostic when preceded by unreachable/br/return; `br_on_null`/`br_on_non_null` use dynamic arity
- **Block labels**: `expr1_try_table` added to BLOCK_KINDS_EXPR for label tracking

--- 

- closes https://github.com/EmNudge/wat-lsp/issues/173