### PR TITLE
defrag: extract shared signature_core, replace HashMap arity with sorted vec binary search

### DIFF
--- a/src/diagnostics_core/arity.rs
+++ b/src/diagnostics_core/arity.rs
@@ -4,9 +4,8 @@
 //! of immediate parameters (index nodes, constants, etc.).
 
 use crate::core::types::Diagnostic;
-use crate::instruction_metadata::get_instruction_arity_map;
+use crate::instruction_metadata::lookup_instruction_arity;
 use crate::utils::node_to_range;
-use std::sync::OnceLock;
 
 // Use the appropriate tree-sitter types based on feature
 #[cfg(feature = "native")]
@@ -14,16 +13,6 @@ use tree_sitter::Node;
 
 #[cfg(all(feature = "wasm", not(feature = "native")))]
 use crate::ts_facade::Node;
-
-static INSTRUCTION_ARITY: OnceLock<
-    std::collections::HashMap<&'static str, crate::instruction_metadata::InstructionArity>,
-> = OnceLock::new();
-
-fn get_arity_map(
-) -> &'static std::collections::HashMap<&'static str, crate::instruction_metadata::InstructionArity>
-{
-    INSTRUCTION_ARITY.get_or_init(get_instruction_arity_map)
-}
 
 /// Check if an instruction has the correct number of parameters (linear format)
 pub fn check_instruction_parameter_count(node: &Node, source: &str) -> Vec<Diagnostic> {
@@ -128,9 +117,7 @@ fn validate_instruction_arity(
     node: &Node,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
-    let arity_map = get_arity_map();
-
-    if let Some(arity) = arity_map.get(instr_name) {
+    if let Some(arity) = lookup_instruction_arity(instr_name) {
         if !arity.is_valid(param_count) {
             let range = node_to_range(node);
             let param_word = if param_count == 1 {

--- a/src/diagnostics_core/folded_checks.rs
+++ b/src/diagnostics_core/folded_checks.rs
@@ -13,7 +13,7 @@ use crate::symbols::{SymbolTable, TypeKind};
 use crate::utils::node_to_range;
 
 use super::references::is_nested_in_expr;
-use super::semantic::get_arity_map;
+use crate::instruction_metadata::lookup_instruction_arity;
 
 #[cfg(feature = "native")]
 use tree_sitter::Node;
@@ -68,8 +68,7 @@ pub fn check_folded_operand_count(
         .count();
 
     // Resolve arity: try explicit map first, then SIMD pattern fallback
-    let arity_map = get_arity_map();
-    let resolved = if let Some(arity) = arity_map.get(instr_name.as_str()) {
+    let resolved = if let Some(arity) = lookup_instruction_arity(instr_name.as_str()) {
         Some((arity.operand_mode, true))
     } else {
         infer_simd_instruction_arity(&instr_name).map(|(c, _)| (OperandMode::Fixed(c), false))

--- a/src/diagnostics_core/semantic.rs
+++ b/src/diagnostics_core/semantic.rs
@@ -14,13 +14,10 @@
 
 use crate::core::types::Diagnostic;
 use crate::instruction_metadata::{
-    get_instruction_arity_map, infer_simd_instruction_arity, is_terminating_instruction,
-    InstructionArity, OperandMode,
+    infer_simd_instruction_arity, is_terminating_instruction, lookup_instruction_arity, OperandMode,
 };
 use crate::symbols::{SymbolTable, TypeKind, ValueType};
 use crate::utils::node_to_range;
-use std::collections::HashMap;
-use std::sync::OnceLock;
 
 use super::sequence_always_terminates;
 use super::type_check::{CtrlOpcode, TypeChecker};
@@ -31,13 +28,6 @@ use tree_sitter::Node;
 
 #[cfg(all(feature = "wasm", not(feature = "native")))]
 use crate::ts_facade::Node;
-
-// Lazy static initialization for instruction arity map
-static INSTRUCTION_ARITY: OnceLock<HashMap<&'static str, InstructionArity>> = OnceLock::new();
-
-pub fn get_arity_map() -> &'static HashMap<&'static str, InstructionArity> {
-    INSTRUCTION_ARITY.get_or_init(get_instruction_arity_map)
-}
 
 /// Track stack state through an instruction list and report underflow/type errors.
 /// If expected_results is None, skip return type validation (e.g., when function uses type reference).
@@ -50,7 +40,6 @@ pub fn track_stack_in_instr_list(
     symbols: &SymbolTable,
     expected_results: Option<&[ValueType]>,
 ) -> Vec<Diagnostic> {
-    let arity_map = get_arity_map();
     let mut checker = TypeChecker::new();
 
     // Get function result types for the control frame
@@ -76,31 +65,24 @@ pub fn track_stack_in_instr_list(
 
         match kind.as_ref() {
             "instr" => {
-                process_instr_node(&child, source, symbols, arity_map, &mut checker);
+                process_instr_node(&child, source, symbols, &mut checker);
             }
             "instr_plain" => {
                 if let Some(instr_name) = get_instruction_name(&child, source) {
-                    process_instruction(
-                        &child,
-                        &instr_name,
-                        &mut checker,
-                        symbols,
-                        source,
-                        arity_map,
-                    );
+                    process_instruction(&child, &instr_name, &mut checker, symbols, source);
                 }
             }
             "expr" => {
-                process_folded_expr(&child, source, symbols, arity_map, &mut checker);
+                process_folded_expr(&child, source, symbols, &mut checker);
             }
             "instr_block" | "instr_loop" => {
-                process_block_node(&child, source, symbols, arity_map, &mut checker);
+                process_block_node(&child, source, symbols, &mut checker);
             }
             "instr_if" => {
-                process_if_node(&child, source, symbols, arity_map, &mut checker);
+                process_if_node(&child, source, symbols, &mut checker);
             }
             "instr_call" => {
-                process_instr_call_node(&child, source, symbols, arity_map, &mut checker);
+                process_instr_call_node(&child, source, symbols, &mut checker);
             }
             "instr_list_call" => {
                 process_call_indirect_node(&child, source, symbols, &mut checker);
@@ -120,7 +102,6 @@ fn process_instr_node(
     instr_node: &Node,
     source: &str,
     symbols: &SymbolTable,
-    arity_map: &HashMap<&'static str, InstructionArity>,
     checker: &mut TypeChecker,
 ) {
     let mut cursor = instr_node.walk();
@@ -133,20 +114,20 @@ fn process_instr_node(
         match kind.as_ref() {
             "instr_plain" => {
                 if let Some(instr_name) = get_instruction_name(&child, source) {
-                    process_instruction(&child, &instr_name, checker, symbols, source, arity_map);
+                    process_instruction(&child, &instr_name, checker, symbols, source);
                 }
             }
             "expr" => {
-                process_folded_expr(&child, source, symbols, arity_map, checker);
+                process_folded_expr(&child, source, symbols, checker);
             }
             "instr_block" | "instr_loop" => {
-                process_block_node(&child, source, symbols, arity_map, checker);
+                process_block_node(&child, source, symbols, checker);
             }
             "instr_if" => {
-                process_if_node(&child, source, symbols, arity_map, checker);
+                process_if_node(&child, source, symbols, checker);
             }
             "instr_call" => {
-                process_instr_call_node(&child, source, symbols, arity_map, checker);
+                process_instr_call_node(&child, source, symbols, checker);
             }
             "instr_list_call" => {
                 process_call_indirect_node(&child, source, symbols, checker);
@@ -158,13 +139,7 @@ fn process_instr_node(
 
 /// Process a block or loop instruction (instr_block or instr_loop).
 /// Uses push_ctrl/pop_ctrl for proper control frame tracking.
-fn process_block_node(
-    node: &Node,
-    source: &str,
-    symbols: &SymbolTable,
-    arity_map: &HashMap<&'static str, InstructionArity>,
-    checker: &mut TypeChecker,
-) {
+fn process_block_node(node: &Node, source: &str, symbols: &SymbolTable, checker: &mut TypeChecker) {
     let is_if = contains_block_if(node);
 
     // If this is a linear if, pop i32 condition from outer stack
@@ -196,20 +171,14 @@ fn process_block_node(
     checker.push_ctrl(opcode, params, results);
 
     // Process body
-    process_block_body(node, source, symbols, arity_map, checker);
+    process_block_body(node, source, symbols, checker);
 
     // Pop control frame
     checker.pop_ctrl(node);
 }
 
 /// Process an if instruction (instr_if — folded or linear format with explicit if keyword).
-fn process_if_node(
-    node: &Node,
-    source: &str,
-    symbols: &SymbolTable,
-    arity_map: &HashMap<&'static str, InstructionArity>,
-    checker: &mut TypeChecker,
-) {
+fn process_if_node(node: &Node, source: &str, symbols: &SymbolTable, checker: &mut TypeChecker) {
     // Pop i32 condition
     checker.pop_expect(&ValueType::I32, node);
 
@@ -224,19 +193,13 @@ fn process_if_node(
     checker.push_ctrl(CtrlOpcode::If, params, results);
 
     // Process body
-    process_block_body(node, source, symbols, arity_map, checker);
+    process_block_body(node, source, symbols, checker);
 
     checker.pop_ctrl(node);
 }
 
 /// Process the body of a block/loop/if by recursing into children
-fn process_block_body(
-    node: &Node,
-    source: &str,
-    symbols: &SymbolTable,
-    arity_map: &HashMap<&'static str, InstructionArity>,
-    checker: &mut TypeChecker,
-) {
+fn process_block_body(node: &Node, source: &str, symbols: &SymbolTable, checker: &mut TypeChecker) {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         #[cfg(feature = "native")]
@@ -256,7 +219,7 @@ fn process_block_body(
 
                     match list_kind.as_ref() {
                         "instr" => {
-                            process_instr_node(&list_child, source, symbols, arity_map, checker);
+                            process_instr_node(&list_child, source, symbols, checker);
                         }
                         "instr_plain" => {
                             if let Some(instr_name) = get_instruction_name(&list_child, source) {
@@ -266,27 +229,20 @@ fn process_block_body(
                                     checker,
                                     symbols,
                                     source,
-                                    arity_map,
                                 );
                             }
                         }
                         "expr" => {
-                            process_folded_expr(&list_child, source, symbols, arity_map, checker);
+                            process_folded_expr(&list_child, source, symbols, checker);
                         }
                         "instr_block" | "instr_loop" => {
-                            process_block_node(&list_child, source, symbols, arity_map, checker);
+                            process_block_node(&list_child, source, symbols, checker);
                         }
                         "instr_if" => {
-                            process_if_node(&list_child, source, symbols, arity_map, checker);
+                            process_if_node(&list_child, source, symbols, checker);
                         }
                         "instr_call" => {
-                            process_instr_call_node(
-                                &list_child,
-                                source,
-                                symbols,
-                                arity_map,
-                                checker,
-                            );
+                            process_instr_call_node(&list_child, source, symbols, checker);
                         }
                         "instr_list_call" => {
                             process_call_indirect_node(&list_child, source, symbols, checker);
@@ -297,38 +253,38 @@ fn process_block_body(
             }
             "block_block" | "loop_block" => {
                 // Nested block in linear format
-                process_block_body(&child, source, symbols, arity_map, checker);
+                process_block_body(&child, source, symbols, checker);
             }
             "block_if" | "if_block" => {
                 // Nested if block in linear format
-                process_block_body(&child, source, symbols, arity_map, checker);
+                process_block_body(&child, source, symbols, checker);
             }
             "instr_else" | "else" => {
                 // At else, we need to reset to block params for the else branch
                 // The then branch's values should match end_types, then reset
                 // For simplicity, just process the else branch's instructions
-                process_block_body(&child, source, symbols, arity_map, checker);
+                process_block_body(&child, source, symbols, checker);
             }
             // Direct instruction children
             "instr" => {
-                process_instr_node(&child, source, symbols, arity_map, checker);
+                process_instr_node(&child, source, symbols, checker);
             }
             "instr_plain" => {
                 if let Some(instr_name) = get_instruction_name(&child, source) {
-                    process_instruction(&child, &instr_name, checker, symbols, source, arity_map);
+                    process_instruction(&child, &instr_name, checker, symbols, source);
                 }
             }
             "expr" => {
-                process_folded_expr(&child, source, symbols, arity_map, checker);
+                process_folded_expr(&child, source, symbols, checker);
             }
             "instr_block" | "instr_loop" => {
-                process_block_node(&child, source, symbols, arity_map, checker);
+                process_block_node(&child, source, symbols, checker);
             }
             "instr_if" => {
-                process_if_node(&child, source, symbols, arity_map, checker);
+                process_if_node(&child, source, symbols, checker);
             }
             "instr_call" => {
-                process_instr_call_node(&child, source, symbols, arity_map, checker);
+                process_instr_call_node(&child, source, symbols, checker);
             }
             "instr_list_call" => {
                 process_call_indirect_node(&child, source, symbols, checker);
@@ -451,7 +407,6 @@ fn process_instr_call_node(
     node: &Node,
     source: &str,
     symbols: &SymbolTable,
-    arity_map: &HashMap<&'static str, InstructionArity>,
     checker: &mut TypeChecker,
 ) {
     process_call_indirect_node(node, source, symbols, checker);
@@ -465,7 +420,7 @@ fn process_instr_call_node(
         let kind = child.kind();
 
         if kind == "instr" {
-            process_instr_node(&child, source, symbols, arity_map, checker);
+            process_instr_node(&child, source, symbols, checker);
         }
     }
 }
@@ -477,11 +432,10 @@ fn process_instruction(
     checker: &mut TypeChecker,
     symbols: &SymbolTable,
     source: &str,
-    arity_map: &HashMap<&'static str, InstructionArity>,
 ) {
     // Handle tail call instructions
     if matches!(instr_name, "return_call" | "return_call_ref") {
-        let consumed = get_instruction_consumed_types(node, instr_name, symbols, source, arity_map);
+        let consumed = get_instruction_consumed_types(node, instr_name, symbols, source);
         if !consumed.is_empty() {
             checker.pop_vals_for_instr(&consumed, node, instr_name);
         }
@@ -543,8 +497,7 @@ fn process_instruction(
         }
         // For 'throw', pop tag parameter types
         if instr_name == "throw" {
-            let consumed =
-                get_instruction_consumed_types(node, instr_name, symbols, source, arity_map);
+            let consumed = get_instruction_consumed_types(node, instr_name, symbols, source);
             if !consumed.is_empty() {
                 checker.pop_vals_for_instr(&consumed, node, instr_name);
             }
@@ -554,14 +507,14 @@ fn process_instruction(
     }
 
     // Regular instructions: consume typed operands, produce typed results
-    let consumed = get_instruction_consumed_types(node, instr_name, symbols, source, arity_map);
+    let consumed = get_instruction_consumed_types(node, instr_name, symbols, source);
     if !consumed.is_empty() {
         checker.pop_vals_for_instr(&consumed, node, instr_name);
     }
 
     let produced = infer_instruction_result_types(instr_name, node, symbols, source);
     // If we know the instruction produces N values but couldn't infer types, pad with Unknown
-    let produces_count = get_instruction_produces_count(instr_name, arity_map);
+    let produces_count = get_instruction_produces_count(instr_name);
     let mut types = produced;
     while types.len() < produces_count {
         types.push(ValueType::Unknown);
@@ -570,11 +523,8 @@ fn process_instruction(
 }
 
 /// Get the number of values an instruction produces
-fn get_instruction_produces_count(
-    instr_name: &str,
-    arity_map: &HashMap<&'static str, InstructionArity>,
-) -> usize {
-    if let Some(arity) = arity_map.get(instr_name) {
+fn get_instruction_produces_count(instr_name: &str) -> usize {
+    if let Some(arity) = lookup_instruction_arity(instr_name) {
         arity.produces
     } else if let Some((_c, p)) = infer_simd_instruction_arity(instr_name) {
         p
@@ -590,7 +540,6 @@ fn get_instruction_consumed_types(
     instr_name: &str,
     symbols: &SymbolTable,
     source: &str,
-    arity_map: &HashMap<&'static str, InstructionArity>,
 ) -> Vec<ValueType> {
     // Try pattern-based type derivation first
     if let Some(types) = derive_consumed_types_from_name(instr_name, node, symbols, source) {
@@ -598,7 +547,7 @@ fn get_instruction_consumed_types(
     }
 
     // Fall back to untyped count from arity map (use Unknown for each operand)
-    let count = if let Some(arity) = arity_map.get(instr_name) {
+    let count = if let Some(arity) = lookup_instruction_arity(instr_name) {
         match arity.operand_mode {
             OperandMode::Fixed(n) => n,
             OperandMode::Dynamic => get_dynamic_operand_count(node, instr_name, symbols, source),
@@ -1136,7 +1085,6 @@ pub fn infer_instruction_result_types(
     symbols: &SymbolTable,
     source: &str,
 ) -> Vec<ValueType> {
-    let arity_map = get_arity_map();
     let skip_early_return = matches!(
         instr_name,
         "call"
@@ -1147,7 +1095,7 @@ pub fn infer_instruction_result_types(
             | "return_call_indirect"
     );
     if !skip_early_return {
-        if let Some(arity) = arity_map.get(instr_name) {
+        if let Some(arity) = lookup_instruction_arity(instr_name) {
             if arity.produces == 0 {
                 return vec![];
             }
@@ -1547,10 +1495,9 @@ pub fn get_expected_operands_by_name(
     instr_name: &str,
     symbols: &SymbolTable,
     source: &str,
-    arity_map: &HashMap<&'static str, InstructionArity>,
     expr: &Node,
 ) -> usize {
-    if let Some(arity) = arity_map.get(instr_name) {
+    if let Some(arity) = lookup_instruction_arity(instr_name) {
         match arity.operand_mode {
             OperandMode::Fixed(n) => n,
             OperandMode::Dynamic => {
@@ -1598,7 +1545,6 @@ fn process_folded_expr(
     expr: &Node,
     source: &str,
     symbols: &SymbolTable,
-    arity_map: &HashMap<&'static str, InstructionArity>,
     checker: &mut TypeChecker,
 ) {
     if let Some((instr_name, explicit_operands)) = get_folded_expr_info(expr, source) {
@@ -1607,8 +1553,7 @@ fn process_folded_expr(
             instr_name.as_str(),
             "return_call" | "return_call_ref" | "return_call_indirect"
         ) {
-            let expected =
-                get_expected_operands_by_name(&instr_name, symbols, source, arity_map, expr);
+            let expected = get_expected_operands_by_name(&instr_name, symbols, source, expr);
             let from_stack = expected.saturating_sub(explicit_operands);
             if from_stack > 0 {
                 let consumed = vec![ValueType::Unknown; from_stack];
@@ -1630,7 +1575,7 @@ fn process_folded_expr(
         }
 
         // Calculate operands needed from the stack
-        let expected = get_expected_operands_by_name(&instr_name, symbols, source, arity_map, expr);
+        let expected = get_expected_operands_by_name(&instr_name, symbols, source, expr);
         let from_stack = expected.saturating_sub(explicit_operands);
 
         if from_stack > 0 {
@@ -1652,17 +1597,12 @@ fn process_folded_expr(
     }
 
     // Produce result values with actual types
-    let result_types = get_expr_result_types(expr, source, symbols, arity_map);
+    let result_types = get_expr_result_types(expr, source, symbols);
     checker.push_vals(&result_types);
 }
 
 /// Get result types from a folded expression
-pub fn get_expr_result_types(
-    expr: &Node,
-    source: &str,
-    symbols: &SymbolTable,
-    arity_map: &HashMap<&'static str, InstructionArity>,
-) -> Vec<ValueType> {
+pub fn get_expr_result_types(expr: &Node, source: &str, symbols: &SymbolTable) -> Vec<ValueType> {
     let mut cursor = expr.walk();
     for child in expr.children(&mut cursor) {
         #[cfg(feature = "native")]
@@ -1671,7 +1611,7 @@ pub fn get_expr_result_types(
         let kind = child.kind();
 
         if kind.starts_with("expr1_") {
-            return get_expr1_result_types(&child, source, symbols, arity_map);
+            return get_expr1_result_types(&child, source, symbols);
         }
         if kind == "expr1" {
             let mut inner_cursor = child.walk();
@@ -1682,7 +1622,7 @@ pub fn get_expr_result_types(
                 let inner_kind = inner_child.kind();
 
                 if inner_kind.starts_with("expr1_") {
-                    return get_expr1_result_types(&inner_child, source, symbols, arity_map);
+                    return get_expr1_result_types(&inner_child, source, symbols);
                 }
             }
         }
@@ -1691,12 +1631,7 @@ pub fn get_expr_result_types(
 }
 
 /// Get result types for expr1_* nodes
-fn get_expr1_result_types(
-    expr1: &Node,
-    source: &str,
-    symbols: &SymbolTable,
-    _arity_map: &HashMap<&'static str, InstructionArity>,
-) -> Vec<ValueType> {
+fn get_expr1_result_types(expr1: &Node, source: &str, symbols: &SymbolTable) -> Vec<ValueType> {
     #[cfg(feature = "native")]
     let kind = expr1.kind();
     #[cfg(all(feature = "wasm", not(feature = "native")))]

--- a/src/features/hover/mod.rs
+++ b/src/features/hover/mod.rs
@@ -643,8 +643,7 @@ fn get_instruction_doc(word: &str) -> Option<String> {
     }
 
     // Fallback: check the arity map to at least identify known instructions
-    let arity_map = crate::diagnostics_core::get_arity_map();
-    if let Some(arity) = arity_map.get(word) {
+    if let Some(arity) = crate::instruction_metadata::lookup_instruction_arity(word) {
         let operands = match arity.operand_mode {
             crate::instruction_metadata::OperandMode::Fixed(n) => format!("{}", n),
             crate::instruction_metadata::OperandMode::Dynamic => "dynamic".to_string(),

--- a/src/features/references_core.rs
+++ b/src/features/references_core.rs
@@ -74,6 +74,26 @@ pub enum ReferenceTarget {
     },
 }
 
+impl ReferenceTarget {
+    /// Returns true if this symbol has a name (i.e. can be renamed).
+    /// Block labels are always considered named.
+    pub fn has_name(&self) -> bool {
+        match self {
+            ReferenceTarget::Function { name, .. }
+            | ReferenceTarget::Global { name, .. }
+            | ReferenceTarget::Local { name, .. }
+            | ReferenceTarget::Parameter { name, .. }
+            | ReferenceTarget::Table { name, .. }
+            | ReferenceTarget::Memory { name, .. }
+            | ReferenceTarget::Type { name, .. }
+            | ReferenceTarget::Tag { name, .. }
+            | ReferenceTarget::Data { name, .. }
+            | ReferenceTarget::Elem { name, .. } => name.is_some(),
+            ReferenceTarget::BlockLabel { .. } => true,
+        }
+    }
+}
+
 /// Block information for tracking nesting depth
 #[derive(Debug, Clone)]
 struct BlockInfo {

--- a/src/features/signature/mod.rs
+++ b/src/features/signature/mod.rs
@@ -1,12 +1,13 @@
 // Shared call-info extraction (available for both native and WASM)
 pub mod call_info;
 
+// Shared signature building logic (available for both native and WASM)
+pub mod signature_core;
+
 #[cfg(feature = "native")]
 use crate::symbols::*;
 #[cfg(feature = "native")]
-use crate::utils::{
-    format_function_signature, get_line_at_position, node_at_position, utf16_offset_to_byte_offset,
-};
+use crate::utils::{get_line_at_position, node_at_position, utf16_offset_to_byte_offset};
 #[cfg(feature = "native")]
 use tower_lsp::lsp_types::*;
 #[cfg(feature = "native")]
@@ -14,6 +15,8 @@ use tree_sitter::Tree;
 
 #[cfg(feature = "native")]
 use call_info::{find_function_call, find_function_call_ast, CallType};
+#[cfg(feature = "native")]
+use signature_core::{provide_call_ref_signature_core, provide_direct_call_signature_core};
 
 #[cfg(all(test, feature = "native"))]
 mod tests;
@@ -40,145 +43,38 @@ pub fn provide_signature_help(
     })?;
 
     match call_info.call_type {
-        CallType::Direct => provide_direct_call_signature(symbols, &call_info),
+        CallType::Direct => {
+            let info = provide_direct_call_signature_core(symbols, &call_info)?;
+            Some(signature_info_to_lsp(info))
+        }
         CallType::CallRef | CallType::ReturnCallRef => {
-            provide_call_ref_signature(symbols, &call_info)
+            let info = provide_call_ref_signature_core(symbols, &call_info)?;
+            Some(signature_info_to_lsp(info))
         }
     }
 }
 
-/// Provide signature help for direct function calls (call $func)
+/// Convert protocol-independent signature help into LSP SignatureHelp.
 #[cfg(feature = "native")]
-fn provide_direct_call_signature(
-    symbols: &SymbolTable,
-    call_info: &call_info::CallInfo,
-) -> Option<SignatureHelp> {
-    // Look up the function in the symbol table
-    let func = if call_info.name.starts_with('$') {
-        symbols.get_function_by_name(&call_info.name)?
-    } else if let Ok(index) = call_info.name.parse::<usize>() {
-        symbols.get_function_by_index(index)?
-    } else {
-        return None;
-    };
+fn signature_info_to_lsp(info: signature_core::SignatureHelpInfo) -> SignatureHelp {
+    let sig = info.signature;
+    let parameters: Vec<ParameterInformation> = sig
+        .parameters
+        .into_iter()
+        .map(|p| ParameterInformation {
+            label: ParameterLabel::Simple(p.label),
+            documentation: p.documentation.map(Documentation::String),
+        })
+        .collect();
 
-    // Build signature information
-    let label = format_function_signature(func);
-
-    let mut parameters = Vec::new();
-    for param in &func.parameters {
-        let param_label = if let Some(ref name) = param.name {
-            format!("({} {})", name, param.param_type)
-        } else {
-            format!("(param {})", param.param_type)
-        };
-        parameters.push(ParameterInformation {
-            label: ParameterLabel::Simple(param_label),
-            documentation: None,
-        });
-    }
-
-    // Determine which parameter we're currently on based on comma count
-    let active_parameter = call_info.arg_text.matches(',').count() as u32;
-
-    Some(SignatureHelp {
+    SignatureHelp {
         signatures: vec![SignatureInformation {
-            label,
-            documentation: None,
+            label: sig.label,
+            documentation: sig.documentation.map(Documentation::String),
             parameters: Some(parameters),
-            active_parameter: Some(active_parameter.min(func.parameters.len() as u32)),
+            active_parameter: Some(sig.active_parameter),
         }],
         active_signature: Some(0),
-        active_parameter: Some(active_parameter.min(func.parameters.len() as u32)),
-    })
-}
-
-/// Provide signature help for indirect calls via typed function references (call_ref $type)
-#[cfg(feature = "native")]
-fn provide_call_ref_signature(
-    symbols: &SymbolTable,
-    call_info: &call_info::CallInfo,
-) -> Option<SignatureHelp> {
-    // Look up the type in the symbol table
-    let type_def = if call_info.name.starts_with('$') {
-        symbols.get_type_by_name(&call_info.name)?
-    } else if let Ok(index) = call_info.name.parse::<usize>() {
-        symbols.get_type_by_index(index)?
-    } else {
-        return None;
-    };
-
-    // The type must be a function type
-    let (params, results) = match &type_def.kind {
-        TypeKind::Func { params, results } => (params, results),
-        _ => return None, // Not a function type
-    };
-
-    // Build signature label
-    let call_kind = match call_info.call_type {
-        CallType::CallRef => "call_ref",
-        CallType::ReturnCallRef => "return_call_ref",
-        _ => "call_ref",
-    };
-    let type_index_str = type_def.index.to_string();
-    let type_name = type_def.name.as_deref().unwrap_or(&type_index_str);
-    let params_str = params
-        .iter()
-        .map(|p| p.to_string())
-        .collect::<Vec<_>>()
-        .join(" ");
-    let results_str = results
-        .iter()
-        .map(|r| r.to_string())
-        .collect::<Vec<_>>()
-        .join(" ");
-    let label = format!(
-        "({} {}) (param {}) (result {}) + funcref",
-        call_kind,
-        type_name,
-        if params_str.is_empty() {
-            "none"
-        } else {
-            &params_str
-        },
-        if results_str.is_empty() {
-            "none"
-        } else {
-            &results_str
-        }
-    );
-
-    // Build parameter information
-    let mut parameters = Vec::new();
-    for (i, param_type) in params.iter().enumerate() {
-        parameters.push(ParameterInformation {
-            label: ParameterLabel::Simple(format!("(param{} {})", i, param_type)),
-            documentation: None,
-        });
+        active_parameter: Some(sig.active_parameter),
     }
-    // The last argument is always the funcref
-    parameters.push(ParameterInformation {
-        label: ParameterLabel::Simple("(funcref)".to_string()),
-        documentation: Some(Documentation::String(
-            "Function reference to call".to_string(),
-        )),
-    });
-
-    // Determine which parameter we're currently on
-    let active_parameter = call_info.arg_text.matches(',').count() as u32;
-    let param_count = parameters.len() as u32;
-
-    Some(SignatureHelp {
-        signatures: vec![SignatureInformation {
-            label,
-            documentation: Some(Documentation::String(format!(
-                "Indirect call via typed function reference. The last argument must be a function reference of type {}.",
-                type_name
-            ))),
-            parameters: Some(parameters),
-            active_parameter: Some(active_parameter.min(param_count)),
-        }],
-        active_signature: Some(0),
-        active_parameter: Some(active_parameter.min(params.len() as u32 + 1)),
-    })
 }

--- a/src/features/signature/signature_core.rs
+++ b/src/features/signature/signature_core.rs
@@ -1,0 +1,154 @@
+//! Protocol-independent signature help logic shared between native and WASM.
+//!
+//! Both native (tower-lsp) and WASM (wasm-bindgen) builds convert
+//! `SignatureHelpInfo` into their respective output types.
+
+use crate::symbols::{SymbolTable, TypeKind};
+use crate::utils::format_function_signature;
+
+use super::call_info::{CallInfo, CallType};
+
+/// Protocol-independent parameter information.
+pub struct ParameterInfo {
+    pub label: String,
+    pub documentation: Option<String>,
+}
+
+/// Protocol-independent signature information.
+pub struct SignatureInfo {
+    pub label: String,
+    pub documentation: Option<String>,
+    pub parameters: Vec<ParameterInfo>,
+    pub active_parameter: u32,
+}
+
+/// Protocol-independent signature help result.
+pub struct SignatureHelpInfo {
+    pub signature: SignatureInfo,
+}
+
+/// Build signature help for a direct function call (call $func).
+pub fn provide_direct_call_signature_core(
+    symbols: &SymbolTable,
+    call_info: &CallInfo,
+) -> Option<SignatureHelpInfo> {
+    let func = if call_info.name.starts_with('$') {
+        symbols.get_function_by_name(&call_info.name)?
+    } else if let Ok(index) = call_info.name.parse::<usize>() {
+        symbols.get_function_by_index(index)?
+    } else {
+        return None;
+    };
+
+    let label = format_function_signature(func);
+
+    let parameters: Vec<ParameterInfo> = func
+        .parameters
+        .iter()
+        .map(|param| {
+            let param_label = if let Some(ref name) = param.name {
+                format!("({} {})", name, param.param_type)
+            } else {
+                format!("(param {})", param.param_type)
+            };
+            ParameterInfo {
+                label: param_label,
+                documentation: None,
+            }
+        })
+        .collect();
+
+    let active_parameter = call_info.arg_text.matches(',').count() as u32;
+    let clamped = active_parameter.min(func.parameters.len() as u32);
+
+    Some(SignatureHelpInfo {
+        signature: SignatureInfo {
+            label,
+            documentation: func.doc_comment.clone(),
+            parameters,
+            active_parameter: clamped,
+        },
+    })
+}
+
+/// Build signature help for an indirect call via typed function reference (call_ref $type).
+pub fn provide_call_ref_signature_core(
+    symbols: &SymbolTable,
+    call_info: &CallInfo,
+) -> Option<SignatureHelpInfo> {
+    let type_def = if call_info.name.starts_with('$') {
+        symbols.get_type_by_name(&call_info.name)?
+    } else if let Ok(index) = call_info.name.parse::<usize>() {
+        symbols.get_type_by_index(index)?
+    } else {
+        return None;
+    };
+
+    let (params, results) = match &type_def.kind {
+        TypeKind::Func { params, results } => (params, results),
+        _ => return None,
+    };
+
+    let call_kind = match call_info.call_type {
+        CallType::CallRef => "call_ref",
+        CallType::ReturnCallRef => "return_call_ref",
+        _ => "call_ref",
+    };
+    let type_index_str = type_def.index.to_string();
+    let type_name = type_def.name.as_deref().unwrap_or(&type_index_str);
+    let params_str = params
+        .iter()
+        .map(|p| p.to_string())
+        .collect::<Vec<_>>()
+        .join(" ");
+    let results_str = results
+        .iter()
+        .map(|r| r.to_string())
+        .collect::<Vec<_>>()
+        .join(" ");
+    let label = format!(
+        "({} {}) (param {}) (result {}) + funcref",
+        call_kind,
+        type_name,
+        if params_str.is_empty() {
+            "none"
+        } else {
+            &params_str
+        },
+        if results_str.is_empty() {
+            "none"
+        } else {
+            &results_str
+        }
+    );
+
+    let mut parameters: Vec<ParameterInfo> = params
+        .iter()
+        .enumerate()
+        .map(|(i, param_type)| ParameterInfo {
+            label: format!("(param{} {})", i, param_type),
+            documentation: None,
+        })
+        .collect();
+
+    parameters.push(ParameterInfo {
+        label: "(funcref)".to_string(),
+        documentation: Some("Function reference to call".to_string()),
+    });
+
+    let active_parameter = call_info.arg_text.matches(',').count() as u32;
+    let param_count = parameters.len() as u32;
+    let clamped = active_parameter.min(param_count);
+
+    Some(SignatureHelpInfo {
+        signature: SignatureInfo {
+            label,
+            documentation: Some(format!(
+                "Indirect call via typed function reference. The last argument must be a function reference of type {}.",
+                type_name
+            )),
+            parameters,
+            active_parameter: clamped,
+        },
+    })
+}

--- a/src/features/signature/tests.rs
+++ b/src/features/signature/tests.rs
@@ -1,6 +1,7 @@
 use super::call_info::{extract_name_from_call, find_function_call, CallInfo};
 use super::*;
 use crate::features::test_utils::{create_signature_test_symbols, create_test_tree};
+use crate::utils::format_function_signature;
 
 // Alias for backwards compatibility with existing tests
 fn create_test_symbols() -> SymbolTable {

--- a/src/instruction_metadata.rs
+++ b/src/instruction_metadata.rs
@@ -2,8 +2,14 @@
 //!
 //! This module is shared between native and WASM builds to provide
 //! instruction arity information for stack underflow detection.
+//!
+//! Uses a sorted array with binary search for O(log n) lookups,
+//! matching the pattern used by `docs.rs`. Eliminates HashMap
+//! overhead and runtime allocation in WASM builds.
 
+#[cfg(test)]
 use std::collections::HashMap;
+use std::sync::OnceLock;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum OperandMode {
@@ -12,7 +18,7 @@ pub enum OperandMode {
 }
 
 /// Represents the expected parameter count for a WAT instruction
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct InstructionArity {
     pub min_params: usize,
     pub max_params: usize,
@@ -174,555 +180,526 @@ impl InstructionArity {
     }
 }
 
-/// Returns a map of instruction names to their expected parameter counts
+// ============================================================================
+// Sorted arity table — single OnceLock, binary-search lookup
+// ============================================================================
+
+static ARITY_TABLE: OnceLock<Vec<(&'static str, InstructionArity)>> = OnceLock::new();
+
+fn init_arity_table() -> Vec<(&'static str, InstructionArity)> {
+    let mut entries: Vec<(&'static str, InstructionArity)> = vec![
+        // Local variable instructions
+        ("local.get", InstructionArity::index("index")),
+        ("local.set", InstructionArity::index_set("index")),
+        ("local.tee", InstructionArity::index_tee("index")),
+        // Global variable instructions
+        ("global.get", InstructionArity::index("index")),
+        ("global.set", InstructionArity::index_set("index")),
+        // Control flow
+        ("br", InstructionArity::dynamic(1, 1, "label index", 0)),
+        ("br_if", InstructionArity::dynamic(1, 1, "label index", 0)),
+        (
+            "br_table",
+            InstructionArity::dynamic(1, usize::MAX, "label indices", 0),
+        ),
+        ("call", InstructionArity::dynamic(1, 1, "function index", 0)),
+        (
+            "return_call",
+            InstructionArity::dynamic(1, 1, "function index", 0),
+        ),
+        (
+            "call_indirect",
+            InstructionArity::dynamic(1, 1, "type index", 0),
+        ),
+        (
+            "return_call_indirect",
+            InstructionArity::dynamic(1, 1, "type index", 0),
+        ),
+        ("return", InstructionArity::dynamic(0, 0, "", 0)),
+        ("unreachable", InstructionArity::nullary()),
+        ("nop", InstructionArity::nullary()),
+        // Constants
+        ("i32.const", InstructionArity::constant("literal value")),
+        ("i64.const", InstructionArity::constant("literal value")),
+        ("f32.const", InstructionArity::constant("literal value")),
+        ("f64.const", InstructionArity::constant("literal value")),
+        // Stack manipulation
+        ("drop", InstructionArity::drop_op()),
+        ("select", InstructionArity::exact(0, "", 3, 1)),
+        // i32 arithmetic (binary)
+        ("i32.add", InstructionArity::binary_op()),
+        ("i32.sub", InstructionArity::binary_op()),
+        ("i32.mul", InstructionArity::binary_op()),
+        ("i32.div_s", InstructionArity::binary_op()),
+        ("i32.div_u", InstructionArity::binary_op()),
+        ("i32.rem_s", InstructionArity::binary_op()),
+        ("i32.rem_u", InstructionArity::binary_op()),
+        ("i32.and", InstructionArity::binary_op()),
+        ("i32.or", InstructionArity::binary_op()),
+        ("i32.xor", InstructionArity::binary_op()),
+        ("i32.shl", InstructionArity::binary_op()),
+        ("i32.shr_s", InstructionArity::binary_op()),
+        ("i32.shr_u", InstructionArity::binary_op()),
+        ("i32.rotl", InstructionArity::binary_op()),
+        ("i32.rotr", InstructionArity::binary_op()),
+        // i32 comparison (binary)
+        ("i32.eq", InstructionArity::binary_op()),
+        ("i32.ne", InstructionArity::binary_op()),
+        ("i32.lt_s", InstructionArity::binary_op()),
+        ("i32.lt_u", InstructionArity::binary_op()),
+        ("i32.le_s", InstructionArity::binary_op()),
+        ("i32.le_u", InstructionArity::binary_op()),
+        ("i32.gt_s", InstructionArity::binary_op()),
+        ("i32.gt_u", InstructionArity::binary_op()),
+        ("i32.ge_s", InstructionArity::binary_op()),
+        ("i32.ge_u", InstructionArity::binary_op()),
+        // i32 unary
+        ("i32.clz", InstructionArity::unary_op()),
+        ("i32.ctz", InstructionArity::unary_op()),
+        ("i32.popcnt", InstructionArity::unary_op()),
+        ("i32.eqz", InstructionArity::unary_op()),
+        // i64 arithmetic (binary)
+        ("i64.add", InstructionArity::binary_op()),
+        ("i64.sub", InstructionArity::binary_op()),
+        ("i64.mul", InstructionArity::binary_op()),
+        ("i64.div_s", InstructionArity::binary_op()),
+        ("i64.div_u", InstructionArity::binary_op()),
+        ("i64.rem_s", InstructionArity::binary_op()),
+        ("i64.rem_u", InstructionArity::binary_op()),
+        ("i64.and", InstructionArity::binary_op()),
+        ("i64.or", InstructionArity::binary_op()),
+        ("i64.xor", InstructionArity::binary_op()),
+        ("i64.shl", InstructionArity::binary_op()),
+        ("i64.shr_s", InstructionArity::binary_op()),
+        ("i64.shr_u", InstructionArity::binary_op()),
+        ("i64.rotl", InstructionArity::binary_op()),
+        ("i64.rotr", InstructionArity::binary_op()),
+        // i64 comparison (binary)
+        ("i64.eq", InstructionArity::binary_op()),
+        ("i64.ne", InstructionArity::binary_op()),
+        ("i64.lt_s", InstructionArity::binary_op()),
+        ("i64.lt_u", InstructionArity::binary_op()),
+        ("i64.le_s", InstructionArity::binary_op()),
+        ("i64.le_u", InstructionArity::binary_op()),
+        ("i64.gt_s", InstructionArity::binary_op()),
+        ("i64.gt_u", InstructionArity::binary_op()),
+        ("i64.ge_s", InstructionArity::binary_op()),
+        ("i64.ge_u", InstructionArity::binary_op()),
+        // i64 unary
+        ("i64.clz", InstructionArity::unary_op()),
+        ("i64.ctz", InstructionArity::unary_op()),
+        ("i64.popcnt", InstructionArity::unary_op()),
+        ("i64.eqz", InstructionArity::unary_op()),
+        // f32 arithmetic (binary)
+        ("f32.add", InstructionArity::binary_op()),
+        ("f32.sub", InstructionArity::binary_op()),
+        ("f32.mul", InstructionArity::binary_op()),
+        ("f32.div", InstructionArity::binary_op()),
+        ("f32.min", InstructionArity::binary_op()),
+        ("f32.max", InstructionArity::binary_op()),
+        ("f32.copysign", InstructionArity::binary_op()),
+        // f32 comparison (binary)
+        ("f32.eq", InstructionArity::binary_op()),
+        ("f32.ne", InstructionArity::binary_op()),
+        ("f32.lt", InstructionArity::binary_op()),
+        ("f32.le", InstructionArity::binary_op()),
+        ("f32.gt", InstructionArity::binary_op()),
+        ("f32.ge", InstructionArity::binary_op()),
+        // f32 unary
+        ("f32.abs", InstructionArity::unary_op()),
+        ("f32.neg", InstructionArity::unary_op()),
+        ("f32.ceil", InstructionArity::unary_op()),
+        ("f32.floor", InstructionArity::unary_op()),
+        ("f32.trunc", InstructionArity::unary_op()),
+        ("f32.nearest", InstructionArity::unary_op()),
+        ("f32.sqrt", InstructionArity::unary_op()),
+        // f64 arithmetic (binary)
+        ("f64.add", InstructionArity::binary_op()),
+        ("f64.sub", InstructionArity::binary_op()),
+        ("f64.mul", InstructionArity::binary_op()),
+        ("f64.div", InstructionArity::binary_op()),
+        ("f64.min", InstructionArity::binary_op()),
+        ("f64.max", InstructionArity::binary_op()),
+        ("f64.copysign", InstructionArity::binary_op()),
+        // f64 comparison (binary)
+        ("f64.eq", InstructionArity::binary_op()),
+        ("f64.ne", InstructionArity::binary_op()),
+        ("f64.lt", InstructionArity::binary_op()),
+        ("f64.le", InstructionArity::binary_op()),
+        ("f64.gt", InstructionArity::binary_op()),
+        ("f64.ge", InstructionArity::binary_op()),
+        // f64 unary
+        ("f64.abs", InstructionArity::unary_op()),
+        ("f64.neg", InstructionArity::unary_op()),
+        ("f64.ceil", InstructionArity::unary_op()),
+        ("f64.floor", InstructionArity::unary_op()),
+        ("f64.trunc", InstructionArity::unary_op()),
+        ("f64.nearest", InstructionArity::unary_op()),
+        ("f64.sqrt", InstructionArity::unary_op()),
+        // Conversion operations (unary)
+        ("i32.wrap_i64", InstructionArity::unary_op()),
+        ("i64.extend_i32_s", InstructionArity::unary_op()),
+        ("i64.extend_i32_u", InstructionArity::unary_op()),
+        ("i32.trunc_f32_s", InstructionArity::unary_op()),
+        ("i32.trunc_f32_u", InstructionArity::unary_op()),
+        ("i32.trunc_f64_s", InstructionArity::unary_op()),
+        ("i32.trunc_f64_u", InstructionArity::unary_op()),
+        ("i64.trunc_f32_s", InstructionArity::unary_op()),
+        ("i64.trunc_f32_u", InstructionArity::unary_op()),
+        ("i64.trunc_f64_s", InstructionArity::unary_op()),
+        ("i64.trunc_f64_u", InstructionArity::unary_op()),
+        ("f32.convert_i32_s", InstructionArity::unary_op()),
+        ("f32.convert_i32_u", InstructionArity::unary_op()),
+        ("f32.convert_i64_s", InstructionArity::unary_op()),
+        ("f32.convert_i64_u", InstructionArity::unary_op()),
+        ("f32.demote_f64", InstructionArity::unary_op()),
+        ("f64.convert_i32_s", InstructionArity::unary_op()),
+        ("f64.convert_i32_u", InstructionArity::unary_op()),
+        ("f64.convert_i64_s", InstructionArity::unary_op()),
+        ("f64.convert_i64_u", InstructionArity::unary_op()),
+        ("f64.promote_f32", InstructionArity::unary_op()),
+        ("i32.reinterpret_f32", InstructionArity::unary_op()),
+        ("i64.reinterpret_f64", InstructionArity::unary_op()),
+        ("f32.reinterpret_i32", InstructionArity::unary_op()),
+        ("f64.reinterpret_i64", InstructionArity::unary_op()),
+        // Memory load (optional memory index, consume address)
+        ("i32.load", InstructionArity::mem_load()),
+        ("i64.load", InstructionArity::mem_load()),
+        ("f32.load", InstructionArity::mem_load()),
+        ("f64.load", InstructionArity::mem_load()),
+        ("i32.load8_s", InstructionArity::mem_load()),
+        ("i32.load8_u", InstructionArity::mem_load()),
+        ("i32.load16_s", InstructionArity::mem_load()),
+        ("i32.load16_u", InstructionArity::mem_load()),
+        ("i64.load8_s", InstructionArity::mem_load()),
+        ("i64.load8_u", InstructionArity::mem_load()),
+        ("i64.load16_s", InstructionArity::mem_load()),
+        ("i64.load16_u", InstructionArity::mem_load()),
+        ("i64.load32_s", InstructionArity::mem_load()),
+        ("i64.load32_u", InstructionArity::mem_load()),
+        // Memory store (optional memory index, consume address + value)
+        ("i32.store", InstructionArity::mem_store()),
+        ("i64.store", InstructionArity::mem_store()),
+        ("f32.store", InstructionArity::mem_store()),
+        ("f64.store", InstructionArity::mem_store()),
+        ("i32.store8", InstructionArity::mem_store()),
+        ("i32.store16", InstructionArity::mem_store()),
+        ("i64.store8", InstructionArity::mem_store()),
+        ("i64.store16", InstructionArity::mem_store()),
+        ("i64.store32", InstructionArity::mem_store()),
+        // Memory management (optional memory index)
+        (
+            "memory.size",
+            InstructionArity {
+                min_params: 0,
+                max_params: 1,
+                param_description: "optional memory index",
+                operand_mode: OperandMode::Fixed(0),
+                produces: 1,
+            },
+        ),
+        (
+            "memory.grow",
+            InstructionArity {
+                min_params: 0,
+                max_params: 1,
+                param_description: "optional memory index",
+                operand_mode: OperandMode::Fixed(1),
+                produces: 1,
+            },
+        ),
+        // WasmGC — Structs
+        (
+            "struct.new",
+            InstructionArity::dynamic(1, 1, "type index", 1),
+        ),
+        (
+            "struct.new_default",
+            InstructionArity::exact(1, "type index", 0, 1),
+        ),
+        (
+            "struct.get",
+            InstructionArity::exact(2, "type and field index", 1, 1),
+        ),
+        (
+            "struct.get_s",
+            InstructionArity::exact(2, "type and field index", 1, 1),
+        ),
+        (
+            "struct.get_u",
+            InstructionArity::exact(2, "type and field index", 1, 1),
+        ),
+        (
+            "struct.set",
+            InstructionArity::exact(2, "type and field index", 2, 0),
+        ),
+        // WasmGC — Arrays
+        ("array.new", InstructionArity::exact(1, "type index", 2, 1)),
+        (
+            "array.new_default",
+            InstructionArity::exact(1, "type index", 1, 1),
+        ),
+        (
+            "array.new_fixed",
+            InstructionArity::dynamic(2, 2, "type index and length", 1),
+        ),
+        (
+            "array.new_data",
+            InstructionArity::exact(2, "type and data index", 2, 1),
+        ),
+        (
+            "array.new_elem",
+            InstructionArity::exact(2, "type and elem index", 2, 1),
+        ),
+        ("array.get", InstructionArity::exact(1, "type index", 2, 1)),
+        (
+            "array.get_s",
+            InstructionArity::exact(1, "type index", 2, 1),
+        ),
+        (
+            "array.get_u",
+            InstructionArity::exact(1, "type index", 2, 1),
+        ),
+        ("array.set", InstructionArity::exact(1, "type index", 3, 0)),
+        ("array.len", InstructionArity::unary_op()),
+        ("array.fill", InstructionArity::exact(1, "type index", 4, 0)),
+        (
+            "array.copy",
+            InstructionArity::exact(2, "dest and src type index", 5, 0),
+        ),
+        (
+            "array.init_data",
+            InstructionArity::exact(2, "type and data index", 4, 0),
+        ),
+        (
+            "array.init_elem",
+            InstructionArity::exact(2, "type and elem index", 4, 0),
+        ),
+        // WasmGC — I31
+        ("ref.i31", InstructionArity::unary_op()),
+        ("i31.get_s", InstructionArity::unary_op()),
+        ("i31.get_u", InstructionArity::unary_op()),
+        // WasmGC — Casts
+        ("ref.test", InstructionArity::exact(1, "type index", 1, 1)),
+        ("ref.cast", InstructionArity::exact(1, "type index", 1, 1)),
+        (
+            "ref.cast_null",
+            InstructionArity::exact(1, "type index", 1, 1),
+        ),
+        (
+            "br_on_cast",
+            InstructionArity::exact(2, "label and type index", 1, 0),
+        ),
+        (
+            "br_on_cast_fail",
+            InstructionArity::exact(2, "label and type index", 1, 0),
+        ),
+        // Exceptions
+        ("throw", InstructionArity::dynamic(1, 1, "tag index", 0)),
+        ("throw_ref", InstructionArity::exact(0, "", 1, 0)),
+        ("rethrow", InstructionArity::exact(1, "label index", 0, 0)),
+        // Typed function references
+        ("call_ref", InstructionArity::dynamic(1, 1, "type index", 0)),
+        (
+            "return_call_ref",
+            InstructionArity::dynamic(1, 1, "type index", 0),
+        ),
+        // Null-checking branches
+        (
+            "br_on_null",
+            InstructionArity::dynamic(1, 1, "label index", 1),
+        ),
+        (
+            "br_on_non_null",
+            InstructionArity::dynamic(1, 1, "label index", 0),
+        ),
+        // Reference equality
+        ("ref.eq", InstructionArity::binary_op()),
+        // Reference conversions
+        ("any.convert_extern", InstructionArity::unary_op()),
+        ("extern.convert_any", InstructionArity::unary_op()),
+        // Bulk memory (optional memory indices)
+        (
+            "memory.copy",
+            InstructionArity {
+                min_params: 0,
+                max_params: 2,
+                param_description: "optional dest and src memory indices",
+                operand_mode: OperandMode::Fixed(3),
+                produces: 0,
+            },
+        ),
+        (
+            "memory.fill",
+            InstructionArity {
+                min_params: 0,
+                max_params: 1,
+                param_description: "optional memory index",
+                operand_mode: OperandMode::Fixed(3),
+                produces: 0,
+            },
+        ),
+        (
+            "memory.init",
+            InstructionArity {
+                min_params: 1,
+                max_params: 2,
+                param_description: "data index and optional memory index",
+                operand_mode: OperandMode::Fixed(3),
+                produces: 0,
+            },
+        ),
+        ("data.drop", InstructionArity::exact(1, "data index", 0, 0)),
+        // Table operations
+        ("table.get", InstructionArity::exact(1, "table index", 1, 1)),
+        ("table.set", InstructionArity::exact(1, "table index", 2, 0)),
+        (
+            "table.size",
+            InstructionArity::exact(1, "table index", 0, 1),
+        ),
+        (
+            "table.grow",
+            InstructionArity::exact(1, "table index", 2, 1),
+        ),
+        (
+            "table.fill",
+            InstructionArity::exact(1, "table index", 3, 0),
+        ),
+        (
+            "table.copy",
+            InstructionArity::exact(2, "dest and src table index", 3, 0),
+        ),
+        (
+            "table.init",
+            InstructionArity::exact(2, "table and elem index", 3, 0),
+        ),
+        ("elem.drop", InstructionArity::exact(1, "elem index", 0, 0)),
+        // Reference operations
+        ("ref.null", InstructionArity::exact(1, "type", 0, 1)),
+        (
+            "ref.func",
+            InstructionArity::exact(1, "function index", 0, 1),
+        ),
+        ("ref.is_null", InstructionArity::unary_op()),
+        ("ref.as_non_null", InstructionArity::unary_op()),
+        // Saturating truncation
+        ("i32.trunc_sat_f32_s", InstructionArity::unary_op()),
+        ("i32.trunc_sat_f32_u", InstructionArity::unary_op()),
+        ("i32.trunc_sat_f64_s", InstructionArity::unary_op()),
+        ("i32.trunc_sat_f64_u", InstructionArity::unary_op()),
+        ("i64.trunc_sat_f32_s", InstructionArity::unary_op()),
+        ("i64.trunc_sat_f32_u", InstructionArity::unary_op()),
+        ("i64.trunc_sat_f64_s", InstructionArity::unary_op()),
+        ("i64.trunc_sat_f64_u", InstructionArity::unary_op()),
+        // Sign extension
+        ("i32.extend8_s", InstructionArity::unary_op()),
+        ("i32.extend16_s", InstructionArity::unary_op()),
+        ("i64.extend8_s", InstructionArity::unary_op()),
+        ("i64.extend16_s", InstructionArity::unary_op()),
+        ("i64.extend32_s", InstructionArity::unary_op()),
+        // Atomic operations
+        ("atomic.fence", InstructionArity::nullary()),
+        // Atomic loads
+        ("i32.atomic.load", InstructionArity::mem_load()),
+        ("i64.atomic.load", InstructionArity::mem_load()),
+        ("i32.atomic.load8_u", InstructionArity::mem_load()),
+        ("i32.atomic.load16_u", InstructionArity::mem_load()),
+        ("i64.atomic.load8_u", InstructionArity::mem_load()),
+        ("i64.atomic.load16_u", InstructionArity::mem_load()),
+        ("i64.atomic.load32_u", InstructionArity::mem_load()),
+        // Atomic stores
+        ("i32.atomic.store", InstructionArity::mem_store()),
+        ("i64.atomic.store", InstructionArity::mem_store()),
+        ("i32.atomic.store8", InstructionArity::mem_store()),
+        ("i32.atomic.store16", InstructionArity::mem_store()),
+        ("i64.atomic.store8", InstructionArity::mem_store()),
+        ("i64.atomic.store16", InstructionArity::mem_store()),
+        ("i64.atomic.store32", InstructionArity::mem_store()),
+        // Atomic RMW i32 full-width
+        ("i32.atomic.rmw.add", InstructionArity::mem_rmw()),
+        ("i32.atomic.rmw.sub", InstructionArity::mem_rmw()),
+        ("i32.atomic.rmw.and", InstructionArity::mem_rmw()),
+        ("i32.atomic.rmw.or", InstructionArity::mem_rmw()),
+        ("i32.atomic.rmw.xor", InstructionArity::mem_rmw()),
+        ("i32.atomic.rmw.xchg", InstructionArity::mem_rmw()),
+        // Atomic RMW i32 narrow
+        ("i32.atomic.rmw8.add_u", InstructionArity::mem_rmw()),
+        ("i32.atomic.rmw8.sub_u", InstructionArity::mem_rmw()),
+        ("i32.atomic.rmw8.and_u", InstructionArity::mem_rmw()),
+        ("i32.atomic.rmw8.or_u", InstructionArity::mem_rmw()),
+        ("i32.atomic.rmw8.xor_u", InstructionArity::mem_rmw()),
+        ("i32.atomic.rmw8.xchg_u", InstructionArity::mem_rmw()),
+        ("i32.atomic.rmw16.add_u", InstructionArity::mem_rmw()),
+        ("i32.atomic.rmw16.sub_u", InstructionArity::mem_rmw()),
+        ("i32.atomic.rmw16.and_u", InstructionArity::mem_rmw()),
+        ("i32.atomic.rmw16.or_u", InstructionArity::mem_rmw()),
+        ("i32.atomic.rmw16.xor_u", InstructionArity::mem_rmw()),
+        ("i32.atomic.rmw16.xchg_u", InstructionArity::mem_rmw()),
+        // Atomic RMW i64 full-width
+        ("i64.atomic.rmw.add", InstructionArity::mem_rmw()),
+        ("i64.atomic.rmw.sub", InstructionArity::mem_rmw()),
+        ("i64.atomic.rmw.and", InstructionArity::mem_rmw()),
+        ("i64.atomic.rmw.or", InstructionArity::mem_rmw()),
+        ("i64.atomic.rmw.xor", InstructionArity::mem_rmw()),
+        ("i64.atomic.rmw.xchg", InstructionArity::mem_rmw()),
+        // Atomic RMW i64 narrow
+        ("i64.atomic.rmw8.add_u", InstructionArity::mem_rmw()),
+        ("i64.atomic.rmw8.sub_u", InstructionArity::mem_rmw()),
+        ("i64.atomic.rmw8.and_u", InstructionArity::mem_rmw()),
+        ("i64.atomic.rmw8.or_u", InstructionArity::mem_rmw()),
+        ("i64.atomic.rmw8.xor_u", InstructionArity::mem_rmw()),
+        ("i64.atomic.rmw8.xchg_u", InstructionArity::mem_rmw()),
+        ("i64.atomic.rmw16.add_u", InstructionArity::mem_rmw()),
+        ("i64.atomic.rmw16.sub_u", InstructionArity::mem_rmw()),
+        ("i64.atomic.rmw16.and_u", InstructionArity::mem_rmw()),
+        ("i64.atomic.rmw16.or_u", InstructionArity::mem_rmw()),
+        ("i64.atomic.rmw16.xor_u", InstructionArity::mem_rmw()),
+        ("i64.atomic.rmw16.xchg_u", InstructionArity::mem_rmw()),
+        ("i64.atomic.rmw32.add_u", InstructionArity::mem_rmw()),
+        ("i64.atomic.rmw32.sub_u", InstructionArity::mem_rmw()),
+        ("i64.atomic.rmw32.and_u", InstructionArity::mem_rmw()),
+        ("i64.atomic.rmw32.or_u", InstructionArity::mem_rmw()),
+        ("i64.atomic.rmw32.xor_u", InstructionArity::mem_rmw()),
+        ("i64.atomic.rmw32.xchg_u", InstructionArity::mem_rmw()),
+        // Atomic cmpxchg
+        ("i32.atomic.rmw.cmpxchg", InstructionArity::mem_cmpxchg()),
+        ("i64.atomic.rmw.cmpxchg", InstructionArity::mem_cmpxchg()),
+        ("i32.atomic.rmw8.cmpxchg_u", InstructionArity::mem_cmpxchg()),
+        (
+            "i32.atomic.rmw16.cmpxchg_u",
+            InstructionArity::mem_cmpxchg(),
+        ),
+        ("i64.atomic.rmw8.cmpxchg_u", InstructionArity::mem_cmpxchg()),
+        (
+            "i64.atomic.rmw16.cmpxchg_u",
+            InstructionArity::mem_cmpxchg(),
+        ),
+        (
+            "i64.atomic.rmw32.cmpxchg_u",
+            InstructionArity::mem_cmpxchg(),
+        ),
+        // Wait/notify
+        ("memory.atomic.wait32", InstructionArity::exact(0, "", 3, 1)),
+        ("memory.atomic.wait64", InstructionArity::exact(0, "", 3, 1)),
+        ("memory.atomic.notify", InstructionArity::exact(0, "", 2, 1)),
+    ];
+    entries.sort_by_key(|(name, _)| *name);
+    entries
+}
+
+/// Look up instruction arity by name using binary search on the sorted table.
+pub fn lookup_instruction_arity(name: &str) -> Option<&'static InstructionArity> {
+    let table = ARITY_TABLE.get_or_init(init_arity_table);
+    table
+        .binary_search_by_key(&name, |(k, _)| k)
+        .ok()
+        .map(|i| &table[i].1)
+}
+
+/// Returns a map of instruction names to their expected parameter counts (test-only).
+#[cfg(test)]
 pub fn get_instruction_arity_map() -> HashMap<&'static str, InstructionArity> {
-    let mut map = HashMap::new();
-
-    // Local variable instructions (index-based, produce values)
-    map.insert("local.get", InstructionArity::index("index"));
-    map.insert("local.set", InstructionArity::index_set("index")); // consumes 1 value
-    map.insert("local.tee", InstructionArity::index_tee("index")); // consumes 1 value, produces 1
-
-    // Global variable instructions
-    map.insert("global.get", InstructionArity::index("index"));
-    map.insert("global.set", InstructionArity::index_set("index")); // consumes 1 value
-
-    // Control flow instructions
-    // br and br_if can pass values to blocks with result types (multi-value)
-    map.insert("br", InstructionArity::dynamic(1, 1, "label index", 0)); // terminates
-    map.insert("br_if", InstructionArity::dynamic(1, 1, "label index", 0)); // consumes condition + optional values
-    map.insert(
-        "br_table",
-        InstructionArity::dynamic(1, usize::MAX, "label indices", 0),
-    ); // terminates - always branches
-    map.insert("call", InstructionArity::dynamic(1, 1, "function index", 0)); // produces depend on function signature (set to 0, handled dynamically)
-    map.insert(
-        "return_call",
-        InstructionArity::dynamic(1, 1, "function index", 0),
-    ); // tail call - args depend on callee signature
-    map.insert(
-        "call_indirect",
-        InstructionArity::dynamic(1, 1, "type index", 0),
-    ); // args + table index -> dynamic results
-    map.insert(
-        "return_call_indirect",
-        InstructionArity::dynamic(1, 1, "type index", 0),
-    ); // args + table index -> dynamic results
-       // return can pass values for functions with result types
-    map.insert("return", InstructionArity::dynamic(0, 0, "", 0)); // terminates
-    map.insert("unreachable", InstructionArity::nullary()); // terminates
-    map.insert("nop", InstructionArity::nullary());
-
-    // Constant instructions (produce values)
-    map.insert("i32.const", InstructionArity::constant("literal value"));
-    map.insert("i64.const", InstructionArity::constant("literal value"));
-    map.insert("f32.const", InstructionArity::constant("literal value"));
-    map.insert("f64.const", InstructionArity::constant("literal value"));
-
-    // Stack manipulation
-    map.insert("drop", InstructionArity::drop_op()); // consumes 1 value, produces 0
-    map.insert("select", InstructionArity::exact(0, "", 3, 1)); // consumes 3 values, produces 1
-
-    // i32 arithmetic operations (binary)
-    map.insert("i32.add", InstructionArity::binary_op());
-    map.insert("i32.sub", InstructionArity::binary_op());
-    map.insert("i32.mul", InstructionArity::binary_op());
-    map.insert("i32.div_s", InstructionArity::binary_op());
-    map.insert("i32.div_u", InstructionArity::binary_op());
-    map.insert("i32.rem_s", InstructionArity::binary_op());
-    map.insert("i32.rem_u", InstructionArity::binary_op());
-    map.insert("i32.and", InstructionArity::binary_op());
-    map.insert("i32.or", InstructionArity::binary_op());
-    map.insert("i32.xor", InstructionArity::binary_op());
-    map.insert("i32.shl", InstructionArity::binary_op());
-    map.insert("i32.shr_s", InstructionArity::binary_op());
-    map.insert("i32.shr_u", InstructionArity::binary_op());
-    map.insert("i32.rotl", InstructionArity::binary_op());
-    map.insert("i32.rotr", InstructionArity::binary_op());
-
-    // i32 comparison operations (binary)
-    map.insert("i32.eq", InstructionArity::binary_op());
-    map.insert("i32.ne", InstructionArity::binary_op());
-    map.insert("i32.lt_s", InstructionArity::binary_op());
-    map.insert("i32.lt_u", InstructionArity::binary_op());
-    map.insert("i32.le_s", InstructionArity::binary_op());
-    map.insert("i32.le_u", InstructionArity::binary_op());
-    map.insert("i32.gt_s", InstructionArity::binary_op());
-    map.insert("i32.gt_u", InstructionArity::binary_op());
-    map.insert("i32.ge_s", InstructionArity::binary_op());
-    map.insert("i32.ge_u", InstructionArity::binary_op());
-
-    // i32 unary operations
-    map.insert("i32.clz", InstructionArity::unary_op());
-    map.insert("i32.ctz", InstructionArity::unary_op());
-    map.insert("i32.popcnt", InstructionArity::unary_op());
-    map.insert("i32.eqz", InstructionArity::unary_op());
-
-    // i64 arithmetic operations (binary)
-    map.insert("i64.add", InstructionArity::binary_op());
-    map.insert("i64.sub", InstructionArity::binary_op());
-    map.insert("i64.mul", InstructionArity::binary_op());
-    map.insert("i64.div_s", InstructionArity::binary_op());
-    map.insert("i64.div_u", InstructionArity::binary_op());
-    map.insert("i64.rem_s", InstructionArity::binary_op());
-    map.insert("i64.rem_u", InstructionArity::binary_op());
-    map.insert("i64.and", InstructionArity::binary_op());
-    map.insert("i64.or", InstructionArity::binary_op());
-    map.insert("i64.xor", InstructionArity::binary_op());
-    map.insert("i64.shl", InstructionArity::binary_op());
-    map.insert("i64.shr_s", InstructionArity::binary_op());
-    map.insert("i64.shr_u", InstructionArity::binary_op());
-    map.insert("i64.rotl", InstructionArity::binary_op());
-    map.insert("i64.rotr", InstructionArity::binary_op());
-
-    // i64 comparison operations (binary)
-    map.insert("i64.eq", InstructionArity::binary_op());
-    map.insert("i64.ne", InstructionArity::binary_op());
-    map.insert("i64.lt_s", InstructionArity::binary_op());
-    map.insert("i64.lt_u", InstructionArity::binary_op());
-    map.insert("i64.le_s", InstructionArity::binary_op());
-    map.insert("i64.le_u", InstructionArity::binary_op());
-    map.insert("i64.gt_s", InstructionArity::binary_op());
-    map.insert("i64.gt_u", InstructionArity::binary_op());
-    map.insert("i64.ge_s", InstructionArity::binary_op());
-    map.insert("i64.ge_u", InstructionArity::binary_op());
-
-    // i64 unary operations
-    map.insert("i64.clz", InstructionArity::unary_op());
-    map.insert("i64.ctz", InstructionArity::unary_op());
-    map.insert("i64.popcnt", InstructionArity::unary_op());
-    map.insert("i64.eqz", InstructionArity::unary_op());
-
-    // f32 arithmetic operations (binary)
-    map.insert("f32.add", InstructionArity::binary_op());
-    map.insert("f32.sub", InstructionArity::binary_op());
-    map.insert("f32.mul", InstructionArity::binary_op());
-    map.insert("f32.div", InstructionArity::binary_op());
-    map.insert("f32.min", InstructionArity::binary_op());
-    map.insert("f32.max", InstructionArity::binary_op());
-    map.insert("f32.copysign", InstructionArity::binary_op());
-
-    // f32 comparison operations (binary)
-    map.insert("f32.eq", InstructionArity::binary_op());
-    map.insert("f32.ne", InstructionArity::binary_op());
-    map.insert("f32.lt", InstructionArity::binary_op());
-    map.insert("f32.le", InstructionArity::binary_op());
-    map.insert("f32.gt", InstructionArity::binary_op());
-    map.insert("f32.ge", InstructionArity::binary_op());
-
-    // f32 unary operations
-    map.insert("f32.abs", InstructionArity::unary_op());
-    map.insert("f32.neg", InstructionArity::unary_op());
-    map.insert("f32.ceil", InstructionArity::unary_op());
-    map.insert("f32.floor", InstructionArity::unary_op());
-    map.insert("f32.trunc", InstructionArity::unary_op());
-    map.insert("f32.nearest", InstructionArity::unary_op());
-    map.insert("f32.sqrt", InstructionArity::unary_op());
-
-    // f64 arithmetic operations (binary)
-    map.insert("f64.add", InstructionArity::binary_op());
-    map.insert("f64.sub", InstructionArity::binary_op());
-    map.insert("f64.mul", InstructionArity::binary_op());
-    map.insert("f64.div", InstructionArity::binary_op());
-    map.insert("f64.min", InstructionArity::binary_op());
-    map.insert("f64.max", InstructionArity::binary_op());
-    map.insert("f64.copysign", InstructionArity::binary_op());
-
-    // f64 comparison operations (binary)
-    map.insert("f64.eq", InstructionArity::binary_op());
-    map.insert("f64.ne", InstructionArity::binary_op());
-    map.insert("f64.lt", InstructionArity::binary_op());
-    map.insert("f64.le", InstructionArity::binary_op());
-    map.insert("f64.gt", InstructionArity::binary_op());
-    map.insert("f64.ge", InstructionArity::binary_op());
-
-    // f64 unary operations
-    map.insert("f64.abs", InstructionArity::unary_op());
-    map.insert("f64.neg", InstructionArity::unary_op());
-    map.insert("f64.ceil", InstructionArity::unary_op());
-    map.insert("f64.floor", InstructionArity::unary_op());
-    map.insert("f64.trunc", InstructionArity::unary_op());
-    map.insert("f64.nearest", InstructionArity::unary_op());
-    map.insert("f64.sqrt", InstructionArity::unary_op());
-
-    // Conversion operations (unary)
-    map.insert("i32.wrap_i64", InstructionArity::unary_op());
-    map.insert("i64.extend_i32_s", InstructionArity::unary_op());
-    map.insert("i64.extend_i32_u", InstructionArity::unary_op());
-    map.insert("i32.trunc_f32_s", InstructionArity::unary_op());
-    map.insert("i32.trunc_f32_u", InstructionArity::unary_op());
-    map.insert("i32.trunc_f64_s", InstructionArity::unary_op());
-    map.insert("i32.trunc_f64_u", InstructionArity::unary_op());
-    map.insert("i64.trunc_f32_s", InstructionArity::unary_op());
-    map.insert("i64.trunc_f32_u", InstructionArity::unary_op());
-    map.insert("i64.trunc_f64_s", InstructionArity::unary_op());
-    map.insert("i64.trunc_f64_u", InstructionArity::unary_op());
-    map.insert("f32.convert_i32_s", InstructionArity::unary_op());
-    map.insert("f32.convert_i32_u", InstructionArity::unary_op());
-    map.insert("f32.convert_i64_s", InstructionArity::unary_op());
-    map.insert("f32.convert_i64_u", InstructionArity::unary_op());
-    map.insert("f32.demote_f64", InstructionArity::unary_op());
-    map.insert("f64.convert_i32_s", InstructionArity::unary_op());
-    map.insert("f64.convert_i32_u", InstructionArity::unary_op());
-    map.insert("f64.convert_i64_s", InstructionArity::unary_op());
-    map.insert("f64.convert_i64_u", InstructionArity::unary_op());
-    map.insert("f64.promote_f32", InstructionArity::unary_op());
-    map.insert("i32.reinterpret_f32", InstructionArity::unary_op());
-    map.insert("i64.reinterpret_f64", InstructionArity::unary_op());
-    map.insert("f32.reinterpret_i32", InstructionArity::unary_op());
-    map.insert("f64.reinterpret_i64", InstructionArity::unary_op());
-
-    // Memory load instructions (optional memory index, consume address)
-    map.insert("i32.load", InstructionArity::mem_load());
-    map.insert("i64.load", InstructionArity::mem_load());
-    map.insert("f32.load", InstructionArity::mem_load());
-    map.insert("f64.load", InstructionArity::mem_load());
-    map.insert("i32.load8_s", InstructionArity::mem_load());
-    map.insert("i32.load8_u", InstructionArity::mem_load());
-    map.insert("i32.load16_s", InstructionArity::mem_load());
-    map.insert("i32.load16_u", InstructionArity::mem_load());
-    map.insert("i64.load8_s", InstructionArity::mem_load());
-    map.insert("i64.load8_u", InstructionArity::mem_load());
-    map.insert("i64.load16_s", InstructionArity::mem_load());
-    map.insert("i64.load16_u", InstructionArity::mem_load());
-    map.insert("i64.load32_s", InstructionArity::mem_load());
-    map.insert("i64.load32_u", InstructionArity::mem_load());
-
-    // Memory store instructions (optional memory index, consume address and value)
-    map.insert("i32.store", InstructionArity::mem_store());
-    map.insert("i64.store", InstructionArity::mem_store());
-    map.insert("f32.store", InstructionArity::mem_store());
-    map.insert("f64.store", InstructionArity::mem_store());
-    map.insert("i32.store8", InstructionArity::mem_store());
-    map.insert("i32.store16", InstructionArity::mem_store());
-    map.insert("i64.store8", InstructionArity::mem_store());
-    map.insert("i64.store16", InstructionArity::mem_store());
-    map.insert("i64.store32", InstructionArity::mem_store());
-
-    // Memory management - support optional memory index (multi-memory proposal)
-    map.insert(
-        "memory.size",
-        InstructionArity {
-            min_params: 0,
-            max_params: 1,
-            param_description: "optional memory index",
-            operand_mode: OperandMode::Fixed(0),
-            produces: 1, // produces i32 (current size)
-        },
-    );
-    map.insert(
-        "memory.grow",
-        InstructionArity {
-            min_params: 0,
-            max_params: 1,
-            param_description: "optional memory index",
-            operand_mode: OperandMode::Fixed(1), // consumes delta
-            produces: 1,                         // produces i32 (previous size or -1)
-        },
-    );
-
-    // WasmGC Instructions
-    // Structs
-    map.insert(
-        "struct.new",
-        InstructionArity::dynamic(1, 1, "type index", 1),
-    ); // produces structref
-    map.insert(
-        "struct.new_default",
-        InstructionArity::exact(1, "type index", 0, 1), // produces structref
-    );
-    map.insert(
-        "struct.get",
-        InstructionArity::exact(2, "type and field index", 1, 1), // consumes structref, produces value
-    );
-    map.insert(
-        "struct.get_s",
-        InstructionArity::exact(2, "type and field index", 1, 1),
-    );
-    map.insert(
-        "struct.get_u",
-        InstructionArity::exact(2, "type and field index", 1, 1),
-    );
-    map.insert(
-        "struct.set",
-        InstructionArity::exact(2, "type and field index", 2, 0), // consumes structref + value, produces nothing
-    );
-
-    // Arrays
-    map.insert("array.new", InstructionArity::exact(1, "type index", 2, 1)); // value, len -> arrayref
-    map.insert(
-        "array.new_default",
-        InstructionArity::exact(1, "type index", 1, 1), // len -> arrayref
-    );
-    map.insert(
-        "array.new_fixed",
-        InstructionArity::dynamic(2, 2, "type index and length", 1), // -> arrayref
-    );
-    map.insert(
-        "array.new_data",
-        InstructionArity::exact(2, "type and data index", 2, 1), // offset, len -> arrayref
-    );
-    map.insert(
-        "array.new_elem",
-        InstructionArity::exact(2, "type and elem index", 2, 1), // offset, len -> arrayref
-    );
-    map.insert("array.get", InstructionArity::exact(1, "type index", 2, 1)); // arrayref, index -> value
-    map.insert(
-        "array.get_s",
-        InstructionArity::exact(1, "type index", 2, 1),
-    );
-    map.insert(
-        "array.get_u",
-        InstructionArity::exact(1, "type index", 2, 1),
-    );
-    map.insert("array.set", InstructionArity::exact(1, "type index", 3, 0)); // arrayref, index, value -> nothing
-    map.insert("array.len", InstructionArity::unary_op()); // arrayref -> i32
-    map.insert("array.fill", InstructionArity::exact(1, "type index", 4, 0)); // arrayref, index, value, len -> nothing
-    map.insert(
-        "array.copy",
-        InstructionArity::exact(2, "dest and src type index", 5, 0), // dest, dest_idx, src, src_idx, len -> nothing
-    );
-
-    // I31
-    map.insert("ref.i31", InstructionArity::unary_op()); // i32 -> i31ref
-    map.insert("i31.get_s", InstructionArity::unary_op()); // i31ref -> i32
-    map.insert("i31.get_u", InstructionArity::unary_op()); // i31ref -> i32
-
-    // Casts
-    map.insert("ref.test", InstructionArity::exact(1, "type index", 1, 1)); // ref -> i32
-    map.insert("ref.cast", InstructionArity::exact(1, "type index", 1, 1)); // ref -> ref
-    map.insert(
-        "ref.cast_null",
-        InstructionArity::exact(1, "type index", 1, 1),
-    ); // ref -> ref
-    map.insert(
-        "br_on_cast",
-        InstructionArity::exact(2, "label and type index", 1, 0), // ref -> (branches or continues)
-    );
-    map.insert(
-        "br_on_cast_fail",
-        InstructionArity::exact(2, "label and type index", 1, 0), // ref -> (branches or continues)
-    );
-
-    // Exceptions
-    map.insert("throw", InstructionArity::dynamic(1, 1, "tag index", 0)); // terminates
-    map.insert("throw_ref", InstructionArity::exact(0, "", 1, 0)); // exnref -> terminates (unary but not returning)
-    map.insert("rethrow", InstructionArity::exact(1, "label index", 0, 0)); // terminates
-
-    // Typed function references
-    map.insert("call_ref", InstructionArity::dynamic(1, 1, "type index", 0)); // args + funcref -> dynamic results
-    map.insert(
-        "return_call_ref",
-        InstructionArity::dynamic(1, 1, "type index", 0), // args + funcref -> terminates (tail call)
-    );
-
-    // Null-checking branches — operand count depends on branch target arity
-    // (branch args + ref to test), so use dynamic mode
-    map.insert(
-        "br_on_null",
-        InstructionArity::dynamic(1, 1, "label index", 1),
-    );
-    map.insert(
-        "br_on_non_null",
-        InstructionArity::dynamic(1, 1, "label index", 0),
-    );
-
-    // Reference equality
-    map.insert("ref.eq", InstructionArity::binary_op()); // eqref, eqref -> i32
-
-    // Reference conversions
-    map.insert("any.convert_extern", InstructionArity::unary_op()); // externref -> anyref
-    map.insert("extern.convert_any", InstructionArity::unary_op()); // anyref -> externref
-
-    // Array initialization from segments
-    map.insert(
-        "array.init_data",
-        InstructionArity::exact(2, "type and data index", 4, 0), // array, dst, src, len -> nothing
-    );
-    map.insert(
-        "array.init_elem",
-        InstructionArity::exact(2, "type and elem index", 4, 0), // array, dst, src, len -> nothing
-    );
-
-    // Bulk memory operations - support optional memory indices (multi-memory proposal)
-    map.insert(
-        "memory.copy",
-        InstructionArity {
-            min_params: 0,
-            max_params: 2,
-            param_description: "optional dest and src memory indices",
-            operand_mode: OperandMode::Fixed(3), // dest offset, src offset, len
-            produces: 0,
-        },
-    );
-    map.insert(
-        "memory.fill",
-        InstructionArity {
-            min_params: 0,
-            max_params: 1,
-            param_description: "optional memory index",
-            operand_mode: OperandMode::Fixed(3), // dest, val, len
-            produces: 0,
-        },
-    );
-    map.insert(
-        "memory.init",
-        InstructionArity {
-            min_params: 1,
-            max_params: 2,
-            param_description: "data index and optional memory index",
-            operand_mode: OperandMode::Fixed(3), // dest, offset, len
-            produces: 0,
-        },
-    );
-    map.insert("data.drop", InstructionArity::exact(1, "data index", 0, 0));
-
-    // Table operations
-    map.insert("table.get", InstructionArity::exact(1, "table index", 1, 1)); // index -> ref
-    map.insert("table.set", InstructionArity::exact(1, "table index", 2, 0)); // index, value -> nothing
-    map.insert(
-        "table.size",
-        InstructionArity::exact(1, "table index", 0, 1),
-    ); // -> i32
-    map.insert(
-        "table.grow",
-        InstructionArity::exact(1, "table index", 2, 1),
-    ); // init, delta -> i32
-    map.insert(
-        "table.fill",
-        InstructionArity::exact(1, "table index", 3, 0),
-    ); // index, value, len -> nothing
-    map.insert(
-        "table.copy",
-        InstructionArity::exact(2, "dest and src table index", 3, 0), // dest, src, len -> nothing
-    );
-    map.insert(
-        "table.init",
-        InstructionArity::exact(2, "table and elem index", 3, 0), // dest, offset, len -> nothing
-    );
-    map.insert("elem.drop", InstructionArity::exact(1, "elem index", 0, 0));
-
-    // Reference operations
-    map.insert("ref.null", InstructionArity::exact(1, "type", 0, 1)); // -> null ref
-    map.insert(
-        "ref.func",
-        InstructionArity::exact(1, "function index", 0, 1),
-    ); // -> funcref
-    map.insert("ref.is_null", InstructionArity::unary_op()); // ref -> i32
-    map.insert("ref.as_non_null", InstructionArity::unary_op()); // nullable ref -> non-null ref
-
-    // Saturating truncation operations
-    map.insert("i32.trunc_sat_f32_s", InstructionArity::unary_op());
-    map.insert("i32.trunc_sat_f32_u", InstructionArity::unary_op());
-    map.insert("i32.trunc_sat_f64_s", InstructionArity::unary_op());
-    map.insert("i32.trunc_sat_f64_u", InstructionArity::unary_op());
-    map.insert("i64.trunc_sat_f32_s", InstructionArity::unary_op());
-    map.insert("i64.trunc_sat_f32_u", InstructionArity::unary_op());
-    map.insert("i64.trunc_sat_f64_s", InstructionArity::unary_op());
-    map.insert("i64.trunc_sat_f64_u", InstructionArity::unary_op());
-
-    // Sign extension operations
-    map.insert("i32.extend8_s", InstructionArity::unary_op());
-    map.insert("i32.extend16_s", InstructionArity::unary_op());
-    map.insert("i64.extend8_s", InstructionArity::unary_op());
-    map.insert("i64.extend16_s", InstructionArity::unary_op());
-    map.insert("i64.extend32_s", InstructionArity::unary_op());
-
-    // Atomic operations
-    map.insert("atomic.fence", InstructionArity::nullary()); // no operands, no results
-
-    // Atomic loads - addr → value
-    map.insert("i32.atomic.load", InstructionArity::mem_load());
-    map.insert("i64.atomic.load", InstructionArity::mem_load());
-    map.insert("i32.atomic.load8_u", InstructionArity::mem_load());
-    map.insert("i32.atomic.load16_u", InstructionArity::mem_load());
-    map.insert("i64.atomic.load8_u", InstructionArity::mem_load());
-    map.insert("i64.atomic.load16_u", InstructionArity::mem_load());
-    map.insert("i64.atomic.load32_u", InstructionArity::mem_load());
-
-    // Atomic stores - addr + value → ∅
-    map.insert("i32.atomic.store", InstructionArity::mem_store());
-    map.insert("i64.atomic.store", InstructionArity::mem_store());
-    map.insert("i32.atomic.store8", InstructionArity::mem_store());
-    map.insert("i32.atomic.store16", InstructionArity::mem_store());
-    map.insert("i64.atomic.store8", InstructionArity::mem_store());
-    map.insert("i64.atomic.store16", InstructionArity::mem_store());
-    map.insert("i64.atomic.store32", InstructionArity::mem_store());
-
-    // Atomic RMW i32 full-width - addr + operand → old value
-    map.insert("i32.atomic.rmw.add", InstructionArity::mem_rmw());
-    map.insert("i32.atomic.rmw.sub", InstructionArity::mem_rmw());
-    map.insert("i32.atomic.rmw.and", InstructionArity::mem_rmw());
-    map.insert("i32.atomic.rmw.or", InstructionArity::mem_rmw());
-    map.insert("i32.atomic.rmw.xor", InstructionArity::mem_rmw());
-    map.insert("i32.atomic.rmw.xchg", InstructionArity::mem_rmw());
-
-    // Atomic RMW i32 narrow
-    map.insert("i32.atomic.rmw8.add_u", InstructionArity::mem_rmw());
-    map.insert("i32.atomic.rmw8.sub_u", InstructionArity::mem_rmw());
-    map.insert("i32.atomic.rmw8.and_u", InstructionArity::mem_rmw());
-    map.insert("i32.atomic.rmw8.or_u", InstructionArity::mem_rmw());
-    map.insert("i32.atomic.rmw8.xor_u", InstructionArity::mem_rmw());
-    map.insert("i32.atomic.rmw8.xchg_u", InstructionArity::mem_rmw());
-    map.insert("i32.atomic.rmw16.add_u", InstructionArity::mem_rmw());
-    map.insert("i32.atomic.rmw16.sub_u", InstructionArity::mem_rmw());
-    map.insert("i32.atomic.rmw16.and_u", InstructionArity::mem_rmw());
-    map.insert("i32.atomic.rmw16.or_u", InstructionArity::mem_rmw());
-    map.insert("i32.atomic.rmw16.xor_u", InstructionArity::mem_rmw());
-    map.insert("i32.atomic.rmw16.xchg_u", InstructionArity::mem_rmw());
-
-    // Atomic RMW i64 full-width
-    map.insert("i64.atomic.rmw.add", InstructionArity::mem_rmw());
-    map.insert("i64.atomic.rmw.sub", InstructionArity::mem_rmw());
-    map.insert("i64.atomic.rmw.and", InstructionArity::mem_rmw());
-    map.insert("i64.atomic.rmw.or", InstructionArity::mem_rmw());
-    map.insert("i64.atomic.rmw.xor", InstructionArity::mem_rmw());
-    map.insert("i64.atomic.rmw.xchg", InstructionArity::mem_rmw());
-
-    // Atomic RMW i64 narrow
-    map.insert("i64.atomic.rmw8.add_u", InstructionArity::mem_rmw());
-    map.insert("i64.atomic.rmw8.sub_u", InstructionArity::mem_rmw());
-    map.insert("i64.atomic.rmw8.and_u", InstructionArity::mem_rmw());
-    map.insert("i64.atomic.rmw8.or_u", InstructionArity::mem_rmw());
-    map.insert("i64.atomic.rmw8.xor_u", InstructionArity::mem_rmw());
-    map.insert("i64.atomic.rmw8.xchg_u", InstructionArity::mem_rmw());
-    map.insert("i64.atomic.rmw16.add_u", InstructionArity::mem_rmw());
-    map.insert("i64.atomic.rmw16.sub_u", InstructionArity::mem_rmw());
-    map.insert("i64.atomic.rmw16.and_u", InstructionArity::mem_rmw());
-    map.insert("i64.atomic.rmw16.or_u", InstructionArity::mem_rmw());
-    map.insert("i64.atomic.rmw16.xor_u", InstructionArity::mem_rmw());
-    map.insert("i64.atomic.rmw16.xchg_u", InstructionArity::mem_rmw());
-    map.insert("i64.atomic.rmw32.add_u", InstructionArity::mem_rmw());
-    map.insert("i64.atomic.rmw32.sub_u", InstructionArity::mem_rmw());
-    map.insert("i64.atomic.rmw32.and_u", InstructionArity::mem_rmw());
-    map.insert("i64.atomic.rmw32.or_u", InstructionArity::mem_rmw());
-    map.insert("i64.atomic.rmw32.xor_u", InstructionArity::mem_rmw());
-    map.insert("i64.atomic.rmw32.xchg_u", InstructionArity::mem_rmw());
-
-    // Atomic cmpxchg - addr + expected + replacement → old value
-    map.insert("i32.atomic.rmw.cmpxchg", InstructionArity::mem_cmpxchg());
-    map.insert("i64.atomic.rmw.cmpxchg", InstructionArity::mem_cmpxchg());
-    map.insert("i32.atomic.rmw8.cmpxchg_u", InstructionArity::mem_cmpxchg());
-    map.insert(
-        "i32.atomic.rmw16.cmpxchg_u",
-        InstructionArity::mem_cmpxchg(),
-    );
-    map.insert("i64.atomic.rmw8.cmpxchg_u", InstructionArity::mem_cmpxchg());
-    map.insert(
-        "i64.atomic.rmw16.cmpxchg_u",
-        InstructionArity::mem_cmpxchg(),
-    );
-    map.insert(
-        "i64.atomic.rmw32.cmpxchg_u",
-        InstructionArity::mem_cmpxchg(),
-    );
-
-    // Wait/notify
-    map.insert("memory.atomic.wait32", InstructionArity::exact(0, "", 3, 1)); // addr + expected(i32) + timeout(i64) → i32
-    map.insert("memory.atomic.wait64", InstructionArity::exact(0, "", 3, 1)); // addr + expected(i64) + timeout(i64) → i32
-    map.insert("memory.atomic.notify", InstructionArity::exact(0, "", 2, 1)); // addr + count → woken
-
-    map
+    init_arity_table().into_iter().collect()
 }
 
 /// Infer the stack arity of a SIMD instruction from its name pattern.

--- a/src/native/server.rs
+++ b/src/native/server.rs
@@ -541,22 +541,7 @@ impl LanguageServer for Backend {
             if let Some(target) =
                 references::identify_symbol_at_position(&doc, &syms, &tree, position)
             {
-                // Check if the symbol has a name - we don't support renaming unnamed symbols yet
-                let has_name = match &target {
-                    references::ReferenceTarget::Function { name, .. } => name.is_some(),
-                    references::ReferenceTarget::Global { name, .. } => name.is_some(),
-                    references::ReferenceTarget::Local { name, .. } => name.is_some(),
-                    references::ReferenceTarget::Parameter { name, .. } => name.is_some(),
-                    references::ReferenceTarget::BlockLabel { .. } => true, // Block labels are always named if identified as such
-                    references::ReferenceTarget::Table { name, .. } => name.is_some(),
-                    references::ReferenceTarget::Memory { name, .. } => name.is_some(),
-                    references::ReferenceTarget::Type { name, .. } => name.is_some(),
-                    references::ReferenceTarget::Tag { name, .. } => name.is_some(),
-                    references::ReferenceTarget::Data { name, .. } => name.is_some(),
-                    references::ReferenceTarget::Elem { name, .. } => name.is_some(),
-                };
-
-                if !has_name {
+                if !target.has_name() {
                     self.client
                         .show_message(MessageType::ERROR, "Cannot rename unnamed symbol")
                         .await;

--- a/src/wasm/api.rs
+++ b/src/wasm/api.rs
@@ -13,12 +13,13 @@ use crate::diagnostics_core::tree_walk::{walk_tree_for_diagnostics, DiagnosticCo
 use crate::folding::{provide_folding_ranges, FoldingRangeKind};
 use crate::hover::provide_hover_core;
 use crate::parser::parse_document_from_tree;
-use crate::signature::call_info::{find_function_call, find_function_call_ast, CallInfo, CallType};
+use crate::signature::call_info::{find_function_call, find_function_call_ast, CallType};
+use crate::signature::signature_core::{
+    provide_call_ref_signature_core, provide_direct_call_signature_core,
+};
 use crate::symbols::SymbolTable;
 use crate::ts_facade::{self, Language, Parser, Query, Tree};
-use crate::utils::{
-    format_function_signature, get_line_at_position, get_word_at_position, node_at_position,
-};
+use crate::utils::{get_line_at_position, get_word_at_position, node_at_position};
 
 /// The highlights.scm query for syntax highlighting
 const HIGHLIGHTS_QUERY: &str =
@@ -317,28 +318,13 @@ impl WatLSP {
         }
 
         // Use the shared core to check if this is a valid, identifiable symbol
-        use crate::features::references_core::{identify_symbol_at_position, ReferenceTarget};
+        use crate::features::references_core::identify_symbol_at_position;
         let target = match identify_symbol_at_position(&self.document, symbols, tree, position) {
             Some(t) => t,
             None => return JsValue::NULL,
         };
 
-        // Only named symbols can be renamed
-        let is_named = match &target {
-            ReferenceTarget::Function { name, .. } => name.is_some(),
-            ReferenceTarget::Global { name, .. } => name.is_some(),
-            ReferenceTarget::Local { name, .. } => name.is_some(),
-            ReferenceTarget::Parameter { name, .. } => name.is_some(),
-            ReferenceTarget::BlockLabel { .. } => true,
-            ReferenceTarget::Table { name, .. } => name.is_some(),
-            ReferenceTarget::Memory { name, .. } => name.is_some(),
-            ReferenceTarget::Type { name, .. } => name.is_some(),
-            ReferenceTarget::Tag { name, .. } => name.is_some(),
-            ReferenceTarget::Data { name, .. } => name.is_some(),
-            ReferenceTarget::Elem { name, .. } => name.is_some(),
-        };
-
-        if !is_named {
+        if !target.has_name() {
             return JsValue::NULL;
         }
 
@@ -714,182 +700,63 @@ impl WatLSP {
             None => return JsValue::NULL,
         };
 
-        match call_info.call_type {
-            CallType::Direct => provide_direct_call_signature_js(symbols, &call_info),
+        let info = match call_info.call_type {
+            CallType::Direct => provide_direct_call_signature_core(symbols, &call_info),
             CallType::CallRef | CallType::ReturnCallRef => {
-                provide_call_ref_signature_js(symbols, &call_info)
+                provide_call_ref_signature_core(symbols, &call_info)
             }
-        }
-    }
-}
-
-// ============================================================================
-// Signature Help helpers (shared call_info module provides CallType, CallInfo,
-// find_function_call_ast, find_function_call, extract_name_from_call)
-// ============================================================================
-
-/// Provide signature help for direct function calls (call $func)
-fn provide_direct_call_signature_js(symbols: &SymbolTable, call_info: &CallInfo) -> JsValue {
-    // Look up the function in the symbol table
-    let func = if call_info.name.starts_with('$') {
-        symbols.get_function_by_name(&call_info.name)
-    } else if let Ok(index) = call_info.name.parse::<usize>() {
-        symbols.get_function_by_index(index)
-    } else {
-        None
-    };
-
-    let func = match func {
-        Some(f) => f,
-        None => return JsValue::NULL,
-    };
-
-    // Build signature information
-    let label = format_function_signature(func);
-
-    let parameters = js_sys::Array::new();
-    for param in &func.parameters {
-        let param_label = if let Some(ref name) = param.name {
-            format!("({} {})", name, param.param_type)
-        } else {
-            format!("(param {})", param.param_type)
         };
 
-        let param_obj = js_sys::Object::new();
-        js_sys::Reflect::set(&param_obj, &"label".into(), &param_label.into()).ok();
-        parameters.push(&param_obj);
+        match info {
+            Some(help) => signature_help_to_js(help),
+            None => JsValue::NULL,
+        }
     }
-
-    // Determine which parameter we're currently on based on comma count
-    let active_parameter = call_info.arg_text.matches(',').count() as u32;
-    let clamped_active = active_parameter.min(func.parameters.len() as u32);
-
-    // Build signature object
-    let sig_obj = js_sys::Object::new();
-    js_sys::Reflect::set(&sig_obj, &"label".into(), &label.into()).ok();
-    js_sys::Reflect::set(&sig_obj, &"parameters".into(), &parameters).ok();
-    js_sys::Reflect::set(&sig_obj, &"activeParameter".into(), &clamped_active.into()).ok();
-
-    // Add documentation if function has doc comment
-    if let Some(ref doc) = func.doc_comment {
-        js_sys::Reflect::set(&sig_obj, &"documentation".into(), &doc.clone().into()).ok();
-    }
-
-    let signatures = js_sys::Array::new();
-    signatures.push(&sig_obj);
-
-    // Build result object
-    let result = js_sys::Object::new();
-    js_sys::Reflect::set(&result, &"signatures".into(), &signatures).ok();
-    js_sys::Reflect::set(&result, &"activeSignature".into(), &0u32.into()).ok();
-    js_sys::Reflect::set(&result, &"activeParameter".into(), &clamped_active.into()).ok();
-
-    result.into()
 }
 
-/// Provide signature help for indirect calls via typed function references (call_ref $type)
-fn provide_call_ref_signature_js(symbols: &SymbolTable, call_info: &CallInfo) -> JsValue {
-    use crate::symbols::TypeKind;
+// ============================================================================
+// Signature Help JS conversion (core logic is in signature::signature_core)
+// ============================================================================
 
-    // Look up the type in the symbol table
-    let type_def = if call_info.name.starts_with('$') {
-        symbols.get_type_by_name(&call_info.name)
-    } else if let Ok(index) = call_info.name.parse::<usize>() {
-        symbols.get_type_by_index(index)
-    } else {
-        None
-    };
+fn signature_help_to_js(info: crate::signature::signature_core::SignatureHelpInfo) -> JsValue {
+    let sig = info.signature;
 
-    let type_def = match type_def {
-        Some(t) => t,
-        None => return JsValue::NULL,
-    };
-
-    // The type must be a function type
-    let (params, results) = match &type_def.kind {
-        TypeKind::Func { params, results } => (params, results),
-        _ => return JsValue::NULL, // Not a function type
-    };
-
-    // Build signature label
-    let call_kind = match call_info.call_type {
-        CallType::CallRef => "call_ref",
-        CallType::ReturnCallRef => "return_call_ref",
-        _ => "call_ref",
-    };
-    let type_index_str = type_def.index.to_string();
-    let type_name = type_def.name.as_deref().unwrap_or(&type_index_str);
-    let params_str = params
-        .iter()
-        .map(|p| p.to_string())
-        .collect::<Vec<_>>()
-        .join(" ");
-    let results_str = results
-        .iter()
-        .map(|r| r.to_string())
-        .collect::<Vec<_>>()
-        .join(" ");
-    let label = format!(
-        "({} {}) (param {}) (result {}) + funcref",
-        call_kind,
-        type_name,
-        if params_str.is_empty() {
-            "none"
-        } else {
-            &params_str
-        },
-        if results_str.is_empty() {
-            "none"
-        } else {
-            &results_str
-        }
-    );
-
-    // Build parameter information
     let parameters = js_sys::Array::new();
-    for (i, param_type) in params.iter().enumerate() {
+    for param in &sig.parameters {
         let param_obj = js_sys::Object::new();
-        let param_label = format!("(param{} {})", i, param_type);
-        js_sys::Reflect::set(&param_obj, &"label".into(), &param_label.into()).ok();
+        js_sys::Reflect::set(&param_obj, &"label".into(), &param.label.clone().into()).ok();
+        if let Some(ref doc) = param.documentation {
+            js_sys::Reflect::set(&param_obj, &"documentation".into(), &doc.clone().into()).ok();
+        }
         parameters.push(&param_obj);
     }
 
-    // The last argument is always the funcref
-    let funcref_param = js_sys::Object::new();
-    js_sys::Reflect::set(&funcref_param, &"label".into(), &"(funcref)".into()).ok();
+    let sig_obj = js_sys::Object::new();
+    js_sys::Reflect::set(&sig_obj, &"label".into(), &sig.label.into()).ok();
+    js_sys::Reflect::set(&sig_obj, &"parameters".into(), &parameters).ok();
     js_sys::Reflect::set(
-        &funcref_param,
-        &"documentation".into(),
-        &"Function reference to call".into(),
+        &sig_obj,
+        &"activeParameter".into(),
+        &sig.active_parameter.into(),
     )
     .ok();
-    parameters.push(&funcref_param);
 
-    // Determine which parameter we're currently on
-    let active_parameter = call_info.arg_text.matches(',').count() as u32;
-    let param_count = (params.len() + 1) as u32; // +1 for funcref
-    let clamped_active = active_parameter.min(param_count);
-
-    // Build signature object
-    let sig_obj = js_sys::Object::new();
-    js_sys::Reflect::set(&sig_obj, &"label".into(), &label.into()).ok();
-    js_sys::Reflect::set(&sig_obj, &"parameters".into(), &parameters).ok();
-    js_sys::Reflect::set(&sig_obj, &"activeParameter".into(), &clamped_active.into()).ok();
-
-    let doc = format!(
-        "Indirect call via typed function reference. The last argument must be a function reference of type {}.",
-        type_name
-    );
-    js_sys::Reflect::set(&sig_obj, &"documentation".into(), &doc.into()).ok();
+    if let Some(doc) = sig.documentation {
+        js_sys::Reflect::set(&sig_obj, &"documentation".into(), &doc.into()).ok();
+    }
 
     let signatures = js_sys::Array::new();
     signatures.push(&sig_obj);
 
-    // Build result object
     let result = js_sys::Object::new();
     js_sys::Reflect::set(&result, &"signatures".into(), &signatures).ok();
     js_sys::Reflect::set(&result, &"activeSignature".into(), &0u32.into()).ok();
-    js_sys::Reflect::set(&result, &"activeParameter".into(), &clamped_active.into()).ok();
+    js_sys::Reflect::set(
+        &result,
+        &"activeParameter".into(),
+        &sig.active_parameter.into(),
+    )
+    .ok();
 
     result.into()
 }


### PR DESCRIPTION
## Summary

- Replace `HashMap` + `OnceLock` in `instruction_metadata.rs` with sorted `Vec` + binary search (consistent with docs.rs pattern)
- Create `features/signature/signature_core.rs` with protocol-independent signature help logic shared between native and WASM
- Add `ReferenceTarget::has_name()` method to eliminate duplicated 11-arm match blocks in both `wasm/api.rs` and `native/server.rs`
- Remove `arity_map` parameter from 12+ functions in `semantic.rs` and `folded_checks.rs`
- WASM binary: 768,177 → 766,431 bytes (-0.23%)