### PR TITLE
validate SIMD lane indices and unknown numeric index references (#176)

### DIFF
--- a/src/diagnostics/semantic_diagnostics.rs
+++ b/src/diagnostics/semantic_diagnostics.rs
@@ -213,6 +213,24 @@ fn unified_tree_walk(
         // Continue to recurse - nested expressions need to be checked
     }
 
+    // Check SIMD lane indices (must be before context check since v128.load*_lane
+    // matches Memory context and would early-return before we check lane bounds)
+    if kind == "instr_plain" {
+        let core_diags = crate::diagnostics_core::simd_checks::check_simd_lane_index(&node, source);
+        diagnostics.extend(core_diags.into_iter().map(Into::into));
+    } else if kind == "expr1_plain" {
+        // In folded form, instr_plain is a child that won't be visited separately
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            if child.kind() == "instr_plain" {
+                let core_diags =
+                    crate::diagnostics_core::simd_checks::check_simd_lane_index(&child, source);
+                diagnostics.extend(core_diags.into_iter().map(Into::into));
+                break;
+            }
+        }
+    }
+
     // Check for undefined references based on instruction context
     // This handles instr_plain nodes and returns early after recursing into nested expr
     let context = determine_instruction_context_at_node(&node, source);

--- a/src/diagnostics_core/mod.rs
+++ b/src/diagnostics_core/mod.rs
@@ -9,6 +9,7 @@ pub mod memory_checks;
 pub mod module_checks;
 pub mod references;
 mod semantic;
+pub mod simd_checks;
 mod stack;
 pub mod subtype;
 mod termination;

