### PR TITLE
normalize wat-snippet to wat in build.rs for LSP hover syntax highlighting

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -112,7 +112,13 @@ fn parse_docs(content: &str) -> HashMap<String, String> {
             in_code_block = !in_code_block;
             // Add code fence to doc if we're collecting
             if instruction_name.is_some() {
-                doc_lines.push(trimmed);
+                // Normalize wat-snippet to wat for LSP hover rendering
+                let fence = if trimmed == "```wat-snippet" {
+                    "```wat"
+                } else {
+                    trimmed
+                };
+                doc_lines.push(fence);
             }
             continue;
         }


### PR DESCRIPTION
The build.rs doc parser now normalizes `wat-snippet` code fences to `wat` when generating LSP instruction docs. This fixes missing syntax highlighting in hover tooltips for entries like `module` and `start` that used the `wat-snippet` language tag (only recognized by the Astro docs site, not by editors).