### PR TITLE
feat: add GC struct field validation and concrete ref subtyping

### DIFF
--- a/packages/playground/examples/gc_advanced.wat
+++ b/packages/playground/examples/gc_advanced.wat
@@ -26,26 +26,26 @@
 
   ;; Base shape type
   (type $shape (sub (struct
-    (field $x f64)
-    (field $y f64))))
+    (field $x (mut f64))
+    (field $y (mut f64)))))
 
   ;; Circle extends shape
   (type $circle (sub $shape (struct
-    (field $x f64)
-    (field $y f64)
+    (field $x (mut f64))
+    (field $y (mut f64))
     (field $radius f64))))
 
   ;; Rectangle extends shape
   (type $rectangle (sub $shape (struct
-    (field $x f64)
-    (field $y f64)
+    (field $x (mut f64))
+    (field $y (mut f64))
     (field $width f64)
     (field $height f64))))
 
   ;; Final square type (cannot be extended)
   (type $square (sub final $rectangle (struct
-    (field $x f64)
-    (field $y f64)
+    (field $x (mut f64))
+    (field $y (mut f64))
     (field $width f64)
     (field $height f64))))
 

--- a/src/diagnostics_core/gc_checks.rs
+++ b/src/diagnostics_core/gc_checks.rs
@@ -1,0 +1,414 @@
+//! GC type validation checks for struct field access instructions.
+//!
+//! Validates `struct.get`, `struct.get_s`, `struct.get_u`, and `struct.set`
+//! instructions have valid field indices and appropriate packed type usage.
+
+use crate::core::types::Diagnostic;
+use crate::symbols::{SymbolTable, TypeKind, ValueType};
+use crate::utils::node_to_range;
+
+#[cfg(feature = "native")]
+use tree_sitter::Node;
+
+#[cfg(all(feature = "wasm", not(feature = "native")))]
+use crate::ts_facade::Node;
+
+// TODO: ref.cast/ref.test/br_on_cast heap type compatibility checks are deferred.
+// The type checker currently uses `Unknown` for all GC stack values, so we cannot
+// validate that cast source/target are in the same hierarchy at the stack level.
+// The concrete ref subtyping in type_check.rs prepares the infrastructure for when
+// typed GC refs flow through the stack.
+
+/// Check struct field access instructions for valid field indices and packed type usage.
+///
+/// Runs on `instr_plain` nodes containing `struct.get/get_s/get_u/set`.
+/// Returns diagnostics for:
+/// - Field index out of bounds
+/// - Named field not found in struct
+/// - `struct.get_s`/`struct.get_u` on non-packed field type
+/// - Type is not a struct (e.g., array used with struct.get)
+pub fn check_struct_field_access(
+    node: &Node,
+    source: &str,
+    symbols: &SymbolTable,
+) -> Vec<Diagnostic> {
+    let text = &source[node.byte_range()];
+    let first_token = text.split_whitespace().next().unwrap_or("");
+
+    if !matches!(
+        first_token,
+        "struct.get" | "struct.get_s" | "struct.get_u" | "struct.set"
+    ) {
+        return Vec::new();
+    }
+
+    let (type_ref, field_ref) = match extract_two_indices(node, source) {
+        Some(pair) => pair,
+        None => return Vec::new(),
+    };
+
+    // Resolve type
+    let type_def = match resolve_type_def(&type_ref, symbols) {
+        Some(td) => td,
+        None => return Vec::new(), // Undefined type caught by reference checker
+    };
+
+    let fields = match &type_def.kind {
+        TypeKind::Struct { fields } => fields,
+        _ => {
+            return vec![Diagnostic::error(
+                node_to_range(node),
+                format!(
+                    "struct.get/set used on non-struct type {}",
+                    type_ref_display(&type_ref, type_def.index)
+                ),
+            )];
+        }
+    };
+
+    let mut diagnostics = Vec::new();
+
+    // Resolve field index
+    let field_idx = match resolve_field_index(&field_ref, fields) {
+        Some(idx) => idx,
+        None => {
+            if field_ref.starts_with('$') {
+                diagnostics.push(Diagnostic::error(
+                    node_to_range(node),
+                    format!("unknown field {}", field_ref),
+                ));
+            } else if let Ok(idx) = field_ref.parse::<usize>() {
+                diagnostics.push(Diagnostic::error(
+                    node_to_range(node),
+                    format!("unknown field {}", idx),
+                ));
+            }
+            return diagnostics;
+        }
+    };
+
+    // Check packed type for struct.get_s / struct.get_u
+    if first_token == "struct.get_s" || first_token == "struct.get_u" {
+        let (_, field_type, _) = &fields[field_idx];
+        if !is_packed_type(field_type) {
+            diagnostics.push(Diagnostic::error(
+                node_to_range(node),
+                format!(
+                    "{} requires a packed storage type (i8 or i16), but field {} has type {}",
+                    first_token, field_idx, field_type
+                ),
+            ));
+        }
+    }
+
+    // Check mutability for struct.set
+    if first_token == "struct.set" {
+        let (_, _, mutable) = &fields[field_idx];
+        if !mutable {
+            diagnostics.push(Diagnostic::error(
+                node_to_range(node),
+                "immutable field".to_string(),
+            ));
+        }
+    }
+
+    diagnostics
+}
+
+/// Extract two index children from a struct instruction node.
+///
+/// struct.get/set instructions have the form: `struct.get $type $field`
+/// where both are `index` nodes in the grammar.
+fn extract_two_indices(node: &Node, source: &str) -> Option<(String, String)> {
+    let mut indices = Vec::new();
+    let mut cursor = node.walk();
+
+    for child in node.children(&mut cursor) {
+        let kind = child.kind();
+        #[cfg(feature = "native")]
+        let kind_ref = kind;
+        #[cfg(all(feature = "wasm", not(feature = "native")))]
+        let kind_ref = &*kind;
+
+        if kind_ref == "index" {
+            // Index node may contain identifier or nat child
+            let index_text = extract_index_value(&child, source);
+            indices.push(index_text);
+            if indices.len() == 2 {
+                break;
+            }
+        }
+    }
+
+    if indices.len() == 2 {
+        Some((indices.remove(0), indices.remove(0)))
+    } else {
+        None
+    }
+}
+
+/// Extract the value from an index node — either a `$name` identifier or numeric `nat`.
+fn extract_index_value(node: &Node, source: &str) -> String {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        let kind = child.kind();
+        #[cfg(feature = "native")]
+        let kind_ref = kind;
+        #[cfg(all(feature = "wasm", not(feature = "native")))]
+        let kind_ref = &*kind;
+
+        if kind_ref == "identifier" || kind_ref == "nat" {
+            return source[child.byte_range()].trim().to_string();
+        }
+    }
+    // Fallback: use the node text directly
+    source[node.byte_range()].trim().to_string()
+}
+
+/// Resolve a type reference (either `$name` or numeric index) to a TypeDef.
+fn resolve_type_def<'a>(
+    type_ref: &str,
+    symbols: &'a SymbolTable,
+) -> Option<&'a crate::symbols::TypeDef> {
+    if type_ref.starts_with('$') {
+        symbols.get_type_by_name(type_ref)
+    } else {
+        type_ref
+            .parse::<usize>()
+            .ok()
+            .and_then(|idx| symbols.get_type_by_index(idx))
+    }
+}
+
+/// Resolve a field reference to an index within the struct fields.
+///
+/// Handles both named (`$name`) and numeric references.
+fn resolve_field_index(
+    field_ref: &str,
+    fields: &[(Option<String>, ValueType, bool)],
+) -> Option<usize> {
+    if field_ref.starts_with('$') {
+        // Named field lookup
+        fields
+            .iter()
+            .position(|(name, _, _)| name.as_deref() == Some(field_ref))
+    } else {
+        // Numeric index
+        let idx = field_ref.parse::<usize>().ok()?;
+        if idx < fields.len() {
+            Some(idx)
+        } else {
+            None
+        }
+    }
+}
+
+/// Check if a ValueType is a packed storage type (i8 or i16).
+fn is_packed_type(ty: &ValueType) -> bool {
+    matches!(ty, ValueType::I8 | ValueType::I16)
+}
+
+/// Display helper for type references.
+fn type_ref_display(type_ref: &str, index: usize) -> String {
+    if type_ref.starts_with('$') {
+        type_ref.to_string()
+    } else {
+        index.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::symbols::ValueType;
+
+    #[test]
+    fn test_resolve_field_index_numeric() {
+        let fields = vec![
+            (Some("$x".to_string()), ValueType::I32, false),
+            (Some("$y".to_string()), ValueType::I64, true),
+        ];
+        assert_eq!(resolve_field_index("0", &fields), Some(0));
+        assert_eq!(resolve_field_index("1", &fields), Some(1));
+        assert_eq!(resolve_field_index("2", &fields), None);
+    }
+
+    #[test]
+    fn test_resolve_field_index_named() {
+        let fields = vec![
+            (Some("$x".to_string()), ValueType::I32, false),
+            (Some("$y".to_string()), ValueType::I64, true),
+        ];
+        assert_eq!(resolve_field_index("$x", &fields), Some(0));
+        assert_eq!(resolve_field_index("$y", &fields), Some(1));
+        assert_eq!(resolve_field_index("$z", &fields), None);
+    }
+
+    #[test]
+    fn test_resolve_field_index_unnamed() {
+        let fields = vec![(None, ValueType::I32, false), (None, ValueType::F64, true)];
+        assert_eq!(resolve_field_index("0", &fields), Some(0));
+        assert_eq!(resolve_field_index("$x", &fields), None);
+    }
+
+    #[test]
+    fn test_is_packed_type() {
+        assert!(is_packed_type(&ValueType::I8));
+        assert!(is_packed_type(&ValueType::I16));
+        assert!(!is_packed_type(&ValueType::I32));
+        assert!(!is_packed_type(&ValueType::I64));
+        assert!(!is_packed_type(&ValueType::F32));
+        assert!(!is_packed_type(&ValueType::Funcref));
+    }
+
+    #[cfg(feature = "native")]
+    mod integration {
+        use crate::parser::parse_document;
+        use crate::tree_sitter_bindings::create_parser;
+
+        fn get_diagnostics(source: &str) -> Vec<String> {
+            let mut parser = create_parser();
+            let tree = parser.parse(source, None).unwrap();
+            let symbols = parse_document(source).expect("Failed to extract symbols");
+            let diags = crate::diagnostics::provide_semantic_diagnostics(&tree, source, &symbols);
+            diags.iter().map(|d| d.message.clone()).collect()
+        }
+
+        #[test]
+        fn test_struct_field_out_of_bounds() {
+            let source = r#"(module
+                (type $point (struct (field $x i32) (field $y i32)))
+                (func (param (ref $point))
+                    local.get 0
+                    struct.get $point 5
+                )
+            )"#;
+            let diags = get_diagnostics(source);
+            assert!(
+                diags.iter().any(|d| d.contains("unknown field")),
+                "Expected 'unknown field' diagnostic, got: {:?}",
+                diags
+            );
+        }
+
+        #[test]
+        fn test_struct_get_s_non_packed() {
+            let source = r#"(module
+                (type $s (struct (field $f i32)))
+                (func (param (ref $s))
+                    local.get 0
+                    struct.get_s $s 0
+                )
+            )"#;
+            let diags = get_diagnostics(source);
+            assert!(
+                diags.iter().any(|d| d.contains("packed storage type")),
+                "Expected 'packed storage type' diagnostic, got: {:?}",
+                diags
+            );
+        }
+
+        #[test]
+        fn test_struct_get_s_packed_valid() {
+            let source = r#"(module
+                (type $s (struct (field $f i8)))
+                (func (param (ref $s)) (result i32)
+                    local.get 0
+                    struct.get_s $s 0
+                )
+            )"#;
+            let diags = get_diagnostics(source);
+            assert!(
+                !diags.iter().any(|d| d.contains("packed storage type")),
+                "Expected no 'packed storage type' diagnostic, got: {:?}",
+                diags
+            );
+        }
+
+        #[test]
+        fn test_struct_get_u_non_packed() {
+            let source = r#"(module
+                (type $s (struct (field $f f64)))
+                (func (param (ref $s))
+                    local.get 0
+                    struct.get_u $s 0
+                )
+            )"#;
+            let diags = get_diagnostics(source);
+            assert!(
+                diags.iter().any(|d| d.contains("packed storage type")),
+                "Expected 'packed storage type' diagnostic, got: {:?}",
+                diags
+            );
+        }
+
+        #[test]
+        fn test_valid_struct_field_access() {
+            let source = r#"(module
+                (type $point (struct (field $x i32) (field $y i32)))
+                (func (param (ref $point)) (result i32)
+                    local.get 0
+                    struct.get $point 0
+                )
+            )"#;
+            let diags = get_diagnostics(source);
+            assert!(
+                !diags.iter().any(|d| d.contains("unknown field")),
+                "Expected no 'unknown field' diagnostic, got: {:?}",
+                diags
+            );
+        }
+
+        #[test]
+        fn test_struct_get_on_array_type() {
+            let source = r#"(module
+                (type $arr (array i32))
+                (func (param (ref $arr))
+                    local.get 0
+                    struct.get $arr 0
+                )
+            )"#;
+            let diags = get_diagnostics(source);
+            assert!(
+                diags.iter().any(|d| d.contains("non-struct type")),
+                "Expected 'non-struct type' diagnostic, got: {:?}",
+                diags
+            );
+        }
+
+        #[test]
+        fn test_struct_field_named_not_found() {
+            let source = r#"(module
+                (type $point (struct (field $x i32) (field $y i32)))
+                (func (param (ref $point))
+                    local.get 0
+                    struct.get $point $z
+                )
+            )"#;
+            let diags = get_diagnostics(source);
+            assert!(
+                diags.iter().any(|d| d.contains("unknown field")),
+                "Expected 'unknown field' diagnostic, got: {:?}",
+                diags
+            );
+        }
+
+        #[test]
+        fn test_struct_set_field_out_of_bounds() {
+            let source = r#"(module
+                (type $s (struct (field $x (mut i32))))
+                (func (param (ref $s))
+                    local.get 0
+                    i32.const 42
+                    struct.set $s 5
+                )
+            )"#;
+            let diags = get_diagnostics(source);
+            assert!(
+                diags.iter().any(|d| d.contains("unknown field")),
+                "Expected 'unknown field' diagnostic, got: {:?}",
+                diags
+            );
+        }
+    }
+}