--- a/src/diagnostics_core/references.rs
+++ b/src/diagnostics_core/references.rs
@@ -44,52 +44,16 @@ pub fn check_catch_clause_references(
         .collect();
 
     for (i, index_node) in indices.iter().enumerate() {
-        // Find the identifier within the index
-        let mut idx_cursor = index_node.walk();
-        for child in index_node.children(&mut idx_cursor) {
-            #[cfg(feature = "native")]
-            let kind = child.kind();
-            #[cfg(all(feature = "wasm", not(feature = "native")))]
-            let kind = child.kind();
-
-            if kind == "identifier" {
-                let identifier_name = &source[child.byte_range()];
-                if !identifier_name.starts_with('$') {
-                    continue;
-                }
-
-                let start_point = child.start_position();
-                let position = Position::new(start_point.row as u32, start_point.column as u32);
-
-                // First index is tag (if has_tag), remaining are labels
-                let is_tag_reference = has_tag && i == 0;
-
-                let is_defined = if is_tag_reference {
-                    symbols.get_tag_by_name(identifier_name).is_some()
-                } else {
-                    // Label reference - check block labels in containing function
-                    if let Some(func) = find_containing_function(symbols, position) {
-                        func.blocks.iter().any(|block| {
-                            format!("${}", block.label) == identifier_name
-                                || block.label == identifier_name
-                        })
-                    } else {
-                        false
-                    }
-                };
-
-                if !is_defined {
-                    let context = if is_tag_reference {
-                        InstructionContext::Tag
-                    } else {
-                        InstructionContext::Branch
-                    };
-                    let diagnostic =
-                        create_undefined_reference_diagnostic(&child, identifier_name, &context);
-                    diagnostics.push(diagnostic);
-                }
-            }
-        }
+        // First index is tag (if has_tag), remaining are labels
+        let is_tag_reference = has_tag && i == 0;
+        let context = if is_tag_reference {
+            InstructionContext::Tag
+        } else {
+            InstructionContext::Branch
+        };
+        diagnostics.extend(find_undefined_identifiers(
+            index_node, source, symbols, &context,
+        ));
     }
 
     diagnostics
@@ -102,9 +66,6 @@ pub fn check_try_catch_clause_references(
     source: &str,
     symbols: &SymbolTable,
 ) -> Vec<Diagnostic> {
-    let mut diagnostics = Vec::new();
-
-    // Find the index child which contains the tag reference
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         #[cfg(feature = "native")]
@@ -113,37 +74,11 @@ pub fn check_try_catch_clause_references(
         let kind = child.kind();
 
         if kind == "index" {
-            // Find the identifier within the index
-            let mut idx_cursor = child.walk();
-            for idx_child in child.children(&mut idx_cursor) {
-                #[cfg(feature = "native")]
-                let idx_kind = idx_child.kind();
-                #[cfg(all(feature = "wasm", not(feature = "native")))]
-                let idx_kind = idx_child.kind();
-
-                if idx_kind == "identifier" {
-                    let identifier_name = &source[idx_child.byte_range()];
-                    if !identifier_name.starts_with('$') {
-                        continue;
-                    }
-
-                    // Check if the tag is defined
-                    if symbols.get_tag_by_name(identifier_name).is_none() {
-                        let diagnostic = create_undefined_reference_diagnostic(
-                            &idx_child,
-                            identifier_name,
-                            &InstructionContext::Tag,
-                        );
-                        diagnostics.push(diagnostic);
-                    }
-                }
-            }
-            // Only one index in try_catch_clause
-            break;
+            return find_undefined_identifiers(&child, source, symbols, &InstructionContext::Tag);
         }
     }
 
-    diagnostics
+    vec![]
 }
 
 /// Check references in a try_delegate_clause node (legacy try syntax)
@@ -153,9 +88,6 @@ pub fn check_try_delegate_clause_references(
     source: &str,
     symbols: &SymbolTable,
 ) -> Vec<Diagnostic> {
-    let mut diagnostics = Vec::new();
-
-    // Find the index child which contains the label reference
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         #[cfg(feature = "native")]
@@ -164,57 +96,21 @@ pub fn check_try_delegate_clause_references(
         let kind = child.kind();
 
         if kind == "index" {
-            // Find the identifier within the index
-            let mut idx_cursor = child.walk();
-            for idx_child in child.children(&mut idx_cursor) {
-                #[cfg(feature = "native")]
-                let idx_kind = idx_child.kind();
-                #[cfg(all(feature = "wasm", not(feature = "native")))]
-                let idx_kind = idx_child.kind();
-
-                if idx_kind == "identifier" {
-                    let identifier_name = &source[idx_child.byte_range()];
-                    if !identifier_name.starts_with('$') {
-                        continue;
-                    }
-
-                    let start_point = idx_child.start_position();
-                    let position = Position::new(start_point.row as u32, start_point.column as u32);
-
-                    // Check if the label is defined
-                    let is_defined = if let Some(func) = find_containing_function(symbols, position)
-                    {
-                        func.blocks.iter().any(|block| {
-                            format!("${}", block.label) == identifier_name
-                                || block.label == identifier_name
-                        })
-                    } else {
-                        false
-                    };
-
-                    if !is_defined {
-                        let diagnostic = create_undefined_reference_diagnostic(
-                            &idx_child,
-                            identifier_name,
-                            &InstructionContext::Branch,
-                        );
-                        diagnostics.push(diagnostic);
-                    }
-                }
-            }
-            // Only one index in try_delegate_clause
-            break;
+            return find_undefined_identifiers(
+                &child,
+                source,
+                symbols,
+                &InstructionContext::Branch,
+            );
         }
     }
 
-    diagnostics
+    vec![]
 }
 
 /// Check the function reference in a module_field_start node.
 /// The start directive takes a single function index: (start $func) or (start 0)
 pub fn check_start_references(node: &Node, source: &str, symbols: &SymbolTable) -> Vec<Diagnostic> {
-    let mut diagnostics = Vec::new();
-
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         #[cfg(feature = "native")]
@@ -223,34 +119,11 @@ pub fn check_start_references(node: &Node, source: &str, symbols: &SymbolTable) 
         let kind = child.kind();
 
         if kind == "index" {
-            let mut idx_cursor = child.walk();
-            for idx_child in child.children(&mut idx_cursor) {
-                #[cfg(feature = "native")]
-                let idx_kind = idx_child.kind();
-                #[cfg(all(feature = "wasm", not(feature = "native")))]
-                let idx_kind = idx_child.kind();
-
-                if idx_kind == "identifier" {
-                    let identifier_name = &source[idx_child.byte_range()];
-                    if !identifier_name.starts_with('$') {
-                        continue;
-                    }
-
-                    if symbols.get_function_by_name(identifier_name).is_none() {
-                        let diagnostic = create_undefined_reference_diagnostic(
-                            &idx_child,
-                            identifier_name,
-                            &InstructionContext::Call,
-                        );
-                        diagnostics.push(diagnostic);
-                    }
-                }
-            }
-            break;
+            return find_undefined_identifiers(&child, source, symbols, &InstructionContext::Call);
         }
     }
 
-    diagnostics
+    vec![]
 }
 
 /// Find and validate only the first index identifier in a node
