### PR TITLE
defrag: gate serde as native-only and extract shared diagnostic tree walk

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ native = [
     "dep:wast",
     "dep:regex",
     "dep:serde_json",
+    "dep:serde",
 ]
 wasm = [
     "dep:wasm-bindgen",
@@ -62,8 +63,8 @@ wasm = [
 ]
 
 [dependencies]
-# Core dependencies (always included)
-serde = { version = "1.0", features = ["derive"] }
+# Native-only serialization (not needed by WASM — uses js_sys for JS conversion)
+serde = { version = "1.0", features = ["derive"], optional = true }
 
 # Native-only core dependencies
 serde_json = { version = "1.0", optional = true }

--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -3,13 +3,15 @@
 //! These types have no dependencies on tower-lsp or wasm-bindgen,
 //! allowing them to be used in both native and WASM builds.
 
+#[cfg(feature = "native")]
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "native")]
 use tower_lsp::lsp_types as lsp;
 
 /// Completion item kind (matches LSP CompletionItemKind values)
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "native", derive(Serialize, Deserialize))]
 #[repr(u8)]
 pub enum CompletionItemKind {
     Text = 1,
@@ -40,7 +42,8 @@ pub enum CompletionItemKind {
 }
 
 /// Insert text format for completion items
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "native", derive(Serialize, Deserialize))]
 #[repr(u8)]
 pub enum InsertTextFormat {
     PlainText = 1,
@@ -48,7 +51,8 @@ pub enum InsertTextFormat {
 }
 
 /// A completion item for code suggestions
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "native", derive(Serialize, Deserialize))]
 pub struct CompletionItem {
     /// The label shown in the completion list
     pub label: String,
@@ -99,7 +103,8 @@ impl CompletionItem {
 }
 
 /// A position in a text document (0-indexed line and character)
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "native", derive(Serialize, Deserialize))]
 pub struct Position {
     pub line: u32,
     pub character: u32,
@@ -112,7 +117,8 @@ impl Position {
 }
 
 /// A range in a text document
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "native", derive(Serialize, Deserialize))]
 pub struct Range {
     pub start: Position,
     pub end: Position,
@@ -133,7 +139,8 @@ impl Range {
 }
 
 /// Hover result containing markdown content
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "native", derive(Serialize, Deserialize))]
 pub struct HoverResult {
     /// Markdown-formatted content to display
     pub contents: String,
@@ -164,7 +171,8 @@ pub type DefinitionResult = Option<Range>;
 pub type ReferencesResult = Vec<Range>;
 
 /// Diagnostic severity (matches LSP DiagnosticSeverity values)
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "native", derive(Serialize, Deserialize))]
 #[repr(u8)]
 pub enum DiagnosticSeverity {
     Error = 1,
@@ -174,7 +182,8 @@ pub enum DiagnosticSeverity {
 }
 
 /// A diagnostic message (error, warning, etc.)
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "native", derive(Serialize, Deserialize))]
 pub struct Diagnostic {
     /// The range where the diagnostic applies
     pub range: Range,

--- a/src/diagnostics/semantic_diagnostics.rs
+++ b/src/diagnostics/semantic_diagnostics.rs
@@ -1,34 +1,7 @@
-use crate::diagnostics_core::track_stack_in_instr_list as core_track_stack_in_instr_list;
-use crate::symbols::{SymbolTable, ValueType};
-use crate::utils::{determine_instruction_context_at_node, node_to_lsp_range, InstructionContext};
+use crate::diagnostics_core::tree_walk::{walk_tree_for_diagnostics, DiagnosticConfig};
+use crate::symbols::SymbolTable;
 use tower_lsp::lsp_types::*;
-use tree_sitter::{Node, Tree};
-
-/// Track stack state through an instruction list and report underflow/type errors
-/// If expected_results is None, skip return type validation (e.g., when function uses type reference)
-/// This is a wrapper that calls the shared core function and converts results to tower_lsp types.
-fn track_stack_in_instr_list(
-    instr_list: &Node,
-    source: &str,
-    symbols: &SymbolTable,
-    expected_results: Option<&[ValueType]>,
-    diagnostics: &mut Vec<Diagnostic>,
-) {
-    // Use the shared core function
-    let core_diagnostics =
-        core_track_stack_in_instr_list(instr_list, source, symbols, expected_results);
-
-    // Convert core::types::Diagnostic to tower_lsp::lsp_types::Diagnostic
-    for diag in core_diagnostics {
-        diagnostics.push(diag.into());
-    }
-}
-
-/// Configuration for which checks to perform during tree walk
-struct DiagnosticConfig {
-    check_atomics: bool,  // Should warn about atomic ops on non-shared memory
-    check_memory64: bool, // Should emit hints about memory64 operations
-}
+use tree_sitter::Tree;
 
 /// Provide semantic diagnostics for undefined references and parameter count validation
 pub fn provide_semantic_diagnostics(
@@ -36,270 +9,32 @@ pub fn provide_semantic_diagnostics(
     source: &str,
     symbols: &SymbolTable,
 ) -> Vec<Diagnostic> {
-    let mut diagnostics = Vec::new();
+    let config = DiagnosticConfig::from_symbols(symbols);
 
-    // Pre-compute configuration to avoid repeated checks during walk
-    let config = DiagnosticConfig {
-        // Only check atomics if there's no shared memory
-        check_atomics: !symbols.memories.is_empty() && !symbols.memories.iter().any(|m| m.shared),
-        // Only check memory64 if there are memory64 memories
-        check_memory64: symbols.memories.iter().any(|m| m.is_memory64),
-    };
-
-    // Single unified tree walk for all semantic checks
-    unified_tree_walk(tree.root_node(), source, symbols, &config, &mut diagnostics);
-
-    // Validate subtype hierarchy
-    let subtype_diags = crate::diagnostics_core::subtype::validate_subtype_hierarchy(symbols);
-    for diag in subtype_diags {
-        diagnostics.push(diag.into());
-    }
-
-    // Module-level structural validations
-    let module_diags = crate::diagnostics_core::module_checks::validate_module_structure(
-        &tree.root_node(),
+    // Single unified tree walk for all semantic checks (shared implementation)
+    let mut core_diagnostics = Vec::new();
+    walk_tree_for_diagnostics(
+        tree.root_node(),
         source,
         symbols,
+        &config,
+        &mut core_diagnostics,
     );
-    diagnostics.extend(module_diags.into_iter().map(Into::into));
 
-    diagnostics
-}
+    // Validate subtype hierarchy
+    core_diagnostics.extend(crate::diagnostics_core::subtype::validate_subtype_hierarchy(symbols));
 
-/// Unified tree walk that performs all semantic checks in a single pass
-fn unified_tree_walk(
-    node: Node,
-    source: &str,
-    symbols: &SymbolTable,
-    config: &DiagnosticConfig,
-    diagnostics: &mut Vec<Diagnostic>,
-) {
-    let kind = node.kind();
+    // Module-level structural validations
+    core_diagnostics.extend(
+        crate::diagnostics_core::module_checks::validate_module_structure(
+            &tree.root_node(),
+            source,
+            symbols,
+        ),
+    );
 
-    // Check block label mismatches
-    if matches!(kind, "block_block" | "block_loop" | "block_if") {
-        let core_diags =
-            crate::diagnostics_core::module_checks::check_block_label_mismatch(&node, source);
-        diagnostics.extend(core_diags.into_iter().map(Into::into));
-    }
-
-    // Check for function body instruction lists - perform stack tracking and return type validation
-    if kind == "module_field_func" {
-        // Get the function's declared return types
-        let func_line = node.start_position().row as u32;
-        let expected_results: &[ValueType] = symbols
-            .find_function_containing_line(func_line)
-            .map(|f| f.results.as_slice())
-            .unwrap_or(&[]);
-
-        let mut cursor = node.walk();
-        let mut found_instr_list = false;
-        for child in node.children(&mut cursor) {
-            if child.kind() == "instr_list" {
-                track_stack_in_instr_list(
-                    &child,
-                    source,
-                    symbols,
-                    Some(expected_results),
-                    diagnostics,
-                );
-                found_instr_list = true;
-                break;
-            }
-        }
-
-        // If no instr_list but function expects return values, report error
-        if !found_instr_list && !expected_results.is_empty() {
-            let range = node_to_lsp_range(&node);
-            diagnostics.push(Diagnostic {
-                range,
-                severity: Some(DiagnosticSeverity::ERROR),
-                code: Some(NumberOrString::String("return-arity-mismatch".to_string())),
-                code_description: None,
-                source: Some("wat-lsp".to_string()),
-                message: format!(
-                    "Type mismatch: function body leaves 0 values on stack but signature requires {}",
-                    expected_results.len()
-                ),
-                related_information: None,
-                tags: None,
-                data: None,
-            });
-        }
-        // Continue recursing for other checks (references, etc.)
-    }
-
-    // Special handling for catch_clause (try_table): first index is tag, second is label
-    if kind == "catch_clause" {
-        let core_diags = crate::diagnostics_core::references::check_catch_clause_references(
-            &node, source, symbols,
-        );
-        diagnostics.extend(core_diags.into_iter().map(Into::into));
-        return;
-    }
-
-    // Special handling for try_catch_clause (legacy try): index is a tag reference
-    if kind == "try_catch_clause" {
-        let core_diags = crate::diagnostics_core::references::check_try_catch_clause_references(
-            &node, source, symbols,
-        );
-        diagnostics.extend(core_diags.into_iter().map(Into::into));
-        // Continue recursing to check nested instructions
-    }
-
-    // Special handling for start directive: index is a function reference
-    if kind == "module_field_start" {
-        let core_diags =
-            crate::diagnostics_core::references::check_start_references(&node, source, symbols);
-        diagnostics.extend(core_diags.into_iter().map(Into::into));
-        return;
-    }
-
-    // Check module-level references (exports, elem/data segment refs)
-    {
-        let module_ref_diags = crate::diagnostics_core::references::check_module_level_references(
-            &node, source, symbols,
-        );
-        if !module_ref_diags.is_empty() {
-            diagnostics.extend(module_ref_diags.into_iter().map(Into::into));
-            // For leaf-ish nodes (export_desc_*, table_use, memory_use, elem_list),
-            // return early. For module_field_elem, continue recursing into children
-            // so that table_use, elem_list, offset, etc. get their own checks.
-            if kind != "module_field_elem" {
-                return;
-            }
-        }
-    }
-
-    // Special handling for try_delegate_clause (legacy try): index is a label reference
-    if kind == "try_delegate_clause" {
-        let core_diags = crate::diagnostics_core::references::check_try_delegate_clause_references(
-            &node, source, symbols,
-        );
-        diagnostics.extend(core_diags.into_iter().map(Into::into));
-        return;
-    }
-
-    // Check folded format instructions (expr1_plain)
-    // Must be checked BEFORE the reference context check because expr1_plain
-    // contains instr_plain as a child which would trigger early return
-    if kind == "expr1_plain" {
-        // Use shared core function for folded operand validation
-        let core_diags = crate::diagnostics_core::folded_checks::check_folded_operand_count(
-            &node, source, symbols,
-        );
-        diagnostics.extend(core_diags.into_iter().map(Into::into));
-
-        let text = &source[node.byte_range()];
-        let first_token = text.split_whitespace().next().unwrap_or("");
-
-        // Check atomic operations in folded expressions
-        if config.check_atomics {
-            let core_diags =
-                crate::diagnostics_core::memory_checks::check_atomic_operation(&node, first_token);
-            diagnostics.extend(core_diags.into_iter().map(Into::into));
-        }
-
-        // Also check memory64 for folded expressions
-        if config.check_memory64 {
-            let core_diags = crate::diagnostics_core::memory_checks::check_memory64_for_instruction(
-                &node,
-                source,
-                symbols,
-                first_token,
-            );
-            diagnostics.extend(core_diags.into_iter().map(Into::into));
-        }
-        // Continue to recurse - nested expressions need to be checked
-    }
-
-    // Check SIMD lane indices (must be before context check since v128.load*_lane
-    // matches Memory context and would early-return before we check lane bounds)
-    // Also check alignment constraints on load/store instructions
-    if kind == "instr_plain" {
-        let core_diags = crate::diagnostics_core::simd_checks::check_simd_lane_index(&node, source);
-        diagnostics.extend(core_diags.into_iter().map(Into::into));
-        let core_diags = crate::diagnostics_core::alignment_checks::check_alignment(&node, source);
-        diagnostics.extend(core_diags.into_iter().map(Into::into));
-    } else if kind == "expr1_plain" {
-        // In folded form, instr_plain is a child that won't be visited separately
-        let mut cursor = node.walk();
-        for child in node.children(&mut cursor) {
-            if child.kind() == "instr_plain" {
-                let core_diags =
-                    crate::diagnostics_core::simd_checks::check_simd_lane_index(&child, source);
-                diagnostics.extend(core_diags.into_iter().map(Into::into));
-                let core_diags =
-                    crate::diagnostics_core::alignment_checks::check_alignment(&child, source);
-                diagnostics.extend(core_diags.into_iter().map(Into::into));
-                break;
-            }
-        }
-    }
-
-    // Check for undefined references based on instruction context
-    // This handles instr_plain nodes and returns early after recursing into nested expr
-    let context = determine_instruction_context_at_node(&node, source);
-    if context != InstructionContext::General {
-        let core_diags =
-            crate::diagnostics_core::references::check_references(&node, source, symbols, &context);
-        diagnostics.extend(core_diags.into_iter().map(Into::into));
-
-        // For instr_plain, also check atomic ops and memory64 (linear format)
-        if kind == "instr_plain" {
-            let text = &source[node.byte_range()];
-            let first_token = text.split_whitespace().next().unwrap_or("");
-
-            // Check atomic operations
-            if config.check_atomics {
-                let core_diags = crate::diagnostics_core::memory_checks::check_atomic_operation(
-                    &node,
-                    first_token,
-                );
-                diagnostics.extend(core_diags.into_iter().map(Into::into));
-            }
-
-            // Check memory64 operations for linear format only
-            // (folded format handled above in expr1_plain check)
-            let parent_is_expr1 = node
-                .parent()
-                .map(|p| p.kind() == "expr1_plain")
-                .unwrap_or(false);
-            if !parent_is_expr1 && config.check_memory64 {
-                let core_diags =
-                    crate::diagnostics_core::memory_checks::check_memory64_for_instruction(
-                        &node,
-                        source,
-                        symbols,
-                        first_token,
-                    );
-                diagnostics.extend(core_diags.into_iter().map(Into::into));
-            }
-
-            // Check parameter count for linear format only
-            if !parent_is_expr1 {
-                let core_diags = crate::diagnostics_core::arity::check_instruction_parameter_count(
-                    &node, source,
-                );
-                diagnostics.extend(core_diags.into_iter().map(Into::into));
-            }
-        }
-
-        // Only recurse into nested expr nodes (which contain nested instructions)
-        let mut cursor = node.walk();
-        for child in node.children(&mut cursor) {
-            if child.kind() == "expr" {
-                unified_tree_walk(child, source, symbols, config, diagnostics);
-            }
-        }
-        return;
-    }
-
-    // Recursively check children
-    let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
-        unified_tree_walk(child, source, symbols, config, diagnostics);
-    }
+    // Convert all core diagnostics to tower_lsp types
+    core_diagnostics.into_iter().map(Into::into).collect()
 }
 
 #[cfg(test)]

--- a/src/diagnostics_core/mod.rs
+++ b/src/diagnostics_core/mod.rs
@@ -14,6 +14,7 @@ pub mod simd_checks;
 pub mod subtype;
 mod termination;
 pub mod tree_sitter;
+pub mod tree_walk;
 pub mod type_check;
 
 pub use module_checks::{check_block_label_mismatch, validate_module_structure};

--- a/src/diagnostics_core/tree_walk.rs
+++ b/src/diagnostics_core/tree_walk.rs
@@ -1,0 +1,257 @@
+//! Shared diagnostic tree walk for both native and WASM builds.
+//!
+//! This module provides the unified tree walk that orchestrates all semantic
+//! diagnostic checks in a single pass over the AST. Both native and WASM
+//! builds delegate to this shared implementation.
+
+use crate::core::types::Diagnostic;
+use crate::symbols::{SymbolTable, ValueType};
+use crate::utils::{determine_instruction_context_at_node, InstructionContext};
+
+#[cfg(feature = "native")]
+use tree_sitter::Node;
+
+#[cfg(all(feature = "wasm", not(feature = "native")))]
+use crate::ts_facade::Node;
+
+/// Pre-computed configuration for which diagnostic checks to perform.
+pub struct DiagnosticConfig {
+    pub check_atomics: bool,
+    pub check_memory64: bool,
+}
+
+impl DiagnosticConfig {
+    /// Build config from symbol table state.
+    pub fn from_symbols(symbols: &SymbolTable) -> Self {
+        Self {
+            check_atomics: !symbols.memories.is_empty()
+                && !symbols.memories.iter().any(|m| m.shared),
+            check_memory64: symbols.memories.iter().any(|m| m.is_memory64),
+        }
+    }
+}
+
+/// Walk the AST and collect all semantic diagnostics in a single pass.
+///
+/// This is the shared implementation used by both native and WASM builds.
+/// Callers can convert the returned `Vec<Diagnostic>` to platform-specific
+/// types as needed (e.g., `tower_lsp::lsp_types::Diagnostic` for native).
+pub fn walk_tree_for_diagnostics(
+    node: Node,
+    source: &str,
+    symbols: &SymbolTable,
+    config: &DiagnosticConfig,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let kind = node.kind();
+
+    // Normalize kind for cross-platform matching
+    #[cfg(feature = "native")]
+    let kind_str = kind;
+    #[cfg(all(feature = "wasm", not(feature = "native")))]
+    let kind_str = &*kind;
+
+    // Check block label mismatches
+    if matches!(kind_str, "block_block" | "block_loop" | "block_if") {
+        diagnostics.extend(
+            crate::diagnostics_core::module_checks::check_block_label_mismatch(&node, source),
+        );
+    }
+
+    // Check for function body instruction lists — stack tracking and return type validation
+    if kind_str == "module_field_func" {
+        let func_line = node.start_position().row as u32;
+        let expected_results: &[ValueType] = symbols
+            .find_function_containing_line(func_line)
+            .map(|f| f.results.as_slice())
+            .unwrap_or(&[]);
+
+        let mut cursor = node.walk();
+        let mut found_instr_list = false;
+        for child in node.children(&mut cursor) {
+            if child.kind() == "instr_list" {
+                diagnostics.extend(crate::diagnostics_core::track_stack_in_instr_list(
+                    &child,
+                    source,
+                    symbols,
+                    Some(expected_results),
+                ));
+                found_instr_list = true;
+                break;
+            }
+        }
+
+        if !found_instr_list && !expected_results.is_empty() {
+            diagnostics.push(Diagnostic::error(
+                crate::utils::node_to_range(&node),
+                format!(
+                    "Type mismatch: function body leaves 0 values on stack but signature requires {}",
+                    expected_results.len()
+                ),
+            ));
+        }
+    }
+
+    // Special handling for catch clauses (try_table)
+    if kind_str == "catch_clause" {
+        diagnostics.extend(
+            crate::diagnostics_core::references::check_catch_clause_references(
+                &node, source, symbols,
+            ),
+        );
+        return;
+    }
+
+    // Special handling for legacy try catch clause
+    if kind_str == "try_catch_clause" {
+        diagnostics.extend(
+            crate::diagnostics_core::references::check_try_catch_clause_references(
+                &node, source, symbols,
+            ),
+        );
+        // Continue recursing to check nested instructions
+    }
+
+    // Special handling for start directive
+    if kind_str == "module_field_start" {
+        diagnostics.extend(crate::diagnostics_core::references::check_start_references(
+            &node, source, symbols,
+        ));
+        return;
+    }
+
+    // Check module-level references (exports, elem/data segment refs)
+    {
+        let module_ref_diags = crate::diagnostics_core::references::check_module_level_references(
+            &node, source, symbols,
+        );
+        if !module_ref_diags.is_empty() {
+            diagnostics.extend(module_ref_diags);
+            if kind_str != "module_field_elem" {
+                return;
+            }
+        }
+    }
+
+    // Special handling for try_delegate_clause (legacy try): index is a label reference
+    if kind_str == "try_delegate_clause" {
+        diagnostics.extend(
+            crate::diagnostics_core::references::check_try_delegate_clause_references(
+                &node, source, symbols,
+            ),
+        );
+        return;
+    }
+
+    // Check folded expression operand count (expr1_plain nodes)
+    if kind_str == "expr1_plain" {
+        diagnostics.extend(
+            crate::diagnostics_core::folded_checks::check_folded_operand_count(
+                &node, source, symbols,
+            ),
+        );
+
+        let text = &source[node.byte_range()];
+        let first_token = text.split_whitespace().next().unwrap_or("");
+
+        if config.check_atomics {
+            diagnostics.extend(
+                crate::diagnostics_core::memory_checks::check_atomic_operation(&node, first_token),
+            );
+        }
+        if config.check_memory64 {
+            diagnostics.extend(
+                crate::diagnostics_core::memory_checks::check_memory64_for_instruction(
+                    &node,
+                    source,
+                    symbols,
+                    first_token,
+                ),
+            );
+        }
+    }
+
+    // Check SIMD lane indices and alignment constraints
+    if kind_str == "instr_plain" {
+        diagnostics.extend(crate::diagnostics_core::simd_checks::check_simd_lane_index(
+            &node, source,
+        ));
+        diagnostics.extend(crate::diagnostics_core::alignment_checks::check_alignment(
+            &node, source,
+        ));
+    } else if kind_str == "expr1_plain" {
+        // In folded form, instr_plain is a child that won't be visited separately
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            if child.kind() == "instr_plain" {
+                diagnostics.extend(crate::diagnostics_core::simd_checks::check_simd_lane_index(
+                    &child, source,
+                ));
+                diagnostics.extend(crate::diagnostics_core::alignment_checks::check_alignment(
+                    &child, source,
+                ));
+                break;
+            }
+        }
+    }
+
+    // Check for undefined references based on instruction context
+    let context = determine_instruction_context_at_node(&node, source);
+    if context != InstructionContext::General {
+        diagnostics.extend(crate::diagnostics_core::references::check_references(
+            &node, source, symbols, &context,
+        ));
+
+        // For instr_plain, also check atomic, memory64, and arity (linear format)
+        if kind_str == "instr_plain" {
+            let text = &source[node.byte_range()];
+            let first_token = text.split_whitespace().next().unwrap_or("");
+
+            if config.check_atomics {
+                diagnostics.extend(
+                    crate::diagnostics_core::memory_checks::check_atomic_operation(
+                        &node,
+                        first_token,
+                    ),
+                );
+            }
+
+            let parent_is_expr1 = node
+                .parent()
+                .map(|p| p.kind() == "expr1_plain")
+                .unwrap_or(false);
+            if !parent_is_expr1 {
+                if config.check_memory64 {
+                    diagnostics.extend(
+                        crate::diagnostics_core::memory_checks::check_memory64_for_instruction(
+                            &node,
+                            source,
+                            symbols,
+                            first_token,
+                        ),
+                    );
+                }
+                diagnostics.extend(
+                    crate::diagnostics_core::arity::check_instruction_parameter_count(
+                        &node, source,
+                    ),
+                );
+            }
+        }
+
+        // Only recurse into nested expr nodes
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            if child.kind() == "expr" {
+                walk_tree_for_diagnostics(child, source, symbols, config, diagnostics);
+            }
+        }
+        return;
+    }
+
+    // Recursively check children
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        walk_tree_for_diagnostics(child, source, symbols, config, diagnostics);
+    }
+}

