### PR TITLE
fix: call_ref grammar to bare index, replace wabt with js-wasm-tools

### DIFF
--- a/grammars/tree-sitter-wat/grammar.js
+++ b/grammars/tree-sitter-wat/grammar.js
@@ -379,8 +379,8 @@ module.exports = grammar({
         seq("br_on_cast", $.index, $._heap_type_or_ref, $._heap_type_or_ref),
         seq("br_on_cast_fail", $.index, $._heap_type_or_ref, $._heap_type_or_ref),
         // typed function references
-        seq("call_ref", choice($.type_use, $.index)),
-        seq("return_call_ref", choice($.type_use, $.index)),
+        seq("call_ref", $.index),
+        seq("return_call_ref", $.index),
       ),
 
     _instruction_exception: $ =>

--- a/packages/playground/examples/call_ref_type_annotation.wat
+++ b/packages/playground/examples/call_ref_type_annotation.wat
@@ -1,8 +1,7 @@
-;; call_ref / return_call_ref with (type $t) annotation
-;; The Typed Function References proposal allows both forms:
-;;   call_ref $type         - bare index
-;;   call_ref (type $type)  - type annotation
-;; Both are equivalent. The annotation form mirrors call_indirect (type $t).
+;; call_ref / return_call_ref with bare type index
+;; Unlike call_indirect which uses (type $t), call_ref takes a bare type index:
+;;   call_ref $type       - named type index
+;;   call_ref 0           - numeric type index
 
 (module
   (type $unary (func (param i32) (result i32)))
@@ -16,47 +15,46 @@
   (func $add (param $a i32) (param $b i32) (result i32)
     (i32.add (local.get $a) (local.get $b)))
 
-  ;; --- call_ref with (type ...) annotation (s-expression style) ---
+  ;; --- call_ref with named type index (s-expression style) ---
 
   (func $apply_unary (param $fn (ref $unary)) (param $x i32) (result i32)
-    (call_ref (type $unary) (local.get $x) (local.get $fn)))
+    (call_ref $unary (local.get $x) (local.get $fn)))
 
   (func $apply_binary (param $fn (ref $binary)) (param $a i32) (param $b i32) (result i32)
-    (call_ref (type $binary) (local.get $a) (local.get $b) (local.get $fn)))
+    (call_ref $binary (local.get $a) (local.get $b) (local.get $fn)))
 
-  ;; --- call_ref with (type ...) annotation (linear/stack style) ---
+  ;; --- call_ref with named type index (linear/stack style) ---
 
   (func $apply_unary_linear (param $fn (ref $unary)) (param $x i32) (result i32)
     local.get $x
     local.get $fn
-    call_ref (type $unary))
+    call_ref $unary)
 
   (func $apply_binary_linear (param $fn (ref $binary)) (param $a i32) (param $b i32) (result i32)
     local.get $a
     local.get $b
     local.get $fn
-    call_ref (type $binary))
+    call_ref $binary)
 
-  ;; --- return_call_ref with (type ...) annotation (tail call) ---
+  ;; --- return_call_ref with bare type index (tail call) ---
 
   (func $tail_apply (param $fn (ref $unary)) (param $x i32) (result i32)
     local.get $x
     local.get $fn
-    return_call_ref (type $unary))
+    return_call_ref $unary)
 
-  ;; --- Mixing both forms in the same module ---
+  ;; --- Mixing named and numeric type indices ---
 
   (func $double_then_add (param $x i32) (param $y i32) (result i32)
-    ;; bare form producing i32, then annotation form consuming it
-    (call_ref (type $binary)
+    (call_ref $binary
       (call_ref $unary (local.get $x) (ref.func $double))
       (local.get $y)
       (ref.func $add)))
 
-  ;; --- Numeric index works with annotation form ---
+  ;; --- Numeric type index ---
 
   (func $call_by_index (param $fn (ref $unary)) (param $x i32) (result i32)
-    (call_ref (type 0) (local.get $x) (local.get $fn)))
+    (call_ref 0 (local.get $x) (local.get $fn)))
 
   ;; Exports
   (export "apply_unary" (func $apply_unary))

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -21,7 +21,7 @@
     "vscode-oniguruma": "^2.0.1",
     "vscode-textmate": "^9.3.1",
     "vue": "^3.5.27",