@@ -374,6 +247,75 @@ pub fn find_undefined_identifiers(
         if !is_defined {
             let diagnostic = create_undefined_reference_diagnostic(node, identifier_name, context);
             diagnostics.push(diagnostic);
+        }
+        return diagnostics;
+    }
+
+    // Check numeric indices (nat nodes inside index parents)
+    if kind == "nat" {
+        // Only validate nat nodes that are inside an index node
+        let in_index = node
+            .parent()
+            .map(|p| {
+                let pk = p.kind();
+                #[cfg(feature = "native")]
+                {
+                    pk == "index"
+                }
+                #[cfg(all(feature = "wasm", not(feature = "native")))]
+                {
+                    &*pk == "index"
+                }
+            })
+            .unwrap_or(false);
+
+        if in_index {
+            let nat_text = &source[node.byte_range()];
+            if let Ok(idx) = nat_text.parse::<usize>() {
+                let start_point = node.start_position();
+                let position = Position::new(start_point.row as u32, start_point.column as u32);
+
+                let is_valid = match context {
+                    InstructionContext::Call => idx < symbols.functions.len(),
+                    InstructionContext::Local => {
+                        if let Some(func) = find_containing_function(symbols, position) {
+                            idx < func.parameters.len() + func.locals.len()
+                        } else {
+                            true
+                        }
+                    }
+                    InstructionContext::Global => idx < symbols.globals.len(),
+                    InstructionContext::Table => idx < symbols.tables.len(),
+                    InstructionContext::Memory => idx < symbols.memories.len(),
+                    InstructionContext::Tag => idx < symbols.tags.len(),
+                    InstructionContext::Data => idx < symbols.data_segments.len(),
+                    InstructionContext::Elem => idx < symbols.elem_segments.len(),
+                    // Type indices can't be reliably validated because implicit types
+                    // (created by function signatures) aren't tracked in the symbol table.
+                    // Branch indices are depth-relative, not absolute — skip.
+                    InstructionContext::Type
+                    | InstructionContext::Branch
+                    | InstructionContext::Block
+                    | InstructionContext::Function
+                    | InstructionContext::General => true,
+                };
+
+                if !is_valid {
+                    let range = node_to_range(node);
+                    let message = match context {
+                        InstructionContext::Call => format!("unknown function {}", idx),
+                        InstructionContext::Local => format!("unknown local {}", idx),
+                        InstructionContext::Global => format!("unknown global {}", idx),
+                        InstructionContext::Table => format!("unknown table {}", idx),
+                        InstructionContext::Memory => format!("unknown memory {}", idx),
+                        InstructionContext::Tag => format!("unknown tag {}", idx),
+                        InstructionContext::Data => format!("unknown data segment {}", idx),
+                        InstructionContext::Elem => format!("unknown elem segment {}", idx),
+                        _ => unreachable!(),
+                    };
+                    diagnostics.push(Diagnostic::error(range, message));
+                }
+            }
         }
         return diagnostics;
     }