--- a/src/wasm/api.rs
+++ b/src/wasm/api.rs
@@ -9,12 +9,12 @@ use crate::core::types::{
     CompletionItem, CompletionItemKind, Diagnostic as CoreDiagnostic, HoverResult,
     InsertTextFormat, Position, Range,
 };
-use crate::diagnostics_core::track_stack_in_instr_list as core_track_stack_in_instr_list;
+use crate::diagnostics_core::tree_walk::{walk_tree_for_diagnostics, DiagnosticConfig};
 use crate::folding::{provide_folding_ranges, FoldingRangeKind};
 use crate::hover::provide_hover_core;
 use crate::parser::parse_document_from_tree;
 use crate::signature::call_info::{find_function_call, find_function_call_ast, CallInfo, CallType};
-use crate::symbols::{SymbolTable, ValueType};
+use crate::symbols::SymbolTable;
 use crate::ts_facade::{self, Language, Parser, Query, Tree};
 use crate::utils::{
     format_function_signature, get_line_at_position, get_word_at_position, node_at_position,
@@ -135,36 +135,37 @@ impl WatLSP {
     pub fn provide_diagnostics(&self) -> JsValue {
         let js_array = js_sys::Array::new();
 
-        // Add tree-sitter based syntax diagnostics and semantic diagnostics
         if let (Some(tree), Some(symbols)) = (&self.tree, &self.symbols) {
-            // Add syntax errors from tree-sitter ERROR nodes (shared implementation)
+            // Syntax errors from tree-sitter ERROR nodes
             let syntax_diagnostics =
                 crate::diagnostics_core::provide_tree_sitter_diagnostics(tree, &self.document);
             for diag in syntax_diagnostics {
                 js_array.push(&core_diagnostic_to_js(&diag));
             }
 
-            // Add semantic diagnostics (now returns CoreDiagnostic directly)
-            let semantic_diagnostics =
-                provide_wasm_semantic_diagnostics(tree, &self.document, symbols);
-            for diag in semantic_diagnostics {
-                js_array.push(&core_diagnostic_to_js(&diag));
-            }
-
-            // Add subtype hierarchy diagnostics
-            let subtype_diagnostics =
-                crate::diagnostics_core::subtype::validate_subtype_hierarchy(symbols);
-            for diag in subtype_diagnostics {
-                js_array.push(&core_diagnostic_to_js(&diag));
-            }
-
-            // Add module-level structural validations
-            let module_diags = crate::diagnostics_core::module_checks::validate_module_structure(
-                &tree.root_node(),
+            // Semantic diagnostics via shared tree walk
+            let config = DiagnosticConfig::from_symbols(symbols);
+            let mut diagnostics = Vec::new();
+            walk_tree_for_diagnostics(
+                tree.root_node(),
                 &self.document,
                 symbols,
+                &config,
+                &mut diagnostics,
             );
-            for diag in module_diags {
+
+            // Subtype hierarchy + module-level structural validations
+            diagnostics
+                .extend(crate::diagnostics_core::subtype::validate_subtype_hierarchy(symbols));
+            diagnostics.extend(
+                crate::diagnostics_core::module_checks::validate_module_structure(
+                    &tree.root_node(),
+                    &self.document,
+                    symbols,
+                ),
+            );
+
+            for diag in diagnostics {
                 js_array.push(&core_diagnostic_to_js(&diag));
             }
         }
@@ -1042,236 +1043,6 @@ fn reference_to_js(range: &Range) -> JsValue {
     let obj = js_sys::Object::new();
     js_sys::Reflect::set(&obj, &"range".into(), &range_to_js(range)).ok();
     obj.into()
-}
-
-use crate::ts_facade::Node;
-use crate::utils::{determine_instruction_context_at_node, InstructionContext};
-
-/// Pre-computed configuration for diagnostic checks
-struct DiagnosticConfig {
-    check_atomics: bool,
-    check_memory64: bool,
-}
-
-/// Provide semantic diagnostics for undefined references (WASM version).
-/// All diagnostic logic delegates to shared `diagnostics_core` modules.
-fn provide_wasm_semantic_diagnostics(
-    tree: &crate::ts_facade::Tree,
-    source: &str,
-    symbols: &SymbolTable,
-) -> Vec<CoreDiagnostic> {
-    let config = DiagnosticConfig {
-        check_atomics: !symbols.memories.is_empty() && !symbols.memories.iter().any(|m| m.shared),
-        check_memory64: symbols.memories.iter().any(|m| m.is_memory64),
-    };
-    let mut diagnostics = Vec::new();
-    walk_tree_for_diagnostics(tree.root_node(), source, symbols, &config, &mut diagnostics);
-    diagnostics
-}
-
-fn walk_tree_for_diagnostics(
-    node: Node,
-    source: &str,
-    symbols: &SymbolTable,
-    config: &DiagnosticConfig,
-    diagnostics: &mut Vec<CoreDiagnostic>,
-) {
-    let kind = node.kind();
-
-    // Check block label mismatches
-    if matches!(&*kind, "block_block" | "block_loop" | "block_if") {
-        diagnostics.extend(
-            crate::diagnostics_core::module_checks::check_block_label_mismatch(&node, source),
-        );
-    }
-
-    // Check for function body instruction lists — shared stack tracking
-    if &*kind == "module_field_func" {
-        let func_line = node.start_position().row as u32;
-        let expected_results: &[ValueType] = symbols
-            .find_function_containing_line(func_line)
-            .map(|f| f.results.as_slice())
-            .unwrap_or(&[]);
-
-        let mut cursor = node.walk();
-        let mut found_instr_list = false;
-        for child in node.children(&mut cursor) {
-            if child.kind() == "instr_list" {
-                diagnostics.extend(core_track_stack_in_instr_list(
-                    &child,
-                    source,
-                    symbols,
-                    Some(expected_results),
-                ));
-                found_instr_list = true;
-                break;
-            }
-        }
-
-        if !found_instr_list && !expected_results.is_empty() {
-            diagnostics.push(CoreDiagnostic::error(
-                crate::utils::node_to_range(&node),
-                format!(
-                    "Type mismatch: function body leaves 0 values on stack but signature requires {}",
-                    expected_results.len()
-                ),
-            ));
-        }
-    }
-
-    // Special handling for start directive — shared core
-    if &*kind == "module_field_start" {
-        diagnostics.extend(crate::diagnostics_core::references::check_start_references(
-            &node, source, symbols,
-        ));
-        return;
-    }
-
-    // Check module-level references (exports, elem/data segment refs) — shared core
-    {
-        let module_ref_diags = crate::diagnostics_core::references::check_module_level_references(
-            &node, source, symbols,
-        );
-        if !module_ref_diags.is_empty() {
-            diagnostics.extend(module_ref_diags);
-            if &*kind != "module_field_elem" {
-                return;
-            }
-        }
-    }
-
-    // Special handling for catch clauses — shared core
-    if &*kind == "catch_clause" {
-        diagnostics.extend(
-            crate::diagnostics_core::references::check_catch_clause_references(
-                &node, source, symbols,
-            ),
-        );
-        return;
-    }
-
-    // Special handling for legacy try catch clause — shared core
-    if &*kind == "try_catch_clause" {
-        diagnostics.extend(
-            crate::diagnostics_core::references::check_try_catch_clause_references(
-                &node, source, symbols,
-            ),
-        );
-    }
-
-    // Check folded expression operand count (expr1_plain nodes) — shared core
-    if &*kind == "expr1_plain" {
-        diagnostics.extend(
-            crate::diagnostics_core::folded_checks::check_folded_operand_count(
-                &node, source, symbols,
-            ),
-        );
-
-        // Also check atomic and memory64 for folded expressions
-        let text = &source[node.byte_range()];
-        let first_token = text.split_whitespace().next().unwrap_or("");
-
-        if config.check_atomics {
-            diagnostics.extend(
-                crate::diagnostics_core::memory_checks::check_atomic_operation(&node, first_token),
-            );
-        }
-        if config.check_memory64 {
-            diagnostics.extend(
-                crate::diagnostics_core::memory_checks::check_memory64_for_instruction(
-                    &node,
-                    source,
-                    symbols,
-                    first_token,
-                ),
-            );
-        }
-    }
-
-    // Check SIMD lane indices (must be before context check since v128.load*_lane
-    // matches Memory context and would early-return before we check lane bounds)
-    // Also check alignment constraints on load/store instructions
-    if &*kind == "instr_plain" {
-        diagnostics.extend(crate::diagnostics_core::simd_checks::check_simd_lane_index(
-            &node, source,
-        ));
-        diagnostics.extend(crate::diagnostics_core::alignment_checks::check_alignment(
-            &node, source,
-        ));
-    } else if &*kind == "expr1_plain" {
-        // In folded form, instr_plain is a child that won't be visited separately
-        let mut cursor = node.walk();
-        for child in node.children(&mut cursor) {
-            if child.kind() == "instr_plain" {
-                diagnostics.extend(crate::diagnostics_core::simd_checks::check_simd_lane_index(
-                    &child, source,
-                ));
-                diagnostics.extend(crate::diagnostics_core::alignment_checks::check_alignment(
-                    &child, source,
-                ));
-                break;
-            }
-        }
-    }
-
-    // Check for undefined references based on instruction context — shared core
-    let context = determine_instruction_context_at_node(&node, source);
-    if context != InstructionContext::General {
-        diagnostics.extend(crate::diagnostics_core::references::check_references(
-            &node, source, symbols, &context,
-        ));
-
-        // For instr_plain, also check atomic, memory64, and arity (linear format)
-        if &*kind == "instr_plain" {
-            let text = &source[node.byte_range()];
-            let first_token = text.split_whitespace().next().unwrap_or("");
-
-            if config.check_atomics {
-                diagnostics.extend(
-                    crate::diagnostics_core::memory_checks::check_atomic_operation(
-                        &node,
-                        first_token,
-                    ),
-                );
-            }
-
-            let parent_is_expr1 = node
-                .parent()
-                .map(|p| p.kind() == "expr1_plain")
-                .unwrap_or(false);
-            if !parent_is_expr1 {
-                if config.check_memory64 {
-                    diagnostics.extend(
-                        crate::diagnostics_core::memory_checks::check_memory64_for_instruction(
-                            &node,
-                            source,
-                            symbols,
-                            first_token,
-                        ),
-                    );
-                }
-                diagnostics.extend(
-                    crate::diagnostics_core::arity::check_instruction_parameter_count(
-                        &node, source,
-                    ),
-                );
-            }
-        }
-
-        let mut cursor = node.walk();
-        for child in node.children(&mut cursor) {
-            if child.kind() == "expr" {
-                walk_tree_for_diagnostics(child, source, symbols, config, diagnostics);
-            }
-        }
-        return;
-    }
-
-    // Recursively check children
-    let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
-        walk_tree_for_diagnostics(child, source, symbols, config, diagnostics);
-    }
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- **Gate `serde` as native-only optional dep** — WASM never uses Serialize/Deserialize (uses `js_sys` for JS conversion). Changed 8 types in `core/types.rs` to `#[cfg_attr(feature = "native", derive(Serialize, Deserialize))]`.
- **Extract shared diagnostic tree walk** to `diagnostics_core/tree_walk.rs` (257 lines) — eliminates ~200 lines of duplicated tree walk code from both native and WASM implementations. Net reduction: -227 lines.
- **WASM gains `try_delegate_clause` validation** — was missing from WASM tree walk, now shared via the unified implementation.