### PR TITLE
fix: restrict i8/i16 to packed storage types, add try_table stack tracking (#195, #189)

### DIFF
--- a/grammars/tree-sitter-wat/grammar.js
+++ b/grammars/tree-sitter-wat/grammar.js
@@ -977,9 +977,12 @@ module.exports = grammar({
 
     field_type: $ => seq("(", "field", optional(field("identifier", $.identifier)), repeat1($.storage_type), ")"),
 
-    // Storage type can be mutable or immutable
-    storage_type: $ => choice($.value_type, $.mut_storage_type),
-    mut_storage_type: $ => seq("(", "mut", $.value_type, ")"),
+    // Packed types (i8/i16) are only valid as storage types in struct/array fields
+    packed_type: $ => choice("i8", "i16"),
+
+    // Storage type can be mutable or immutable, and includes packed types
+    storage_type: $ => choice($.value_type, $.packed_type, $.mut_storage_type),
+    mut_storage_type: $ => seq("(", "mut", choice($.value_type, $.packed_type), ")"),
 
     // Exception handling blocks
     block_try_table: $ =>
@@ -1016,7 +1019,7 @@ module.exports = grammar({
 
     value_type: $ => choice($.value_type_num_type, $.value_type_ref_type),
 
-    value_type_num_type: $ => choice($.num_type_f32, $.num_type_f64, $.num_type_i32, $.num_type_i64, $.num_type_v128, "i8", "i16"),
+    value_type_num_type: $ => choice($.num_type_f32, $.num_type_f64, $.num_type_i32, $.num_type_i64, $.num_type_v128),
 
     value_type_ref_type: $ => $.ref_type,
   },

--- a/packages/docs/src/content/docs/control/try-table.md
+++ b/packages/docs/src/content/docs/control/try-table.md
@@ -1,0 +1,54 @@
+---
+title: try_table
+description: Exception handling with try_table, catch clauses, and tags.
+sidebar:
+  order: 8
+---
+
+`try_table` creates a block that can catch exceptions thrown during its execution. Catch clauses specify which exception tags to handle and where to branch when caught.
+
+```wat
+(module
+  (tag $e-i32 (param i32))
+
+  (func $example (result i32)
+    (block $handler (result i32)
+      (try_table (result i32) (catch $e-i32 $handler)
+        (throw $e-i32 (i32.const 42))
+        (i32.const 0)
+      )
+    )
+  )
+)
+```
+
+## Catch clause variants
+
+| Clause          | Syntax                    | Behavior                                                         |
+| --------------- | ------------------------- | ---------------------------------------------------------------- |
+| `catch`         | `(catch $tag $label)`     | Catches the tag, branches to label with the tag's payload values |
+| `catch_ref`     | `(catch_ref $tag $label)` | Like `catch`, also pushes an `exnref`                            |
+| `catch_all`     | `(catch_all $label)`      | Catches any exception, branches to label                         |
+| `catch_all_ref` | `(catch_all_ref $label)`  | Like `catch_all`, also pushes an `exnref`                        |
+
+## Tags
+
+Tags declare exception types with their payload signatures:
+
+```wat
+(tag $my-error (param i32 i32))
+```
+
+When a `catch` clause matches, the tag's parameter types are delivered to the branch target label.
+
+## Stack typing
+
+- `try_table` blocks follow the same typing rules as `block` — they declare params and results.
+- The LSP validates that the body leaves the correct result types on the stack.
+- Catch clauses are declarative (label references) and don't contain code.
+
+## Related instructions
+
+- `throw $tag` — throws an exception with the given tag
+- `throw_ref` — rethrows a caught exception reference
+- `block` / `loop` / `if` — other structured control flow

--- a/packages/docs/src/content/docs/language/packed-types.md
+++ b/packages/docs/src/content/docs/language/packed-types.md
@@ -1,0 +1,42 @@
+---
+title: Packed Types
+description: i8 and i16 storage types for struct and array fields (GC proposal).
+sidebar:
+  order: 5
+---
+
+The GC proposal introduces **packed storage types** `i8` and `i16`. These are _not_ value types — they can only appear in struct fields and array element definitions.
+
+## Valid usage
+
+Packed types are valid as storage types inside `field` and `array` definitions:
+
+```wat
+(module
+  (type $pixel (struct
+    (field $r i8)
+    (field $g i8)
+    (field $b i8)
+    (field $a i8)))
+
+  (type $buffer (array (mut i16)))
+)
+```
+
+## Invalid usage
+
+Using `i8` or `i16` as value types in parameters, results, locals, or globals is an error:
+
+```wat
+;; All of these are invalid:
+(func (param i8))        ;; error: i8 is not a value type
+(func (result i16))      ;; error: i16 is not a value type
+(local $x i8)            ;; error: i8 is not a value type
+(global $g i16 ...)      ;; error: i16 is not a value type
+```
+
+The LSP reports: _"i8 is a packed storage type and can only be used in struct/array field definitions"_.
+
+## Accessing packed fields
+
+Use `struct.get_s` / `struct.get_u` (signed/unsigned extension) to read packed fields, and `struct.set` to write them. Reading with plain `struct.get` on a packed field is invalid — you must specify the sign extension.

--- a/src/diagnostics_core/semantic.rs
+++ b/src/diagnostics_core/semantic.rs
@@ -154,6 +154,8 @@ fn process_block_node(node: &Node, source: &str, symbols: &SymbolTable, checker:
         CtrlOpcode::If
     } else if is_loop_node(node) {
         CtrlOpcode::Loop
+    } else if is_try_table_node(node) {
+        CtrlOpcode::TryTable
     } else {
         CtrlOpcode::Block
     };
@@ -163,6 +165,7 @@ fn process_block_node(node: &Node, source: &str, symbols: &SymbolTable, checker:
         let block_name = match opcode {
             CtrlOpcode::If => "if",
             CtrlOpcode::Loop => "loop",
+            CtrlOpcode::TryTable => "try_table",
             _ => "block",
         };
         checker.pop_vals_for_instr(&params, node, block_name);
@@ -259,6 +262,14 @@ fn process_block_body(node: &Node, source: &str, symbols: &SymbolTable, checker:
                 // Nested if block in linear format
                 process_block_body(&child, source, symbols, checker);
             }
+            "block_try_table" | "block_try" => {
+                // Exception handling block — recurse into its body
+                process_block_body(&child, source, symbols, checker);
+            }
+            "catch_clause" => {
+                // Catch clauses in try_table are label declarations, not code blocks.
+                // Reference checking is handled in tree_walk.rs.
+            }
             "instr_else" | "else" => {
                 // At else, we need to reset to block params for the else branch
                 // The then branch's values should match end_types, then reset
@@ -327,6 +338,25 @@ fn contains_block_if(node: &Node) -> bool {
         let kind = child.kind();
 
         if kind == "block_if" {
+            return true;
+        }
+    }
+    false
+}
+
+/// Check if a node is or contains a try_table block
+fn is_try_table_node(node: &Node) -> bool {
+    #[cfg(feature = "native")]
+    let kind = node.kind();
+    #[cfg(all(feature = "wasm", not(feature = "native")))]
+    let kind = node.kind();
+
+    if kind == "block_try_table" {
+        return true;
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "block_try_table" {
             return true;
         }
     }
@@ -1815,7 +1845,12 @@ pub fn get_block_result_types(block_node: &Node, source: &str) -> Vec<ValueType>
         if kind == "block_type" {
             return parse_result_types(&child, source);
         }
-        if kind == "block_block" || kind == "loop_block" || kind == "if_block" || kind == "block_if"
+        if kind == "block_block"
+            || kind == "loop_block"
+            || kind == "if_block"
+            || kind == "block_if"
+            || kind == "block_try_table"
+            || kind == "block_try"
         {
             let mut inner_cursor = child.walk();
             for inner_child in child.children(&mut inner_cursor) {
@@ -1842,7 +1877,12 @@ fn get_block_param_types_from_expr(expr: &Node, source: &str) -> Vec<ValueType> 
         #[cfg(all(feature = "wasm", not(feature = "native")))]
         let kind = child.kind();
 
-        if kind == "expr1_block" || kind == "expr1_loop" || kind == "expr1_if" {
+        if kind == "expr1_block"
+            || kind == "expr1_loop"
+            || kind == "expr1_if"
+            || kind == "expr1_try_table"
+            || kind == "expr1_try"
+        {
             return get_block_param_types(&child, source);
         }
         if kind == "expr1" {
@@ -1856,6 +1896,8 @@ fn get_block_param_types_from_expr(expr: &Node, source: &str) -> Vec<ValueType> 
                 if inner_kind == "expr1_block"
                     || inner_kind == "expr1_loop"
                     || inner_kind == "expr1_if"
+                    || inner_kind == "expr1_try_table"
+                    || inner_kind == "expr1_try"
                 {
                     return get_block_param_types(&inner_child, source);
                 }
@@ -1878,7 +1920,12 @@ pub fn get_block_param_types(block_node: &Node, source: &str) -> Vec<ValueType> 
         if kind == "func_type_params_many" {
             types.extend(parse_func_type_results(&child, source));
         }
-        if kind == "block_block" || kind == "loop_block" || kind == "if_block" || kind == "block_if"
+        if kind == "block_block"
+            || kind == "loop_block"
+            || kind == "if_block"
+            || kind == "block_if"
+            || kind == "block_try_table"
+            || kind == "block_try"
         {
             let mut inner_cursor = child.walk();
             for inner_child in child.children(&mut inner_cursor) {

--- a/src/diagnostics_core/tree_walk.rs
+++ b/src/diagnostics_core/tree_walk.rs
@@ -53,6 +53,21 @@ pub fn walk_tree_for_diagnostics(
     #[cfg(all(feature = "wasm", not(feature = "native")))]
     let kind_str = &*kind;
 
+    // Check for packed types (i8/i16) used in value type positions (params, results, locals, globals)
+    if kind_str == "ERROR" {
+        let text = &source[node.byte_range()];
+        let trimmed = text.trim();
+        if (trimmed == "i8" || trimmed == "i16") && is_value_type_context(&node) {
+            diagnostics.push(Diagnostic::error(
+                node_to_range(&node),
+                format!(
+                    "{} is a packed storage type and can only be used in struct/array field definitions",
+                    trimmed
+                ),
+            ));
+        }
+    }
+
     // Check block label mismatches
     if matches!(kind_str, "block_block" | "block_loop" | "block_if") {
         diagnostics.extend(
@@ -260,6 +275,27 @@ pub fn walk_tree_for_diagnostics(
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         walk_tree_for_diagnostics(child, source, symbols, config, diagnostics);
+    }
+}
+
+/// Check if an ERROR node is in a value type context (params, results, locals, globals)
+fn is_value_type_context(node: &Node) -> bool {
+    if let Some(parent) = node.parent() {
+        let pk = parent.kind();
+        #[cfg(all(feature = "wasm", not(feature = "native")))]
+        let pk = &*pk;
+        matches!(
+            pk,
+            "func_type_params_many"
+                | "func_type_params_one"
+                | "func_type_results"
+                | "func_locals_many"
+                | "func_locals_one"
+                | "global_type_imm"
+                | "global_type_mut"
+        )
+    } else {
+        false
     }
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1320,10 +1320,28 @@ fn extract_field_type(field_node: &Node, source: &str) -> (Option<String>, Value
 
     let mut cursor = field_node.walk();
     for child in field_node.children(&mut cursor) {
-        if child.kind() == "identifier" {
-            field_name = Some(node_text(&child, source));
-        } else if child.kind() == "value_type" {
-            field_type = extract_value_type(&child, source);
+        let ck = child.kind();
+        #[cfg(all(feature = "wasm", not(feature = "native")))]
+        let ck = ck.as_str();
+        match ck {
+            "identifier" => {
+                field_name = Some(node_text(&child, source));
+            }
+            "value_type" => {
+                field_type = extract_value_type(&child, source);
+            }
+            "storage_type" => {
+                field_type = extract_storage_type(&child, source);
+            }
+            "packed_type" => {
+                let text = node_text(&child, source);
+                field_type = match text.as_str() {
+                    "i8" => ValueType::I8,
+                    "i16" => ValueType::I16,
+                    _ => ValueType::Unknown,
+                };
+            }
+            _ => {}
         }
     }
 
@@ -1410,24 +1428,8 @@ fn extract_type(type_node: &Node, source: &str, index: usize) -> Option<TypeDef>
 
             for struct_child in child.children(&mut struct_cursor) {
                 if struct_child.kind() == "field_type" {
-                    let mut field_name = None;
-                    let mut field_type = ValueType::Unknown;
-                    let mut mutable = false;
-
-                    let mut fc = struct_child.walk();
-                    for c in struct_child.children(&mut fc) {
-                        if c.kind() == "identifier" {
-                            field_name = Some(node_text(&c, source));
-                        } else if c.kind() == "value_type" {
-                            field_type = extract_value_type(&c, source);
-                        }
-                    }
-
-                    let text = node_text(&struct_child, source);
-                    if text.contains("(mut") || text.contains(" mut ") {
-                        mutable = true;
-                    }
-
+                    let (field_name, field_type, mutable) =
+                        extract_field_type(&struct_child, source);
                     fields.push((field_name, field_type, mutable));
                 }
             }
@@ -1440,16 +1442,9 @@ fn extract_type(type_node: &Node, source: &str, index: usize) -> Option<TypeDef>
             let mut array_cursor = child.walk();
             for array_child in child.children(&mut array_cursor) {
                 if array_child.kind() == "field_type" {
-                    let mut fc = array_child.walk();
-                    for c in array_child.children(&mut fc) {
-                        if c.kind() == "value_type" {
-                            element_type = extract_value_type(&c, source);
-                        }
-                    }
-                    let text = node_text(&array_child, source);
-                    if text.contains("(mut") || text.contains(" mut ") {
-                        mutable = true;
-                    }
+                    let (_, ft, m) = extract_field_type(&array_child, source);
+                    element_type = ft;
+                    mutable = m;
                 }
             }
             kind = TypeKind::Array {
@@ -1474,31 +1469,8 @@ fn extract_type(type_node: &Node, source: &str, index: usize) -> Option<TypeDef>
 
                     for struct_child in field_child.children(&mut struct_cursor) {
                         if struct_child.kind() == "field_type" {
-                            // field_type: (field $id? type ...)
-                            let mut field_name = None;
-                            let mut field_type = ValueType::Unknown;
-                            let mut mutable = false;
-
-                            let mut fc = struct_child.walk();
-                            for c in struct_child.children(&mut fc) {
-                                if c.kind() == "identifier" {
-                                    field_name = Some(node_text(&c, source));
-                                } else if c.kind() == "value_type" {
-                                    field_type = extract_value_type(&c, source);
-                                } else if c.kind() == "mut" {
-                                    // If we see 'mut' directly (depends on grammar)
-                                    mutable = true;
-                                }
-                                // Check for (mut type) pattern if it exists as a node
-                                // Current grammar is tricky, doing best effort
-                            }
-
-                            // Check source text for "mut" if structure is unclear
-                            let text = node_text(&struct_child, source);
-                            if text.contains("(mut") || text.contains(" mut ") {
-                                mutable = true;
-                            }
-
+                            let (field_name, field_type, mutable) =
+                                extract_field_type(&struct_child, source);
                             fields.push((field_name, field_type, mutable));
                         }
                     }
@@ -1512,17 +1484,9 @@ fn extract_type(type_node: &Node, source: &str, index: usize) -> Option<TypeDef>
                     let mut array_cursor = field_child.walk();
                     for array_child in field_child.children(&mut array_cursor) {
                         if array_child.kind() == "field_type" {
-                            // Extract type from field_type
-                            let mut fc = array_child.walk();
-                            for c in array_child.children(&mut fc) {
-                                if c.kind() == "value_type" {
-                                    element_type = extract_value_type(&c, source);
-                                }
-                            }
-                            let text = node_text(&array_child, source);
-                            if text.contains("(mut") || text.contains(" mut ") {
-                                mutable = true;
-                            }
+                            let (_, ft, m) = extract_field_type(&array_child, source);
+                            element_type = ft;
+                            mutable = m;
                         }
                     }
                     kind = TypeKind::Array {
@@ -1615,16 +1579,9 @@ fn extract_array_kind(array_node: &Node, source: &str) -> TypeKind {
     let mut array_cursor = array_node.walk();
     for array_child in array_node.children(&mut array_cursor) {
         if array_child.kind() == "field_type" {
-            let mut fc = array_child.walk();
-            for c in array_child.children(&mut fc) {
-                if c.kind() == "value_type" {
-                    element_type = extract_value_type(&c, source);
-                }
-            }
-            let text = node_text(&array_child, source);
-            if text.contains("(mut") || text.contains(" mut ") {
-                mutable = true;
-            }
+            let (_, ft, m) = extract_field_type(&array_child, source);
+            element_type = ft;
+            mutable = m;
         }
     }
     TypeKind::Array {
@@ -2045,6 +2002,52 @@ fn extract_value_type(value_type_node: &Node, source: &str) -> ValueType {
         }
     }
     ValueType::Unknown
+}
+
+/// Extract value type from a storage_type node (handles packed types and value types)
+fn extract_storage_type(storage_node: &Node, source: &str) -> ValueType {
+    let mut cursor = storage_node.walk();
+    for child in storage_node.children(&mut cursor) {
+        let ck = child.kind();
+        #[cfg(all(feature = "wasm", not(feature = "native")))]
+        let ck = ck.as_str();
+        match ck {
+            "value_type" => return extract_value_type(&child, source),
+            "packed_type" => {
+                let text = node_text(&child, source);
+                return match text.as_str() {
+                    "i8" => ValueType::I8,
+                    "i16" => ValueType::I16,
+                    _ => ValueType::Unknown,
+                };
+            }
+            "mut_storage_type" => {
+                // Recurse into the mutable wrapper
+                let mut inner_cursor = child.walk();
+                for inner_child in child.children(&mut inner_cursor) {
+                    let ik = inner_child.kind();
+                    #[cfg(all(feature = "wasm", not(feature = "native")))]
+                    let ik = ik.as_str();
+                    match ik {
+                        "value_type" => return extract_value_type(&inner_child, source),
+                        "packed_type" => {
+                            let text = node_text(&inner_child, source);
+                            return match text.as_str() {
+                                "i8" => ValueType::I8,
+                                "i16" => ValueType::I16,
+                                _ => ValueType::Unknown,
+                            };
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    // Fallback: try text
+    let text = node_text(storage_node, source);
+    ValueType::try_parse(&text).unwrap_or(ValueType::Unknown)
 }
 
 /// Alias for ValueType::try_parse for convenience in tree traversal code.


### PR DESCRIPTION
## Summary

- closes #195 (i8/i16 restriction)
  - Removed i8/i16 from `value_type_num_type` grammar rule so they only appear in struct/array field definitions via the new `packed_type` rule. Added a clear diagnostic for i8/i16 used in params/results/locals/globals. Updated parser to handle `storage_type`/`packed_type` nodes and consolidated inline field-type extraction to use `extract_field_type()`.
- closes #189 (try_table stack tracking)
  - Added `CtrlOpcode::TryTable` detection in `process_block_node`, recurse into `block_try_table`/`block_try` in `process_block_body`, and extended block type resolution functions to handle try_table/try nodes (both linear and folded forms).
- Added docs for `try_table` exception handling and packed storage types.

Zero regressions on spec test suite (992/1038 valid modules, 641/658 assert_malformed, 465/1299 assert_invalid).