--- a/src/diagnostics_core/simd_checks.rs
+++ b/src/diagnostics_core/simd_checks.rs
@@ -1,0 +1,333 @@
+//! Shared SIMD lane index validation for both native and WASM builds.
+//!
+//! Validates that SIMD lane indices are within the valid range for each instruction.
+
+use crate::core::types::Diagnostic;
+use crate::utils::node_to_range;
+
+#[cfg(feature = "native")]
+use tree_sitter::Node;
+
+#[cfg(all(feature = "wasm", not(feature = "native")))]
+use crate::ts_facade::Node;
+
+/// Check SIMD lane indices in an `instr_plain` node.
+///
+/// Returns diagnostics for any lane index that exceeds the valid range
+/// for the given instruction.
+pub fn check_simd_lane_index(node: &Node, source: &str) -> Vec<Diagnostic> {
+    let mut diagnostics = Vec::new();
+
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        let kind = child.kind();
+        #[cfg(feature = "native")]
+        let kind_ref = kind;
+        #[cfg(all(feature = "wasm", not(feature = "native")))]
+        let kind_ref = &*kind;
+
+        if kind_ref == "op_simd_lane" {
+            // op_simd_lane contains instr_name + int children
+            // Extract the instruction name from the first child
+            let instr_name = find_instr_name(&child, source);
+            if let Some(max_lane) = max_lane_index(&instr_name) {
+                // Collect all int children and validate
+                let mut int_cursor = child.walk();
+                for int_child in child.children(&mut int_cursor) {
+                    let int_kind = int_child.kind();
+                    #[cfg(feature = "native")]
+                    let int_kind_ref = int_kind;
+                    #[cfg(all(feature = "wasm", not(feature = "native")))]
+                    let int_kind_ref = &*int_kind;
+
+                    if int_kind_ref == "int" {
+                        if let Some(diag) = validate_lane_value(&int_child, source, max_lane) {
+                            diagnostics.push(diag);
+                        }
+                    }
+                }
+            }
+        } else if kind_ref == "op_simd_lane_memarg" {
+            // op_simd_lane_memarg is a token like "v128.load8_lane"
+            // The int child is a sibling of op_simd_lane_memarg under instr_plain
+            let memarg_text = &source[child.byte_range()];
+            if let Some(max_lane) = max_lane_index(memarg_text) {
+                // Find the int sibling (last int child of the instr_plain parent)
+                let mut parent_cursor = node.walk();
+                for sibling in node.children(&mut parent_cursor) {
+                    let sib_kind = sibling.kind();
+                    #[cfg(feature = "native")]
+                    let sib_kind_ref = sib_kind;
+                    #[cfg(all(feature = "wasm", not(feature = "native")))]
+                    let sib_kind_ref = &*sib_kind;
+
+                    if sib_kind_ref == "int" {
+                        if let Some(diag) = validate_lane_value(&sibling, source, max_lane) {
+                            diagnostics.push(diag);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    diagnostics
+}
+
+/// Find the instruction name from an op_simd_lane node.
+/// The grammar splits the instruction name into multiple `instr_name` children
+/// (e.g., "i8x16", ".", "extract_lane", "_", "s"), so we concatenate them all.
+fn find_instr_name(node: &Node, source: &str) -> String {
+    let mut name = String::new();
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        let kind = child.kind();
+        #[cfg(feature = "native")]
+        let kind_ref = kind;
+        #[cfg(all(feature = "wasm", not(feature = "native")))]
+        let kind_ref = &*kind;
+
+        if kind_ref == "instr_name" {
+            name.push_str(&source[child.byte_range()]);
+        }
+    }
+    if name.is_empty() {
+        // Fallback: use the text from the node's first token
+        source[node.byte_range()]
+            .split_whitespace()
+            .next()
+            .unwrap_or("")
+            .to_string()
+    } else {
+        name
+    }
+}
+
+/// Validate a single lane index value against the maximum.
+fn validate_lane_value(int_node: &Node, source: &str, max_lane: u32) -> Option<Diagnostic> {
+    let text = &source[int_node.byte_range()];
+    // Lane indices must be non-negative integers
+    // The `int` node may have a sign child; negative values are always invalid
+    if text.starts_with('-') {
+        return Some(Diagnostic::error(
+            node_to_range(int_node),
+            "invalid lane index".to_string(),
+        ));
+    }
+    if let Ok(value) = text.trim_start_matches('+').parse::<u32>() {
+        if value > max_lane {
+            return Some(Diagnostic::error(
+                node_to_range(int_node),
+                "invalid lane index".to_string(),
+            ));
+        }
+    }
+    None
+}
+
+/// Get the maximum valid lane index for a SIMD instruction.
+///
+/// Returns `None` if the instruction is not a SIMD lane instruction.
+fn max_lane_index(instr_name: &str) -> Option<u32> {
+    // i8x16.shuffle: selects from two concatenated v128s (32 lanes total)
+    if instr_name == "i8x16.shuffle" {
+        return Some(31);
+    }
+
+    // Extract/replace lane instructions: max = (128 / lane_bits) - 1
+    if instr_name.contains("extract_lane") || instr_name.contains("replace_lane") {
+        return lane_count_from_prefix(instr_name).map(|count| count - 1);
+    }
+
+    // v128.load/store lane: max = (128 / lane_bits) - 1
+    if instr_name.starts_with("v128.load") || instr_name.starts_with("v128.store") {
+        if let Some(bits) = extract_lane_bits_from_memarg(instr_name) {
+            return Some(128 / bits - 1);
+        }
+    }
+
+    None
+}
+
+/// Get the number of lanes from an instruction prefix like "i8x16", "i32x4", etc.
+fn lane_count_from_prefix(instr_name: &str) -> Option<u32> {
+    let prefix = instr_name.split('.').next()?;
+    match prefix {
+        "i8x16" => Some(16),
+        "i16x8" => Some(8),
+        "i32x4" | "f32x4" => Some(4),
+        "i64x2" | "f64x2" => Some(2),
+        _ => None,
+    }
+}
+
+/// Extract lane bit width from a v128.load/store lane instruction name.
+/// E.g., "v128.load8_lane" -> 8, "v128.store64_lane" -> 64
+fn extract_lane_bits_from_memarg(instr_name: &str) -> Option<u32> {
+    // Pattern: v128.{load|store}{8|16|32|64}_lane
+    let after_op = instr_name
+        .strip_prefix("v128.load")
+        .or_else(|| instr_name.strip_prefix("v128.store"))?;
+
+    let bits_str = after_op.split('_').next()?;
+    bits_str.parse::<u32>().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_max_lane_index() {
+        // Extract lane instructions
+        assert_eq!(max_lane_index("i8x16.extract_lane_s"), Some(15));
+        assert_eq!(max_lane_index("i8x16.extract_lane_u"), Some(15));
+        assert_eq!(max_lane_index("i16x8.extract_lane_s"), Some(7));
+        assert_eq!(max_lane_index("i16x8.extract_lane_u"), Some(7));
+        assert_eq!(max_lane_index("i32x4.extract_lane"), Some(3));
+        assert_eq!(max_lane_index("i64x2.extract_lane"), Some(1));
+        assert_eq!(max_lane_index("f32x4.extract_lane"), Some(3));
+        assert_eq!(max_lane_index("f64x2.extract_lane"), Some(1));
+
+        // Replace lane instructions
+        assert_eq!(max_lane_index("i8x16.replace_lane"), Some(15));
+        assert_eq!(max_lane_index("i16x8.replace_lane"), Some(7));
+        assert_eq!(max_lane_index("i32x4.replace_lane"), Some(3));
+        assert_eq!(max_lane_index("i64x2.replace_lane"), Some(1));
+        assert_eq!(max_lane_index("f32x4.replace_lane"), Some(3));
+        assert_eq!(max_lane_index("f64x2.replace_lane"), Some(1));
+
+        // Shuffle
+        assert_eq!(max_lane_index("i8x16.shuffle"), Some(31));
+
+        // Memory lane operations
+        assert_eq!(max_lane_index("v128.load8_lane"), Some(15));
+        assert_eq!(max_lane_index("v128.load16_lane"), Some(7));
+        assert_eq!(max_lane_index("v128.load32_lane"), Some(3));
+        assert_eq!(max_lane_index("v128.load64_lane"), Some(1));
+        assert_eq!(max_lane_index("v128.store8_lane"), Some(15));
+        assert_eq!(max_lane_index("v128.store16_lane"), Some(7));
+        assert_eq!(max_lane_index("v128.store32_lane"), Some(3));
+        assert_eq!(max_lane_index("v128.store64_lane"), Some(1));
+
+        // Non-lane instructions
+        assert_eq!(max_lane_index("i32.add"), None);
+        assert_eq!(max_lane_index("v128.load"), None);
+        assert_eq!(max_lane_index("i8x16.add"), None);
+    }
+
+    #[cfg(feature = "native")]
+    mod integration {
+        use crate::parser::parse_document;
+        use crate::tree_sitter_bindings::create_parser;
+
+        fn get_diagnostics(source: &str) -> Vec<String> {
+            let mut parser = create_parser();
+            let tree = parser.parse(source, None).unwrap();
+            let symbols = parse_document(source).expect("Failed to extract symbols");
+            let diags = crate::diagnostics::provide_semantic_diagnostics(&tree, source, &symbols);
+            diags
+                .iter()
+                .filter(|d| d.message == "invalid lane index")
+                .map(|d| d.message.clone())
+                .collect()
+        }
+
+        #[test]
+        fn test_valid_lane_indices() {
+            // These should produce no diagnostics
+            let source = r#"(module
+                (func
+                    i32.const 0
+                    i8x16.extract_lane_s 0
+                    drop
+                    i32.const 0
+                    i8x16.extract_lane_s 15
+                    drop
+                    i32.const 0
+                    i32x4.extract_lane 3
+                    drop
+                    i32.const 0
+                    i64x2.extract_lane 1
+                    drop
+                )
+            )"#;
+            assert!(get_diagnostics(source).is_empty());
+        }
+
+        #[test]
+        fn test_invalid_lane_index_i8x16() {
+            let source = r#"(module
+                (func
+                    i32.const 0
+                    i8x16.extract_lane_s 16
+                    drop
+                )
+            )"#;
+            assert_eq!(get_diagnostics(source).len(), 1);
+        }
+
+        #[test]
+        fn test_invalid_lane_index_i32x4() {
+            let source = r#"(module
+                (func
+                    i32.const 0
+                    i32x4.extract_lane 4
+                    drop
+                )
+            )"#;
+            assert_eq!(get_diagnostics(source).len(), 1);
+        }
+
+        #[test]
+        fn test_invalid_lane_index_i64x2() {
+            let source = r#"(module
+                (func
+                    i64.const 0
+                    i64x2.extract_lane 2
+                    drop
+                )
+            )"#;
+            assert_eq!(get_diagnostics(source).len(), 1);
+        }
+
+        #[test]
+        fn test_invalid_shuffle_index() {
+            let source = r#"(module
+                (func
+                    v128.const i32x4 0 0 0 0
+                    v128.const i32x4 0 0 0 0
+                    i8x16.shuffle 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 32
+                    drop
+                )
+            )"#;
+            assert_eq!(get_diagnostics(source).len(), 1);
+        }
+
+        #[test]
+        fn test_valid_shuffle_max() {
+            let source = r#"(module
+                (func
+                    v128.const i32x4 0 0 0 0
+                    v128.const i32x4 0 0 0 0
+                    i8x16.shuffle 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 31
+                    drop
+                )
+            )"#;
+            assert!(get_diagnostics(source).is_empty());
+        }
+
+        #[test]
+        fn test_replace_lane_invalid() {
+            let source = r#"(module
+                (func
+                    v128.const i32x4 0 0 0 0
+                    f32.const 0
+                    f32x4.replace_lane 4
+                    drop
+                )
+            )"#;
+            assert_eq!(get_diagnostics(source).len(), 1);
+        }
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -246,6 +246,8 @@ pub fn determine_instruction_context_at_node(node: &Node, document: &str) -> Ins
             || first_token == "return_call_ref"
         {
             return InstructionContext::Type;
+        } else if first_token == "ref.func" || first_token == "return_call" {
+            return InstructionContext::Call;
         } else if first_token.starts_with("br") {
             return InstructionContext::Branch;
         } else if first_token.starts_with("call") && first_token != "call_indirect" {

--- a/src/wasm/api.rs
+++ b/src/wasm/api.rs
@@ -1188,6 +1188,25 @@ fn walk_tree_for_diagnostics(
         }
     }
 
