### PR TITLE
fix: br_table validation, instruction metadata fixes, duplicate local detection

### DIFF
--- a/src/diagnostics/semantic_diagnostics.rs
+++ b/src/diagnostics/semantic_diagnostics.rs
@@ -3117,4 +3117,114 @@ mod tests {
             undefined_diags
         );
     }
+
+    // ======================================================================
+    // br_table label consistency tests (#190)
+    // ======================================================================
+
+    #[test]
+    fn test_br_table_consistent_labels_ok() {
+        // Linear format: both blocks have (result i32)
+        let document = r#"(module (func (result i32)
+  block (result i32)
+    block (result i32)
+      i32.const 1
+      i32.const 0
+      br_table 0 1
+    end
+  end
+))"#;
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        let br_table_diags: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.message.contains("br_table"))
+            .collect();
+        assert!(
+            br_table_diags.is_empty(),
+            "Consistent br_table targets should not produce diagnostics, got: {:?}",
+            br_table_diags
+        );
+    }
+
+    #[test]
+    fn test_br_table_mismatched_labels() {
+        // Linear format: inner block has no result, outer block has (result i32)
+        let document = r#"(module (func
+  block (result i32)
+    block
+      i32.const 0
+      br_table 0 1
+    end
+    i32.const 42
+  end
+  drop
+))"#;
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        let br_table_diags: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.message.contains("br_table targets have inconsistent"))
+            .collect();
+        assert!(
+            !br_table_diags.is_empty(),
+            "Mismatched br_table targets should produce a diagnostic"
+        );
+    }
+
+    // ======================================================================
+    // Typed select tests (#192)
+    // ======================================================================
+
+    #[test]
+    fn test_typed_select_ok() {
+        let document = r#"(module (func (result i32)
+  (i32.const 1)
+  (i32.const 2)
+  (i32.const 0)
+  (select (result i32))
+))"#;
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        let type_diags: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.message.contains("type mismatch"))
+            .collect();
+        assert!(
+            type_diags.is_empty(),
+            "Valid typed select should not produce type mismatch, got: {:?}",
+            type_diags
+        );
+    }
+
+    #[test]
+    fn test_untyped_select_ok() {
+        let document = r#"(module (func (result i32)
+  (i32.const 1)
+  (i32.const 2)
+  (i32.const 0)
+  (select)
+))"#;
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        let stack_diags: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| {
+                d.message.contains("Stack underflow") || d.message.contains("type mismatch")
+            })
+            .collect();
+        assert!(
+            stack_diags.is_empty(),
+            "Valid untyped select should not produce diagnostics, got: {:?}",
+            stack_diags
+        );
+    }
 }

--- a/src/diagnostics_core/module_checks.rs
+++ b/src/diagnostics_core/module_checks.rs
@@ -7,6 +7,7 @@
 //! - Duplicate export names
 //! - Import ordering (imports must precede definitions)
 //! - Duplicate identifiers within the same index space
+//! - Duplicate local/parameter names within functions
 //! - Inline function type mismatches
 //! - Constant expression validation
 //! - Block label mismatches