-    "wabt": "^1.0.36",
+    "js-wasm-tools": "^1.3.1",
     "web-tree-sitter": "^0.25.3"
   },
   "devDependencies": {

--- a/packages/playground/src/store/playground.ts
+++ b/packages/playground/src/store/playground.ts
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia';
 import { ref, computed } from 'vue';
 import { examples, getDefaultExample } from '../../examples';
-import wabtInit from 'wabt';
+import init, { parseWat } from 'js-wasm-tools';
 
 export interface OpenFile {
     id: string;
@@ -26,13 +26,13 @@ export const usePlaygroundStore = defineStore('playground', () => {
     const isCompiling = ref(false);
     const recentlyUsedIds = ref<string[]>([]);
 
-    let wabt: any = null;
+    let wasmToolsReady = false;
 
-    async function initWabt() {
-        if (!wabt) {
-            wabt = await (wabtInit as any)();
+    async function ensureWasmTools() {
+        if (!wasmToolsReady) {
+            await init();
+            wasmToolsReady = true;
         }
-        return wabt;
     }
 
     const currentFile = computed(() =>
@@ -135,34 +135,18 @@ export const usePlaygroundStore = defineStore('playground', () => {
         log(`Starting compilation of ${currentFile.value.filename}...`, 'info');
 
         try {
-            const wabt = await initWabt();
-            const module = wabt.parseWat(currentFile.value.filename, currentFile.value.code, {
-                bulk_memory: true,
-                exceptions: true,
-                gc: true,
-                multi_value: true,
-                mutable_globals: true,
-                reference_types: true,
-                saturating_float_to_int: true,
-                sign_extension: true,
-                simd: true,
-                tail_call: true,
-            });
+            await ensureWasmTools();
+            const bytes = parseWat(currentFile.value.code);
+            wasmBytes.value = bytes;
 
-            module.validate();
-            const result = module.toBinary({ log: false, write_debug_names: true });
-            wasmBytes.value = result.buffer;
+            log(`Compiled successfully (${bytes.byteLength} bytes)`, 'success');
+            const compiledModule = await WebAssembly.compile(bytes.buffer as ArrayBuffer);
+            wasmModule.value = compiledModule;
 
-            if (wasmBytes.value) {
-                log(`Compiled successfully (${wasmBytes.value.byteLength} bytes)`, 'success');
-                const compiledModule = await WebAssembly.compile(wasmBytes.value.buffer as ArrayBuffer);
-                wasmModule.value = compiledModule;
+            // Extract imports/exports
+            moduleImports.value = WebAssembly.Module.imports(compiledModule);
+            moduleExports.value = WebAssembly.Module.exports(compiledModule);
 
-                // Extract imports/exports
-                moduleImports.value = WebAssembly.Module.imports(compiledModule);
-                moduleExports.value = WebAssembly.Module.exports(compiledModule);
-            }
-            module.destroy();
             return true;
         } catch (e: any) {
             log(`Compilation failed: ${e.message}`, 'error');

--- a/packages/playground/vite.config.ts
+++ b/packages/playground/vite.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   plugins: [vue()],
   base: './',
   optimizeDeps: {
-    include: ['monaco-editor', 'wabt', 'web-tree-sitter'],
+    include: ['monaco-editor', 'web-tree-sitter'],
     exclude: ['@emnudge/wat-lsp'],
   },
   resolve: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,6 +110,9 @@ importers:
       '@vitejs/plugin-vue':
         specifier: ^6.0.4
         version: 6.0.4(vite@5.4.21(@types/node@20.19.33))(vue@3.5.27(typescript@5.9.3))
+      js-wasm-tools:
+        specifier: ^1.3.1
+        version: 1.3.1
       monaco-editor:
         specifier: ^0.45.0
         version: 0.45.0
@@ -128,9 +131,6 @@ importers:
       vue:
         specifier: ^3.5.27
         version: 3.5.27(typescript@5.9.3)
-      wabt:
-        specifier: ^1.0.36
-        version: 1.0.39
       web-tree-sitter:
         specifier: ^0.25.3
         version: 0.25.10
@@ -2787,6 +2787,10 @@ packages:
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
+  js-wasm-tools@1.3.1:
+    resolution: {integrity: sha512-NjE/R9JyV8BMozQOXiDMEd+yiDBaD6lSHMzOqTqb+EY8iTGHszCHhDie0LKbmmRO3oQAE/93WSPRjtRrAsnPBw==}
+    hasBin: true
+
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
@@ -4326,10 +4330,6 @@ packages:
 
   w3c-keyname@2.2.8:
     resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
-
-  wabt@1.0.39:
-    resolution: {integrity: sha512-ba+dRL/75VQQY7RkU/CgriGbkoWAfS8TDyUlJfJhJ8KhtXgMl5dhNvoPNUcQ9IWRhW8u41glMSuZeTvsYq2rRg==}
-    hasBin: true
 
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
@@ -7402,6 +7402,8 @@ snapshots:
 
   js-tokens@9.0.1: {}
 
+  js-wasm-tools@1.3.1: {}
+
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
@@ -9254,8 +9256,6 @@ snapshots:
       typescript: 5.9.3
 
   w3c-keyname@2.2.8: {}
-
-  wabt@1.0.39: {}
 
   web-namespaces@2.0.1: {}
 

--- a/src/diagnostics/semantic_diagnostics.rs
+++ b/src/diagnostics/semantic_diagnostics.rs
@@ -972,8 +972,8 @@ mod tests {
     }
 
     #[test]
-    fn test_call_ref_type_use_syntax() {
-        // Issue #124: call_ref (type $t) syntax should be recognized
+    fn test_call_ref_bare_index_syntax() {
+        // call_ref takes a bare type index (not type_use like call_indirect)
         let document = r#"(module
   (type $t (func (param i32) (result i32)))
   (func $inc (type $t) (param $x i32) (result i32)
@@ -988,7 +988,7 @@ mod tests {
     ref.func $inc
     drop
     local.get $x
-    call_ref (type $t))
+    call_ref $t)
 )"#;
 
         let mut parser = create_parser();
@@ -1003,15 +1003,14 @@ mod tests {
         assert_eq!(
             errors.len(),
             0,
-            "call_ref (type $t) should produce no errors, got: {:?}",
+            "call_ref $t should produce no errors, got: {:?}",
             errors.iter().map(|d| &d.message).collect::<Vec<_>>()
         );
     }
 
     #[test]
-    fn test_return_call_ref_type_use_syntax() {
-        // return_call_ref (type $t) should also be recognized
-        // The function needs param + funcref on the stack for return_call_ref
+    fn test_return_call_ref_bare_index_syntax() {
+        // return_call_ref takes a bare type index
         let document = r#"(module
   (type $t (func (param i32) (result i32)))
   (func $inc (type $t) (param $x i32) (result i32)
@@ -1022,7 +1021,7 @@ mod tests {
   (func $dispatch (type $t) (param $x i32) (param $f funcref) (result i32)
     local.get $x
     local.get $f
-    return_call_ref (type $t))
+    return_call_ref $t)
 )"#;
 
         let mut parser = create_parser();
@@ -1037,7 +1036,7 @@ mod tests {
         assert_eq!(
             errors.len(),
             0,
-            "return_call_ref (type $t) should produce no errors, got: {:?}",
+            "return_call_ref $t should produce no errors, got: {:?}",
             errors.iter().map(|d| &d.message).collect::<Vec<_>>()
         );
     }

--- a/src/features/signature/call_info.rs
+++ b/src/features/signature/call_info.rs
@@ -70,6 +70,7 @@ pub fn find_function_call_ast(node: &Node, document: &str) -> Option<CallInfo> {
                             arg_count += 1;
                         }
                     }
+                    // call_indirect uses type_use (type $t), extract index from it
                     if child_kind == "type_use" && name.is_none() {
                         let mut inner_cursor = child.walk();
                         for inner_child in child.children(&mut inner_cursor) {
@@ -181,18 +182,6 @@ pub fn find_function_call(line_prefix: &str) -> Option<CallInfo> {
 
 /// Extract the function/type name from text after a call keyword.
 pub fn extract_name_from_call(after_call: &str) -> Option<String> {
-    let trimmed = after_call.trim_start();
-    // Handle (type $t) annotation form
-    if trimmed.starts_with("(type ") || trimmed.starts_with("(type\t") {
-        let inner = &trimmed[6..]; // skip "(type "
-        let name_end = inner
-            .find(|c: char| c == ')' || c.is_whitespace())
-            .unwrap_or(inner.len());
-        let name = inner[..name_end].trim().to_string();
-        if !name.is_empty() {
-            return Some(name);
-        }
-    }
     let name_end = after_call
         .find(|c: char| c.is_whitespace() || c == '(')
         .unwrap_or(after_call.len());

--- a/src/features/signature/tests.rs
+++ b/src/features/signature/tests.rs
@@ -414,37 +414,10 @@ fn test_call_type_enum() {
     assert_eq!(call_info_return_ref.call_type, CallType::ReturnCallRef);
 }
 
-// Tests for (type $t) annotation form
+// call_ref uses bare type index (not type_use like call_indirect)
 
 #[test]
-fn test_find_function_call_call_ref_type_use() {
-    let line = "call_ref (type $binop)(";
-    let info = find_function_call(line);
-    assert!(info.is_some());
-
-    let call = info.unwrap();
-    assert_eq!(call.name, "$binop");
-    assert_eq!(call.call_type, CallType::CallRef);
-}
-
-#[test]
-fn test_find_function_call_return_call_ref_type_use() {
-    let line = "return_call_ref (type $binop)(";
-    let info = find_function_call(line);
-    assert!(info.is_some());
-
-    let call = info.unwrap();
-    assert_eq!(call.name, "$binop");
-    assert_eq!(call.call_type, CallType::ReturnCallRef);
-}
-
-#[test]
-fn test_extract_name_from_call_type_use() {
-    assert_eq!(
-        extract_name_from_call("(type $binop)"),
-        Some("$binop".to_string())
-    );
-    assert_eq!(extract_name_from_call("(type 0)"), Some("0".to_string()));
-    // Bare index form should still work
+fn test_extract_name_from_call_bare_index() {
     assert_eq!(extract_name_from_call("$binop"), Some("$binop".to_string()));
+    assert_eq!(extract_name_from_call("0"), Some("0".to_string()));
 }


### PR DESCRIPTION
## Summary

- Fix `call_ref` / `return_call_ref` grammar to accept only bare type index (not `type_use`), matching the spec
- Replace `wabt` with `js-wasm-tools` in the playground compile flow
- Update `call_ref_type_annotation.wat` example to use valid bare-index syntax
- Clean up signature helper and tests to remove `(type $t)` handling for call_ref