+    // Check SIMD lane indices (must be before context check since v128.load*_lane
+    // matches Memory context and would early-return before we check lane bounds)
+    if &*kind == "instr_plain" {
+        diagnostics.extend(crate::diagnostics_core::simd_checks::check_simd_lane_index(
+            &node, source,
+        ));
+    } else if &*kind == "expr1_plain" {
+        // In folded form, instr_plain is a child that won't be visited separately
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            if child.kind() == "instr_plain" {
+                diagnostics.extend(crate::diagnostics_core::simd_checks::check_simd_lane_index(
+                    &child, source,
+                ));
+                break;
+            }
+        }
+    }
+
     // Check for undefined references based on instruction context — shared core
     let context = determine_instruction_context_at_node(&node, source);
     if context != InstructionContext::General {


### PR DESCRIPTION
## Summary

- **+103 assert_invalid spec tests passing** (506→609) with zero valid module regressions
- New `diagnostics_core/simd_checks.rs`: validates SIMD lane indices (extract_lane, replace_lane, shuffle, load/store lane) — 45 spec tests now pass
- Extended `find_undefined_identifiers()` to validate numeric indices (`nat` nodes) against symbol table counts for functions, locals, globals, tables, memories, tags, data/elem segments
- Simplified `check_start_references`, `check_catch_clause_references`, `check_try_catch/delegate_clause_references` to delegate to shared `find_undefined_identifiers`
- Fixed `ref.func` and `return_call` instruction context detection (were General, now Call)

Closes #176