@@ -39,6 +40,7 @@ pub fn validate_module_structure(
 
     check_memory_limits(symbols, &mut diagnostics);
     check_min_gt_max(symbols, &mut diagnostics);
+    check_duplicate_locals(symbols, &mut diagnostics);
 
     // Find the module node for AST-based checks
     if let Some(module_node) = find_module_node(root) {
@@ -991,6 +993,48 @@ fn check_label_match(
 }
 
 // ============================================================================
+// Duplicate local/parameter names within functions
+// ============================================================================
+
+fn check_duplicate_locals(symbols: &SymbolTable, diagnostics: &mut Vec<Diagnostic>) {
+    for func in &symbols.functions {
+        let mut seen: HashMap<&str, Range> = HashMap::new();
+
+        // Check parameters first
+        for param in &func.parameters {
+            if let Some(ref name) = param.name {
+                if let Some(ref range) = param.range {
+                    if let Some(_first) = seen.get(name.as_str()) {
+                        diagnostics.push(Diagnostic::error(
+                            *range,
+                            format!("duplicate local {}", name),
+                        ));
+                    } else {
+                        seen.insert(name, *range);
+                    }
+                }
+            }
+        }
+
+        // Check locals (also conflicts with params)
+        for local in &func.locals {
+            if let Some(ref name) = local.name {
+                if let Some(ref range) = local.range {
+                    if let Some(_first) = seen.get(name.as_str()) {
+                        diagnostics.push(Diagnostic::error(
+                            *range,
+                            format!("duplicate local {}", name),
+                        ));
+                    } else {
+                        seen.insert(name, *range);
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ============================================================================
 // Tests
 // ============================================================================
 
@@ -1218,6 +1262,64 @@ mod tests {
         let source = r#"(module
             (type $t (func (param i32) (result i32)))
             (func (type $t) (param i32) (result i32))
+        )"#;
+        let diags = get_diagnostics(source);
+        assert!(diags.is_empty());
+    }
+
+    // ======================================================================
+    // Duplicate local/parameter name tests
+    // ======================================================================
+
+    #[test]
+    fn test_duplicate_param_names() {
+        let source = r#"(module
+            (func $f (param $x i32) (param $x i64))
+        )"#;
+        let diags = get_diagnostics(source);
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("duplicate local $x"));
+    }
+
+    #[test]
+    fn test_duplicate_local_names() {
+        let source = r#"(module
+            (func $f
+                (local $y i32)
+                (local $y f64)
+            )
+        )"#;
+        let diags = get_diagnostics(source);
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("duplicate local $y"));
+    }
+
+    #[test]
+    fn test_local_shadows_param() {
+        let source = r#"(module
+            (func $f (param $x i32)
+                (local $x i64)
+            )
+        )"#;
+        let diags = get_diagnostics(source);
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].message.contains("duplicate local $x"));
+    }
+
+    #[test]
+    fn test_same_name_different_functions_ok() {
+        let source = r#"(module
+            (func $f (param $x i32))
+            (func $g (param $x i32))
+        )"#;
+        let diags = get_diagnostics(source);
+        assert!(diags.is_empty());
+    }
+
+    #[test]
+    fn test_unnamed_params_no_conflict() {
+        let source = r#"(module
+            (func (param i32) (param i32))
         )"#;
         let diags = get_diagnostics(source);
         assert!(diags.is_empty());