--- a/src/diagnostics_core/mod.rs
+++ b/src/diagnostics_core/mod.rs
@@ -6,6 +6,7 @@
 pub mod alignment_checks;
 pub mod arity;
 pub mod folded_checks;
+pub mod gc_checks;
 pub mod memory_checks;
 pub mod module_checks;
 pub mod references;

--- a/src/diagnostics_core/tree_walk.rs
+++ b/src/diagnostics_core/tree_walk.rs
@@ -193,7 +193,7 @@ pub fn walk_tree_for_diagnostics(
         }
     }
 
-    // Check SIMD lane indices and alignment constraints
+    // Check SIMD lane indices, alignment constraints, and GC struct field access
     if kind_str == "instr_plain" {
         diagnostics.extend(crate::diagnostics_core::simd_checks::check_simd_lane_index(
             &node, source,
@@ -201,6 +201,9 @@ pub fn walk_tree_for_diagnostics(
         diagnostics.extend(crate::diagnostics_core::alignment_checks::check_alignment(
             &node, source,
         ));
+        diagnostics.extend(
+            crate::diagnostics_core::gc_checks::check_struct_field_access(&node, source, symbols),
+        );
     } else if kind_str == "expr1_plain" {
         // In folded form, instr_plain is a child that won't be visited separately
         let mut cursor = node.walk();
@@ -212,6 +215,11 @@ pub fn walk_tree_for_diagnostics(
                 diagnostics.extend(crate::diagnostics_core::alignment_checks::check_alignment(
                     &child, source,
                 ));
+                diagnostics.extend(
+                    crate::diagnostics_core::gc_checks::check_struct_field_access(
+                        &child, source, symbols,
+                    ),
+                );
                 break;
             }
         }

--- a/src/diagnostics_core/type_check.rs
+++ b/src/diagnostics_core/type_check.rs
@@ -5,7 +5,7 @@
 //! detect both stack underflow AND type mismatches.
 
 use crate::core::types::Diagnostic;
-use crate::symbols::ValueType;
+use crate::symbols::{SymbolTable, TypeKind, ValueType};
 use crate::utils::node_to_range;
 
 // Use the appropriate tree-sitter types based on feature
@@ -77,12 +77,124 @@ fn is_ref_subtype(sub: &ValueType, sup: &ValueType) -> bool {
         // i31ref, structref, arrayref <: eqref <: anyref
         (I31ref | Structref | Arrayref | Eqref, Anyref) => true,
         (I31ref | Structref | Arrayref, Eqref) => true,
-        // Ref(n) <: funcref (non-null func ref)
+        // Ref(n) / RefNull(n) — without symbol table, assume func hierarchy only
         (Ref(_), Funcref) => true,
-        // RefNull(n) <: funcref (nullable func ref)
         (RefNull(_), Funcref) => true,
+        // Non-null <: nullable for same index
+        (Ref(a), RefNull(b)) if a == b => true,
         _ => false,
     }
+}
+
+/// Check type compatibility with access to the symbol table for concrete GC type resolution.
+///
+/// This extends `types_compatible()` with knowledge of concrete type definitions,
+/// enabling validation of `Ref(n)` / `RefNull(n)` against abstract supertypes
+/// (structref, arrayref, eqref, anyref) and concrete parent chains.
+pub fn types_compatible_with_symbols(
+    actual: &ValueType,
+    expected: &ValueType,
+    symbols: &SymbolTable,
+) -> bool {
+    // Fast path: check without symbols first
+    if types_compatible(actual, expected) {
+        return true;
+    }
+    // Concrete ref subtyping requires symbols
+    is_concrete_ref_subtype(actual, expected, symbols)
+}
+
+/// Check concrete reference subtyping using the symbol table.
+///
+/// Handles:
+/// - `Ref(n)` where n is struct → subtype of Structref, Eqref, Anyref
+/// - `Ref(n)` where n is array → subtype of Arrayref, Eqref, Anyref
+/// - `Ref(n)` where n is func → subtype of Funcref
+/// - `Ref(child)` → subtype of `Ref(parent)` via declared parent chain
+/// - `Ref(n)` → subtype of `RefNull(n)` (non-null <: nullable)
+/// - `RefNull(n)` carries same hierarchy but includes null
+fn is_concrete_ref_subtype(sub: &ValueType, sup: &ValueType, symbols: &SymbolTable) -> bool {
+    use ValueType::*;
+
+    let (sub_idx, sub_nullable) = match sub {
+        Ref(n) => (*n, false),
+        RefNull(n) => (*n, true),
+        _ => return false,
+    };
+
+    // Concrete ref vs concrete ref subtyping via parent chain
+    match sup {
+        RefNull(sup_n) => {
+            // Ref(n) <: RefNull(n) and RefNull(n) <: RefNull(n) via parent chain
+            return is_type_subtype(sub_idx as usize, *sup_n as usize, symbols);
+        }
+        Ref(sup_n) => {
+            if sub_nullable {
+                // RefNull(n) is NOT a subtype of Ref(m) — nullable cannot satisfy non-null
+                return false;
+            }
+            return is_type_subtype(sub_idx as usize, *sup_n as usize, symbols);
+        }
+        _ => {}
+    }
+
+    // Check concrete type against abstract supertypes
+    // In the Wasm spec, abstract types like structref/arrayref/funcref are nullable,
+    // so both Ref(n) and RefNull(n) are subtypes.
+    let type_def = match symbols.get_type_by_index(sub_idx as usize) {
+        Some(td) => td,
+        None => return false,
+    };
+
+    matches!(
+        (&type_def.kind, sup),
+        (TypeKind::Struct { .. }, Structref | Eqref | Anyref)
+            | (TypeKind::Array { .. }, Arrayref | Eqref | Anyref)
+            | (TypeKind::Func { .. }, Funcref)
+    )
+}
+
+/// Check if `child_idx` is a declared subtype of `parent_idx` via the parent chain.
+///
+/// Walks up the `TypeDef.parent` chain from child, checking if parent_idx is encountered.
+/// Max depth of 64 prevents infinite loops from cyclic declarations.
+fn is_type_subtype(child_idx: usize, parent_idx: usize, symbols: &SymbolTable) -> bool {
+    if child_idx == parent_idx {
+        return true;
+    }
+
+    let mut current_idx = child_idx;
+    for _ in 0..64 {
+        let type_def = match symbols.get_type_by_index(current_idx) {
+            Some(td) => td,
+            None => return false,
+        };
+
+        let parent_ref = match &type_def.parent {
+            Some(p) => p.clone(),
+            None => return false,
+        };
+
+        // Resolve parent reference to index
+        let resolved_idx = if parent_ref.starts_with('$') {
+            match symbols.get_type_by_name(&parent_ref) {
+                Some(td) => td.index,
+                None => return false,
+            }
+        } else {
+            match parent_ref.parse::<usize>() {
+                Ok(idx) => idx,
+                Err(_) => return false,
+            }
+        };
+
+        if resolved_idx == parent_idx {
+            return true;
+        }
+        current_idx = resolved_idx;
+    }
+
+    false
 }
 
 impl TypeChecker {
@@ -391,5 +503,189 @@ impl TypeChecker {
     /// Take all collected diagnostics out of the checker.
     pub fn take_diagnostics(&mut self) -> Vec<Diagnostic> {
         std::mem::take(&mut self.diagnostics)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::symbols::{TypeDef, TypeKind};
+
+    fn make_symbols_with_types(types: Vec<TypeDef>) -> SymbolTable {
+        let mut symbols = SymbolTable::default();
+        for td in types {
+            symbols.add_type(td);
+        }
+        symbols
+    }
+
+    fn struct_type(index: usize, name: Option<&str>, parent: Option<&str>) -> TypeDef {
+        TypeDef {
+            name: name.map(|s| s.to_string()),
+            index,
+            kind: TypeKind::Struct {
+                fields: vec![(None, ValueType::I32, false)],
+            },
+            parent: parent.map(|s| s.to_string()),
+            is_final: false,
+            line: 0,
+            range: None,
+        }
+    }
+
+    fn array_type(index: usize, name: Option<&str>) -> TypeDef {
+        TypeDef {
+            name: name.map(|s| s.to_string()),
+            index,
+            kind: TypeKind::Array {
+                element_type: ValueType::I32,
+                mutable: false,
+            },
+            parent: None,
+            is_final: false,
+            line: 0,
+            range: None,
+        }
+    }
+
+    fn func_type(index: usize, name: Option<&str>) -> TypeDef {
+        TypeDef {
+            name: name.map(|s| s.to_string()),
+            index,
+            kind: TypeKind::Func {
+                params: vec![],
+                results: vec![],
+            },
+            parent: None,
+            is_final: false,
+            line: 0,
+            range: None,
+        }
+    }
+
+    #[test]
+    fn test_is_type_subtype_self() {
+        let symbols = make_symbols_with_types(vec![struct_type(0, Some("$a"), None)]);
+        assert!(is_type_subtype(0, 0, &symbols));
+    }
+
+    #[test]
+    fn test_is_type_subtype_direct_parent() {
+        let symbols = make_symbols_with_types(vec![
+            struct_type(0, Some("$parent"), None),
+            struct_type(1, Some("$child"), Some("$parent")),
+        ]);
+        assert!(is_type_subtype(1, 0, &symbols));
+        assert!(!is_type_subtype(0, 1, &symbols));
+    }
+
+    #[test]
+    fn test_is_type_subtype_grandparent() {
+        let symbols = make_symbols_with_types(vec![
+            struct_type(0, Some("$grand"), None),
+            struct_type(1, Some("$parent"), Some("$grand")),
+            struct_type(2, Some("$child"), Some("$parent")),
+        ]);
+        assert!(is_type_subtype(2, 0, &symbols));
+        assert!(is_type_subtype(2, 1, &symbols));
+        assert!(!is_type_subtype(0, 2, &symbols));
+    }
+
+    #[test]
+    fn test_is_type_subtype_unrelated() {
+        let symbols = make_symbols_with_types(vec![
+            struct_type(0, Some("$a"), None),
+            struct_type(1, Some("$b"), None),
+        ]);
+        assert!(!is_type_subtype(0, 1, &symbols));
+        assert!(!is_type_subtype(1, 0, &symbols));
+    }
+
+    #[test]
+    fn test_concrete_struct_ref_subtype_of_structref() {
+        let symbols = make_symbols_with_types(vec![struct_type(0, Some("$s"), None)]);
+        assert!(types_compatible_with_symbols(
+            &ValueType::Ref(0),
+            &ValueType::Structref,
+            &symbols
+        ));
+    }
+
+    #[test]
+    fn test_concrete_struct_ref_subtype_of_eqref() {
+        let symbols = make_symbols_with_types(vec![struct_type(0, Some("$s"), None)]);
+        assert!(types_compatible_with_symbols(
+            &ValueType::Ref(0),
+            &ValueType::Eqref,
+            &symbols
+        ));
+    }
+
+    #[test]
+    fn test_concrete_struct_ref_subtype_of_anyref() {
+        let symbols = make_symbols_with_types(vec![struct_type(0, Some("$s"), None)]);
+        assert!(types_compatible_with_symbols(
+            &ValueType::Ref(0),
+            &ValueType::Anyref,
+            &symbols
+        ));
+    }
+
+    #[test]
+    fn test_concrete_array_ref_subtype_of_arrayref() {
+        let symbols = make_symbols_with_types(vec![array_type(0, Some("$a"))]);
+        assert!(types_compatible_with_symbols(
+            &ValueType::Ref(0),
+            &ValueType::Arrayref,
+            &symbols
+        ));
+    }
+
+    #[test]
+    fn test_concrete_func_ref_not_subtype_of_structref() {
+        let symbols = make_symbols_with_types(vec![func_type(0, Some("$f"))]);
+        assert!(!types_compatible_with_symbols(
+            &ValueType::Ref(0),
+            &ValueType::Structref,
+            &symbols
+        ));
+    }
+
+    #[test]
+    fn test_ref_subtype_of_refnull_same_index() {
+        let symbols = make_symbols_with_types(vec![struct_type(0, Some("$s"), None)]);
+        assert!(types_compatible_with_symbols(
+            &ValueType::Ref(0),
+            &ValueType::RefNull(0),
+            &symbols
+        ));
+    }
+
+    #[test]
+    fn test_refnull_not_subtype_of_ref() {
+        let symbols = make_symbols_with_types(vec![struct_type(0, Some("$s"), None)]);
+        assert!(!types_compatible_with_symbols(
+            &ValueType::RefNull(0),
+            &ValueType::Ref(0),
+            &symbols
+        ));
+    }
+
+    #[test]
+    fn test_concrete_ref_parent_chain() {
+        let symbols = make_symbols_with_types(vec![
+            struct_type(0, Some("$parent"), None),
+            struct_type(1, Some("$child"), Some("$parent")),
+        ]);
+        assert!(types_compatible_with_symbols(
+            &ValueType::Ref(1),
+            &ValueType::Ref(0),
+            &symbols
+        ));
+        assert!(types_compatible_with_symbols(
+            &ValueType::Ref(1),
+            &ValueType::RefNull(0),
+            &symbols
+        ));
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1228,13 +1228,12 @@ fn extract_type_from_single_node(
             }
         }
         "struct_type" => {
-            // Extract struct fields
+            // Extract struct fields (handles abbreviated multi-field syntax)
             let mut fields = Vec::new();
             let mut cursor = type_node.walk();
             for child in type_node.children(&mut cursor) {
                 if child.kind() == "field_type" {
-                    let (field_name, field_type, mutable) = extract_field_type(&child, source);
-                    fields.push((field_name, field_type, mutable));
+                    fields.extend(extract_field_types(&child, source));
                 }
             }
             kind = TypeKind::Struct { fields };
@@ -1246,9 +1245,11 @@ fn extract_type_from_single_node(
             let mut cursor = type_node.walk();
             for child in type_node.children(&mut cursor) {
                 if child.kind() == "field_type" {
-                    let (_, field_type, mut_flag) = extract_field_type(&child, source);
-                    element_type = field_type;
-                    mutable = mut_flag;
+                    let extracted = extract_field_types(&child, source);
+                    if let Some((_, ft, m)) = extracted.into_iter().next() {
+                        element_type = ft;
+                        mutable = m;
+                    }
                 }
             }
             kind = TypeKind::Array {
@@ -1312,11 +1313,13 @@ fn extract_type_from_single_node(
     })
 }
 
-/// Extract field_type information (name, type, mutability)
-fn extract_field_type(field_node: &Node, source: &str) -> (Option<String>, ValueType, bool) {
+/// Extract field_type information, returning one or more fields.
+///
+/// Handles abbreviated multi-field syntax: `(field i32 (mut i32))` produces two fields.
+/// Only the first field gets the identifier name (if present); subsequent fields are unnamed.
+fn extract_field_types(field_node: &Node, source: &str) -> Vec<(Option<String>, ValueType, bool)> {
     let mut field_name = None;
-    let mut field_type = ValueType::Unknown;
-    let mut mutable = false;
+    let mut fields = Vec::new();
 
     let mut cursor = field_node.walk();
     for child in field_node.children(&mut cursor) {
@@ -1327,30 +1330,53 @@ fn extract_field_type(field_node: &Node, source: &str) -> (Option<String>, Value
             "identifier" => {
                 field_name = Some(node_text(&child, source));
             }
-            "value_type" => {
-                field_type = extract_value_type(&child, source);
-            }
             "storage_type" => {
-                field_type = extract_storage_type(&child, source);
-            }
-            "packed_type" => {
-                let text = node_text(&child, source);
-                field_type = match text.as_str() {
-                    "i8" => ValueType::I8,
-                    "i16" => ValueType::I16,
-                    _ => ValueType::Unknown,
+                let (ft, mutable) = extract_storage_type_with_mut(&child, source);
+                // First field gets the name, subsequent fields are unnamed
+                let name = if fields.is_empty() {
+                    field_name.clone()
+                } else {
+                    None
                 };
+                fields.push((name, ft, mutable));
             }
             _ => {}
         }
     }
 
-    let text = node_text(field_node, source);
-    if text.contains("(mut") || text.contains(" mut ") {
-        mutable = true;
+    // Fallback for field_type nodes that use value_type or packed_type directly
+    // (without a storage_type wrapper)
+    if fields.is_empty() {
+        let mut field_type = ValueType::Unknown;
+        let mut mutable = false;
+        let mut cursor2 = field_node.walk();
+        for child in field_node.children(&mut cursor2) {
+            let ck = child.kind();
+            #[cfg(all(feature = "wasm", not(feature = "native")))]
+            let ck = ck.as_str();
+            match ck {
+                "value_type" => {
+                    field_type = extract_value_type(&child, source);
+                }
+                "packed_type" => {
+                    let text = node_text(&child, source);
+                    field_type = match text.as_str() {
+                        "i8" => ValueType::I8,
+                        "i16" => ValueType::I16,
+                        _ => ValueType::Unknown,
+                    };
+                }
+                _ => {}
+            }
+        }
+        let text = node_text(field_node, source);
+        if text.contains("(mut") || text.contains(" mut ") {
+            mutable = true;
+        }
+        fields.push((field_name, field_type, mutable));
     }
 
-    (field_name, field_type, mutable)
+    fields
 }
 
 /// Extract a single type definition from a type node
@@ -1422,15 +1448,13 @@ fn extract_type(type_node: &Node, source: &str, index: usize) -> Option<TypeDef>
         // Check if this child is directly a struct_type or array_type
         // (happens when type_field is just the type itself)
         if child.kind() == "struct_type" {
-            // Extract struct fields directly
+            // Extract struct fields directly (handles abbreviated multi-field syntax)
             let mut fields = Vec::new();
             let mut struct_cursor = child.walk();
 
             for struct_child in child.children(&mut struct_cursor) {
                 if struct_child.kind() == "field_type" {
-                    let (field_name, field_type, mutable) =
-                        extract_field_type(&struct_child, source);
-                    fields.push((field_name, field_type, mutable));
+                    fields.extend(extract_field_types(&struct_child, source));
                 }
             }
             kind = TypeKind::Struct { fields };
@@ -1442,9 +1466,11 @@ fn extract_type(type_node: &Node, source: &str, index: usize) -> Option<TypeDef>
             let mut array_cursor = child.walk();
             for array_child in child.children(&mut array_cursor) {
                 if array_child.kind() == "field_type" {
-                    let (_, ft, m) = extract_field_type(&array_child, source);
-                    element_type = ft;
-                    mutable = m;
+                    let extracted = extract_field_types(&array_child, source);
+                    if let Some((_, ft, m)) = extracted.into_iter().next() {
+                        element_type = ft;
+                        mutable = m;
+                    }
                 }
             }
             kind = TypeKind::Array {
@@ -1463,15 +1489,13 @@ fn extract_type(type_node: &Node, source: &str, index: usize) -> Option<TypeDef>
                     }
                     results.extend(extract_results(&field_child, source));
                 } else if field_child.kind() == "struct_type" {
-                    // Extract struct fields
+                    // Extract struct fields (handles abbreviated multi-field syntax)
                     let mut fields = Vec::new();
                     let mut struct_cursor = field_child.walk();
 
                     for struct_child in field_child.children(&mut struct_cursor) {
                         if struct_child.kind() == "field_type" {
-                            let (field_name, field_type, mutable) =
-                                extract_field_type(&struct_child, source);
-                            fields.push((field_name, field_type, mutable));
+                            fields.extend(extract_field_types(&struct_child, source));
                         }
                     }
                     kind = TypeKind::Struct { fields };
@@ -1484,9 +1508,11 @@ fn extract_type(type_node: &Node, source: &str, index: usize) -> Option<TypeDef>
                     let mut array_cursor = field_child.walk();
                     for array_child in field_child.children(&mut array_cursor) {
                         if array_child.kind() == "field_type" {
-                            let (_, ft, m) = extract_field_type(&array_child, source);
-                            element_type = ft;
-                            mutable = m;
+                            let extracted = extract_field_types(&array_child, source);
+                            if let Some((_, ft, m)) = extracted.into_iter().next() {
+                                element_type = ft;
+                                mutable = m;
+                            }
                         }
                     }
                     kind = TypeKind::Array {
@@ -1564,8 +1590,7 @@ fn extract_struct_kind(struct_node: &Node, source: &str) -> TypeKind {
 
     for struct_child in struct_node.children(&mut struct_cursor) {
         if struct_child.kind() == "field_type" {
-            let (field_name, field_type, mutable) = extract_field_type(&struct_child, source);
-            fields.push((field_name, field_type, mutable));
+            fields.extend(extract_field_types(&struct_child, source));
         }
     }
     TypeKind::Struct { fields }
@@ -1579,9 +1604,11 @@ fn extract_array_kind(array_node: &Node, source: &str) -> TypeKind {
     let mut array_cursor = array_node.walk();
     for array_child in array_node.children(&mut array_cursor) {
         if array_child.kind() == "field_type" {
-            let (_, ft, m) = extract_field_type(&array_child, source);
-            element_type = ft;
-            mutable = m;
+            let extracted = extract_field_types(&array_child, source);
+            if let Some((_, ft, m)) = extracted.into_iter().next() {
+                element_type = ft;
+                mutable = m;
+            }
         }
     }
     TypeKind::Array {
@@ -2004,50 +2031,53 @@ fn extract_value_type(value_type_node: &Node, source: &str) -> ValueType {
     ValueType::Unknown
 }
 
-/// Extract value type from a storage_type node (handles packed types and value types)
-fn extract_storage_type(storage_node: &Node, source: &str) -> ValueType {
+/// Extract value type and mutability from a storage_type node.
+///
+/// Returns (type, is_mutable). A `mut_storage_type` child indicates mutability.
+fn extract_storage_type_with_mut(storage_node: &Node, source: &str) -> (ValueType, bool) {
     let mut cursor = storage_node.walk();
     for child in storage_node.children(&mut cursor) {
         let ck = child.kind();
         #[cfg(all(feature = "wasm", not(feature = "native")))]
         let ck = ck.as_str();
         match ck {
-            "value_type" => return extract_value_type(&child, source),
+            "value_type" => return (extract_value_type(&child, source), false),
             "packed_type" => {
                 let text = node_text(&child, source);
-                return match text.as_str() {
+                let vt = match text.as_str() {
                     "i8" => ValueType::I8,
                     "i16" => ValueType::I16,
                     _ => ValueType::Unknown,
                 };
+                return (vt, false);
             }
             "mut_storage_type" => {
-                // Recurse into the mutable wrapper
+                // Mutable wrapper — extract inner type
                 let mut inner_cursor = child.walk();
                 for inner_child in child.children(&mut inner_cursor) {
                     let ik = inner_child.kind();
                     #[cfg(all(feature = "wasm", not(feature = "native")))]
                     let ik = ik.as_str();
                     match ik {
-                        "value_type" => return extract_value_type(&inner_child, source),
+                        "value_type" => return (extract_value_type(&inner_child, source), true),
                         "packed_type" => {
                             let text = node_text(&inner_child, source);
-                            return match text.as_str() {
+                            let vt = match text.as_str() {
                                 "i8" => ValueType::I8,
                                 "i16" => ValueType::I16,
                                 _ => ValueType::Unknown,
                             };
+                            return (vt, true);
                         }
                         _ => {}
                     }
                 }
+                return (ValueType::Unknown, true);
             }
             _ => {}
         }
     }
-    // Fallback: try text
-    let text = node_text(storage_node, source);
-    ValueType::try_parse(&text).unwrap_or(ValueType::Unknown)
+    (ValueType::Unknown, false)
 }
 
 /// Alias for ValueType::try_parse for convenience in tree traversal code.

--- a/tests/diagnostic_corpus/struct_field_out_of_bounds.expected.json
+++ b/tests/diagnostic_corpus/struct_field_out_of_bounds.expected.json
@@ -1,0 +1,10 @@
+{
+  "description": "Struct field index out of bounds should produce error",
+  "diagnostics": [
+    {
+      "line": 5,
+      "message_contains": "unknown field",
+      "severity": 1
+    }
+  ]
+}

--- a/tests/diagnostic_corpus/struct_field_out_of_bounds.wat
+++ b/tests/diagnostic_corpus/struct_field_out_of_bounds.wat
@@ -1,0 +1,8 @@
+;; Struct field index out of bounds
+(module
+  (type $point (struct (field $x i32) (field $y i32)))
+  (func (param (ref $point))
+    local.get 0
+    struct.get $point 5
+  )
+)

--- a/tests/diagnostic_corpus/struct_get_s_non_packed.expected.json
+++ b/tests/diagnostic_corpus/struct_get_s_non_packed.expected.json
@@ -1,0 +1,10 @@
+{
+  "description": "struct.get_s on non-packed field type should produce error",
+  "diagnostics": [
+    {
+      "line": 5,
+      "message_contains": "packed storage type",
+      "severity": 1
+    }
+  ]
+}

--- a/tests/diagnostic_corpus/struct_get_s_non_packed.wat
+++ b/tests/diagnostic_corpus/struct_get_s_non_packed.wat
@@ -1,0 +1,8 @@
+;; struct.get_s on non-packed field type
+(module
+  (type $s (struct (field $f i32)))
+  (func (param (ref $s))
+    local.get 0
+    struct.get_s $s 0
+  )
+)

--- a/tests/diagnostic_corpus/valid_struct_field_access.expected.json
+++ b/tests/diagnostic_corpus/valid_struct_field_access.expected.json
@@ -1,0 +1,4 @@
+{
+  "description": "Valid struct field access should produce no errors",
+  "diagnostics": []
+}

--- a/tests/diagnostic_corpus/valid_struct_field_access.wat
+++ b/tests/diagnostic_corpus/valid_struct_field_access.wat
@@ -1,0 +1,8 @@
+;; Valid struct field access - should produce no field errors
+(module
+  (type $point (struct (field $x i32) (field $y i32)))
+  (func (param (ref $point)) (result i32)
+    local.get 0
+    struct.get $point 0
+  )
+)

--- a/tests/diagnostic_corpus/valid_struct_get_s_packed.expected.json
+++ b/tests/diagnostic_corpus/valid_struct_get_s_packed.expected.json
@@ -1,0 +1,4 @@
+{
+  "description": "Valid struct.get_s on packed i8 field should produce no errors",
+  "diagnostics": []
+}

--- a/tests/diagnostic_corpus/valid_struct_get_s_packed.wat
+++ b/tests/diagnostic_corpus/valid_struct_get_s_packed.wat
@@ -1,0 +1,8 @@
+;; Valid struct.get_s on packed i8 field
+(module
+  (type $s (struct (field $f i8)))
+  (func (param (ref $s)) (result i32)
+    local.get 0
+    struct.get_s $s 0
+  )
+)


### PR DESCRIPTION
## Summary

- New `gc_checks.rs` module validating `struct.get/get_s/get_u/set` instructions: field index bounds, packed type requirements, immutability checks, and non-struct type detection
- Concrete GC ref subtyping in `type_check.rs`: `Ref(n)`/`RefNull(n)` resolved against struct/array/func abstract supertypes and parent chain walking
- Fixed parser to handle abbreviated multi-field struct syntax `(field i32 (mut i32))` producing correct field count
- GC spec tests: +2 valid modules, +1 assert_invalid, zero regressions

---

- closes https://github.com/EmNudge/wat-lsp/issues/193