--- a/src/diagnostics_core/semantic.rs
+++ b/src/diagnostics_core/semantic.rs
@@ -473,13 +473,54 @@ fn process_instruction(
     }
 
     if instr_name == "br_table" {
-        // Pop i32 index, pop label types, mark unreachable
+        // Pop i32 index
         checker.pop_expect(&ValueType::I32, node);
-        // Use default label (last one) for type checking
-        if let Some(depth) = get_last_branch_depth(node, source, checker) {
-            if let Some(label_types) = checker.label_types(depth) {
+        let depths = get_all_branch_depths(node, source, checker);
+        if let Some(&default_depth) = depths.last() {
+            // Type-check using the default (last) label
+            if let Some(label_types) = checker.label_types(default_depth) {
                 let label_types = label_types.to_vec();
                 checker.pop_vals_for_instr(&label_types, node, instr_name);
+            }
+            // Validate all non-default labels have consistent types with default
+            if let Some(default_types) = checker.label_types(default_depth) {
+                let default_types = default_types.to_vec();
+                let default_arity = default_types.len();
+                let mut reported = false;
+                for &depth in depths.iter().take(depths.len().saturating_sub(1)) {
+                    if reported {
+                        break;
+                    }
+                    if let Some(target_types) = checker.label_types(depth) {
+                        let target_types = target_types.to_vec();
+                        if target_types.len() != default_arity {
+                            checker.diagnostics.push(
+                                Diagnostic::error(
+                                    node_to_range(node),
+                                    "type mismatch: br_table targets have inconsistent types"
+                                        .to_string(),
+                                )
+                                .with_code("type-mismatch"),
+                            );
+                            reported = true;
+                        } else {
+                            for (t, d) in target_types.iter().zip(default_types.iter()) {
+                                if !types_compatible(t, d) {
+                                    checker.diagnostics.push(
+                                        Diagnostic::error(
+                                            node_to_range(node),
+                                            "type mismatch: br_table targets have inconsistent types"
+                                                .to_string(),
+                                        )
+                                        .with_code("type-mismatch"),
+                                    );
+                                    reported = true;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
             }
         }
         checker.mark_unreachable();
@@ -653,7 +694,11 @@ fn derive_consumed_types_from_name(
         "drop" => Some(vec![ValueType::Unknown]),
 
         // Select — 2 same-type values + i32 condition
-        "select" => Some(vec![ValueType::Unknown, ValueType::Unknown, ValueType::I32]),
+        // Typed select: (select (result T)) uses declared type for operands
+        "select" => {
+            let ty = get_select_result_type(node, source).unwrap_or(ValueType::Unknown);
+            Some(vec![ty.clone(), ty, ValueType::I32])
+        }
 
         // Local/global get — consume nothing
         "local.get" | "global.get" => Some(vec![]),
@@ -907,10 +952,9 @@ fn get_branch_depth(node: &Node, source: &str, checker: &TypeChecker) -> Option<
     None
 }
 
-/// Get the last (default) branch depth from a br_table instruction
-fn get_last_branch_depth(node: &Node, source: &str, checker: &TypeChecker) -> Option<usize> {
-    // br_table has multiple indices; the last one is the default
-    let mut last_index = None;
+/// Get all branch depths from a br_table instruction (last one is the default)
+fn get_all_branch_depths(node: &Node, source: &str, checker: &TypeChecker) -> Vec<usize> {
+    let mut indices = Vec::new();
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         #[cfg(feature = "native")]
@@ -919,7 +963,7 @@ fn get_last_branch_depth(node: &Node, source: &str, checker: &TypeChecker) -> Op
         let kind = child.kind();
 
         if kind == "index" || kind == "identifier" || kind == "nat" {
-            last_index = Some(source[child.byte_range()].trim().to_string());
+            indices.push(source[child.byte_range()].trim().to_string());
         }
         if kind.starts_with("op_") {
             let mut inner_cursor = child.walk();
@@ -930,15 +974,63 @@ fn get_last_branch_depth(node: &Node, source: &str, checker: &TypeChecker) -> Op
                 let inner_kind = inner_child.kind();
 
                 if inner_kind == "index" || inner_kind == "identifier" || inner_kind == "nat" {
-                    last_index = Some(source[inner_child.byte_range()].trim().to_string());
+                    indices.push(source[inner_child.byte_range()].trim().to_string());
                 }
             }
         }
     }
-    if let Some(ref idx_str) = last_index {
-        if let Ok(depth) = idx_str.parse::<usize>() {
-            if depth < checker.ctrl_depth() {
-                return Some(depth);
+    indices
+        .iter()
+        .filter_map(|idx_str| {
+            idx_str
+                .parse::<usize>()
+                .ok()
+                .filter(|&depth| depth < checker.ctrl_depth())
+        })
+        .collect()
+}
+
+/// Check if two value types are compatible for br_table target consistency
+fn types_compatible(a: &ValueType, b: &ValueType) -> bool {
+    if *a == ValueType::Unknown || *b == ValueType::Unknown {
+        return true;
+    }
+    a == b
+}
+
+/// Get the result type from a typed select instruction: `(select (result T))`
+/// Returns None for untyped select.
+fn get_select_result_type(node: &Node, source: &str) -> Option<ValueType> {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        #[cfg(feature = "native")]
+        let kind = child.kind();
+        #[cfg(all(feature = "wasm", not(feature = "native")))]
+        let kind = child.kind();
+
+        if kind == "op_select" {
+            let mut inner_cursor = child.walk();
+            for inner_child in child.children(&mut inner_cursor) {
+                #[cfg(feature = "native")]
+                let inner_kind = inner_child.kind();
+                #[cfg(all(feature = "wasm", not(feature = "native")))]
+                let inner_kind = inner_child.kind();
+
+                if inner_kind == "func_type_results" {
+                    // Look for value_type children inside (result T)
+                    let mut vt_cursor = inner_child.walk();
+                    for vt_child in inner_child.children(&mut vt_cursor) {
+                        #[cfg(feature = "native")]
+                        let vt_kind = vt_child.kind();
+                        #[cfg(all(feature = "wasm", not(feature = "native")))]
+                        let vt_kind = vt_child.kind();
+
+                        if vt_kind == "value_type" {
+                            let text = &source[vt_child.byte_range()];
+                            return ValueType::try_parse(text.trim());
+                        }
+                    }
+                }
             }
         }
     }
@@ -1226,9 +1318,12 @@ pub fn infer_instruction_result_types(
 
         "ref.null" => vec![ValueType::Unknown],
         "ref.func" => vec![ValueType::Funcref],
+        "ref.extern" => vec![ValueType::Externref],
         "ref.is_null" => vec![ValueType::I32],
 
-        "select" => vec![ValueType::Unknown],
+        "select" => {
+            vec![get_select_result_type(node, source).unwrap_or(ValueType::Unknown)]
+        }
         "br_if" => vec![],
 
         "v128.any_true" => vec![ValueType::I32],

--- a/src/instruction_metadata.rs
+++ b/src/instruction_metadata.rs
@@ -488,11 +488,11 @@ fn init_arity_table() -> Vec<(&'static str, InstructionArity)> {
         ),
         (
             "br_on_cast",
-            InstructionArity::exact(2, "label and type index", 1, 0),
+            InstructionArity::exact(3, "label, source and target type", 1, 0),
         ),
         (
             "br_on_cast_fail",
-            InstructionArity::exact(2, "label and type index", 1, 0),
+            InstructionArity::exact(3, "label, source and target type", 1, 0),
         ),
         // Exceptions
         ("throw", InstructionArity::dynamic(1, 1, "tag index", 0)),
@@ -579,6 +579,10 @@ fn init_arity_table() -> Vec<(&'static str, InstructionArity)> {
         (
             "ref.func",
             InstructionArity::exact(1, "function index", 0, 1),
+        ),
+        (
+            "ref.extern",
+            InstructionArity::exact(1, "externref index", 0, 1),
         ),
         ("ref.is_null", InstructionArity::unary_op()),
         ("ref.as_non_null", InstructionArity::unary_op()),


### PR DESCRIPTION
## Summary

Improves diagnostic accuracy with three targeted fixes:

- **br_table label consistency** (#190): Validates all label targets have consistent arity and types, not just the default (last) label
- **Instruction metadata fixes** (#192): Corrects br_on_cast/br_on_cast_fail arity (2→3 immediates), adds missing ref.extern entry, adds typed select `(select (result T))` support
- **Duplicate local/param names** (#197): Detects duplicate parameter names, duplicate local names, and locals shadowing parameters within functions

Closes #190
Closes #192
Closes #197

## Changes

- `src/diagnostics_core/semantic.rs`: Replace `get_last_branch_depth` with `get_all_branch_depths` to check all br_table targets; add `get_select_result_type` helper for typed select; add `ref.extern` result type
- `src/instruction_metadata.rs`: Fix br_on_cast arity, add `ref.extern` entry
- `src/diagnostics_core/module_checks.rs`: Add `check_duplicate_locals` function
- `src/diagnostics/semantic_diagnostics.rs`: Add 6 new tests
