### PR TITLE
feat: add folded block type checking, ref.func declaration validation, and branch stack tracking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,51 @@ jobs:
           fi
           echo "All examples validated correctly"
 
+  validate-wasm-tools:
+    name: Validate Examples (wasm-tools)
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install wasm-tools
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release download --repo bytecodealliance/wasm-tools --pattern '*x86_64-linux*' --output wasm-tools.tar.gz
+          tar xzf wasm-tools.tar.gz
+          sudo cp wasm-tools-*/wasm-tools /usr/local/bin/
+          wasm-tools --version
+
+      - name: Validate valid examples with wasm-tools
+        shell: bash
+        run: |
+          wrong=()
+
+          echo "Valid examples (wasm-tools validate):"
+          for file in packages/playground/examples/*.wat; do
+            base=$(basename "$file")
+            if wasm-tools validate "$file" > /dev/null 2>&1; then
+              echo "  ok    $base"
+            else
+              echo "  FAIL  $base"
+              wasm-tools validate "$file" 2>&1 || true
+              wrong+=("$base")
+            fi
+          done
+
+          echo ""
+          if [ ${#wrong[@]} -gt 0 ]; then
+            echo "Failures (${#wrong[@]}):"
+            for entry in "${wrong[@]}"; do
+              echo "  - $entry"
+            done
+            exit 1
+          fi
+          echo "All valid examples pass wasm-tools validate"
+
   clippy:
     name: Clippy
     needs: changes

--- a/packages/playground/examples/call_ref_type_annotation.wat
+++ b/packages/playground/examples/call_ref_type_annotation.wat
@@ -7,6 +7,9 @@
   (type $unary (func (param i32) (result i32)))
   (type $binary (func (param i32 i32) (result i32)))
 
+  ;; Declare functions used with ref.func (required by the spec)
+  (elem declare func $double $add)
+
   ;; --- Basic functions ---
 
   (func $double (param $x i32) (result i32)

--- a/packages/playground/examples/exceptions.wat
+++ b/packages/playground/examples/exceptions.wat
@@ -1,11 +1,8 @@
-;; Exception Handling in WebAssembly
+;; Exception Handling in WebAssembly (try_table)
 ;;
-;; This file demonstrates both:
-;; 1. Legacy exception handling (try/catch/throw) - supported in browsers since 2022
-;; 2. Modern exception handling (try_table) - WebAssembly 3.0 standard (2025)
-;;
-;; The legacy syntax is still supported in browsers but may be deprecated.
-;; New code should prefer try_table.
+;; WebAssembly exception handling uses try_table with labeled branches.
+;; When an exception is caught, control branches to the target label
+;; with the exception payload (and optionally an exnref).
 
 (module
   ;; ============================================================
@@ -21,15 +18,11 @@
   (memory 1)
 
   ;; ============================================================
-  ;; PART 1: MODERN SYNTAX (try_table) - WebAssembly 3.0
-  ;;
-  ;; try_table uses labeled branches for exception handling.
-  ;; When an exception is caught, control branches to the label
-  ;; with the exception payload (and optionally an exnref).
+  ;; Basic Exception Handling
   ;; ============================================================
 
-  ;; Safe division using try_table
-  (func $safe_divide_modern (param $a i32) (param $b i32) (result i32)
+  ;; Safe division: throws on divide by zero
+  (func $safe_divide (param $a i32) (param $b i32) (result i32)
     (block $catch (result i32)       ;; catch target - receives the exception payload
       (try_table (result i32) (catch $div_by_zero $catch)
         (if (i32.eqz (local.get $b))
@@ -37,174 +30,149 @@
             (throw $div_by_zero (local.get $a))))
         (i32.div_s (local.get $a) (local.get $b)))))
 
-  ;; Division with default value using try_table
-  (func $divide_with_default_modern (param $a i32) (param $b i32) (param $default i32) (result i32)
-    (block $on_error (result i32)    ;; receives dividend from exception
-      (drop                          ;; drop the exception payload
-        (br_on_null $on_error        ;; if somehow null, use default
-          (block $catch (result i32 exnref)
-            (try_table (result i32) (catch_ref $div_by_zero $catch)
-              (call $safe_divide_modern (local.get $a) (local.get $b))
-              (return)))))
-      (local.get $default)))
+  ;; Division with default value: catch and return default on error
+  (func $divide_with_default (param $a i32) (param $b i32) (param $default i32) (result i32)
+    (block $catch (result i32)
+      (try_table (result i32) (catch $div_by_zero $catch)
+        (call $safe_divide (local.get $a) (local.get $b))
+        (return)))
+    ;; Caught div_by_zero — stack has [dividend]; drop it and return default
+    (drop)
+    (local.get $default))
+
+  ;; ============================================================
+  ;; Multiple Catch Clauses
+  ;; ============================================================
 
   ;; Catch any exception using catch_all
-  (func $try_any_modern (param $op i32) (result i32)
-    (block $catch_all_handler (result exnref)
-      (try_table (result i32) (catch_all_ref $catch_all_handler)
+  (func $try_any (param $op i32) (result i32)
+    (block $catch_all_handler
+      (try_table (catch_all $catch_all_handler)
         (if (i32.eqz (local.get $op))
           (then (throw $invalid_input)))
-        (i32.const 42)
-        (return)))
-    (drop)  ;; drop the exnref
+        (return (i32.const 42))))
+    ;; catch_all handler — return sentinel
     (i32.const -1))
+
+  ;; Multiple catch clauses with try_table
+  ;; Each catch branches to a different labeled block
+  (func $try_operation (param $op i32) (result i32)
+    (local $result i32)
+    (block $catch_all_block
+      (block $catch_div_zero (result i32)
+        (block $catch_invalid
+          (try_table
+            (catch $invalid_input $catch_invalid)
+            (catch $div_by_zero $catch_div_zero)
+            (catch_all $catch_all_block)
+            ;; Try body
+            (if (i32.eq (local.get $op) (i32.const 0))
+              (then (throw $invalid_input)))
+            (if (i32.eq (local.get $op) (i32.const 1))
+              (then (throw $div_by_zero (i32.const 42))))
+            (return (i32.const 100))))
+        ;; catch $invalid_input handler
+        (return (i32.const -1)))
+      ;; catch $div_by_zero handler (payload on stack)
+      (drop)
+      (return (i32.const -2)))
+    ;; catch_all handler
+    (i32.const -999))
+
+  ;; ============================================================
+  ;; Nested Exception Handling
+  ;; ============================================================
 
   ;; Nested try_table blocks
   ;; Uses local variable pattern to avoid complex nested block result types
-  (func $nested_modern (param $x i32) (result i32)
+  (func $nested (param $x i32) (result i32)
     (local $result i32)
     (local.set $result (i32.const -1))  ;; default: invalid input
     (block $done
       (block $outer_catch
         (try_table (catch $invalid_input $outer_catch)
-          (block $inner_catch
+          (block $inner_catch (result i32)
             (try_table (catch $div_by_zero $inner_catch)
               (if (i32.lt_s (local.get $x) (i32.const 0))
                 (then (throw $invalid_input)))
-              (local.set $result (call $safe_divide_modern (i32.const 100) (local.get $x)))
-              (br $done)))
-          ;; inner catch: div by zero, return 0
+              (local.set $result (call $safe_divide (i32.const 100) (local.get $x)))
+              (br $done))
+            (unreachable))
+          ;; inner catch: div by zero — drop dividend payload, set result to 0
+          (drop)
           (local.set $result (i32.const 0))
           (br $done))))
     ;; outer catch falls through with result = -1
     (local.get $result))
 
+  ;; ============================================================
+  ;; Rethrow and Propagation
+  ;; ============================================================
+
   ;; Rethrow using throw_ref
-  (func $log_and_rethrow_modern (param $a i32) (param $b i32) (result i32)
+  ;; Catch an exception, perform a side effect, and rethrow it
+  (func $log_and_rethrow (param $a i32) (param $b i32) (result i32)
     (block $catch (result i32 exnref)
       (try_table (result i32) (catch_ref $div_by_zero $catch)
-        (call $safe_divide_modern (local.get $a) (local.get $b))
-        (return)))
+        (call $safe_divide (local.get $a) (local.get $b))
+        (return))
+      (unreachable))
     ;; Stack: [dividend, exnref]
     (i32.store (i32.const 0) (i32.const 1))  ;; log error flag
     (throw_ref))  ;; rethrow the caught exception
 
-  ;; ============================================================
-  ;; PART 2: LEGACY SYNTAX (try/do/catch)
-  ;;
-  ;; This syntax is still supported in browsers but deprecated.
-  ;; The folded form uses (do ...) for the try body.
-  ;; ============================================================
-
-  ;; Safe division that throws on divide by zero
-  (func $safe_divide_legacy (param $a i32) (param $b i32) (result i32)
-    (if (i32.eqz (local.get $b))
-      (then
-        (throw $div_by_zero (local.get $a))))
-    (i32.div_s (local.get $a) (local.get $b)))
-
-  ;; Function that catches division errors (legacy folded syntax)
-  (func $divide_with_default_legacy (param $a i32) (param $b i32) (param $default i32) (result i32)
-    (try (result i32)
-      (do
-        (call $safe_divide_legacy (local.get $a) (local.get $b)))
-      (catch $div_by_zero
-        (drop)  ;; drop the exception payload
-        (local.get $default))))
-
-  ;; Multiple catch clauses (legacy)
-  (func $try_operation_legacy (param $op i32) (result i32)
-    (try (result i32)
-      (do
-        (if (result i32) (i32.eq (local.get $op) (i32.const 0))
-          (then
-            (throw $invalid_input)
-            (unreachable))
-          (else
-            (if (result i32) (i32.eq (local.get $op) (i32.const 1))
-              (then
-                (throw $div_by_zero (i32.const 42))
-                (unreachable))
-              (else
-                (i32.const 100))))))
-      (catch $invalid_input
-        (i32.const -1))
-      (catch $div_by_zero
-        (drop)
-        (i32.const -2))
-      (catch_all
-        (i32.const -999))))
-
-  ;; Nested try blocks (legacy)
-  (func $nested_try_legacy (param $x i32) (result i32)
-    (try (result i32)
-      (do
-        (try (result i32)
-          (do
-            (if (i32.lt_s (local.get $x) (i32.const 0))
-              (then
-                (throw $invalid_input)))
-            (call $safe_divide_legacy (i32.const 100) (local.get $x)))
-          (catch $div_by_zero
-            (drop)
-            (i32.const 0))))
-      (catch $invalid_input
-        (i32.const -1))))
-
-  ;; Function that rethrows an exception (legacy)
-  (func $log_and_rethrow_legacy (param $a i32) (param $b i32) (result i32)
-    (try (result i32)
-      (do
-        (call $safe_divide_legacy (local.get $a) (local.get $b)))
-      (catch $div_by_zero
-        ;; Log the error (store to memory)
-        (i32.store (i32.const 0) (i32.const 1))  ;; error flag
-        ;; Rethrow the exception
-        (rethrow 0))))
-
-  ;; Delegate to outer handler (legacy)
-  (func $delegating_handler_legacy (param $x i32) (result i32)
-    (try (result i32)
-      (do
-        (try (result i32)
-          (do
+  ;; Catch-and-rethrow pattern (replaces legacy "delegate")
+  ;; Inner handler catches specific exceptions, outer catches everything else
+  (func $delegating_handler (param $x i32) (result i32)
+    (block $outer_catch (result i32)
+      (try_table (result i32) (catch $div_by_zero $outer_catch)
+        (block $inner_catch (result exnref)
+          (try_table (catch_all_ref $inner_catch)
             (if (i32.eqz (local.get $x))
               (then
                 (throw $div_by_zero (local.get $x))))
-            (local.get $x))
-          (delegate 0)))  ;; delegate to outer try
-      (catch $div_by_zero
-        (drop)
-        (i32.const -1))))
+            (return (local.get $x)))
+          (unreachable))
+        ;; inner catch_all: rethrow to outer handler
+        (throw_ref)
+        (unreachable)))
+    ;; outer catch: div_by_zero handler
+    (drop)
+    (i32.const -1))
 
   ;; ============================================================
-  ;; PART 3: UNFOLD SYNTAX (also legacy, but different form)
-  ;;
-  ;; The unfold form doesn't use (do ...), instructions are inline.
+  ;; Practical Patterns
   ;; ============================================================
 
-  ;; Example using folded try syntax (unfold syntax has limited tooling support)
-  (func $unfold_example (param $x i32) (result i32)
-    (try (result i32)
-      (do
-        (if (i32.eqz (local.get $x))
-          (then
-            (throw $div_by_zero (i32.const 42))))
-        (local.get $x))
-      (catch $div_by_zero
-        (drop)
-        (i32.const -1))))
+  ;; Safe array bounds checking with exceptions
+  (func $safe_array_access (param $base i32) (param $index i32) (param $length i32) (result i32)
+    (if (i32.ge_u (local.get $index) (local.get $length))
+      (then
+        (throw $out_of_bounds (local.get $index) (local.get $length))))
+    (i32.load (i32.add (local.get $base) (i32.shl (local.get $index) (i32.const 2)))))
+
+  ;; Multi-value exception: throw and catch with 3 values
+  (func $throw_custom (param $a i32) (param $b i32) (param $c i32)
+    (throw $custom_error (local.get $a) (local.get $b) (local.get $c)))
+
+  (func $catch_custom (result i32)
+    (block $catch (result i32 i32 i32)
+      (try_table (catch $custom_error $catch)
+        (call $throw_custom (i32.const 10) (i32.const 20) (i32.const 30)))
+      (return (i32.const 0)))
+    ;; Stack: [a, b, c] — sum them
+    (i32.add)
+    (i32.add))
 
   ;; ============================================================
   ;; Exports
   ;; ============================================================
 
-  ;; Modern (try_table)
-  (export "safe_divide" (func $safe_divide_modern))
-  (export "divide_with_default" (func $divide_with_default_modern))
-  (export "nested" (func $nested_modern))
-
-  ;; Legacy (try/do/catch)
-  (export "safe_divide_legacy" (func $safe_divide_legacy))
-  (export "divide_with_default_legacy" (func $divide_with_default_legacy))
-  (export "nested_legacy" (func $nested_try_legacy)))
+  (export "safe_divide" (func $safe_divide))
+  (export "divide_with_default" (func $divide_with_default))
+  (export "try_operation" (func $try_operation))
+  (export "nested" (func $nested))
+  (export "log_and_rethrow" (func $log_and_rethrow))
+  (export "delegating_handler" (func $delegating_handler))
+  (export "safe_array_access" (func $safe_array_access))
+  (export "catch_custom" (func $catch_custom)))

--- a/packages/playground/examples/strings_data.wat
+++ b/packages/playground/examples/strings_data.wat
@@ -91,16 +91,15 @@
   (func $strchr (param $str i32) (param $char i32) (result i32)
     (local $i i32)
     (local $c i32)
-    (block $not_found (result i32)
-      (block $found (result i32)
-        (loop $loop
-          (local.set $c (i32.load8_u (i32.add (local.get $str) (local.get $i))))
-          (br_if $found (local.get $i) (i32.eq (local.get $c) (local.get $char)))
-          (br_if $not_found (i32.const -1) (i32.eqz (local.get $c)))
-          (local.set $i (i32.add (local.get $i) (i32.const 1)))
-          (br $loop))
-        (i32.const -1))
-      (i32.const -1)))
+    (block $done
+      (loop $loop
+        (local.set $c (i32.load8_u (i32.add (local.get $str) (local.get $i))))
+        (if (i32.eq (local.get $c) (local.get $char))
+          (then (return (local.get $i))))
+        (br_if $done (i32.eqz (local.get $c)))
+        (local.set $i (i32.add (local.get $i) (i32.const 1)))
+        (br $loop)))
+    (i32.const -1))
 
   ;; Convert string to uppercase (in place)
   (func $strupr (param $str i32)

--- a/packages/playground/examples/trapping.wat
+++ b/packages/playground/examples/trapping.wat
@@ -100,12 +100,16 @@
   ;; Nested blocks with breaks
   (func $nested_blocks (param $x i32) (result i32)
     (block $outer (result i32)
-      (block $middle (result i32)
-        (block $inner (result i32)
-          (br_if $outer (i32.const 100) (i32.eq (local.get $x) (i32.const 0)))
-          (br_if $middle (i32.const 200) (i32.eq (local.get $x) (i32.const 1)))
-          (br_if $inner (i32.const 300) (i32.eq (local.get $x) (i32.const 2)))
-          (i32.const 999)))))
+      (block $case2
+        (block $case1
+          (block $case0
+            (br_if $case0 (i32.eq (local.get $x) (i32.const 0)))
+            (br_if $case1 (i32.eq (local.get $x) (i32.const 1)))
+            (br_if $case2 (i32.eq (local.get $x) (i32.const 2)))
+            (br $outer (i32.const 999)))
+          (br $outer (i32.const 100)))
+        (br $outer (i32.const 200)))
+      (i32.const 300)))
 
   ;; Block with typed result
   (func $typed_block (param $cond i32) (result i32 i32)
@@ -139,14 +143,13 @@
 
   ;; br_table (switch statement)
   (func $switch (param $selector i32) (result i32)
-    (block $default (result i32)
-      (block $case3 (result i32)
-        (block $case2 (result i32)
-          (block $case1 (result i32)
-            (block $case0 (result i32)
+    (block $default
+      (block $case3
+        (block $case2
+          (block $case1
+            (block $case0
               (br_table $case0 $case1 $case2 $case3 $default
-                (local.get $selector))
-              (i32.const -1))  ;; never reached
+                (local.get $selector)))
             (return (i32.const 100)))
           (return (i32.const 200)))
         (return (i32.const 300)))

--- a/src/diagnostics_core/module_checks.rs
+++ b/src/diagnostics_core/module_checks.rs
@@ -14,7 +14,7 @@
 
 #![allow(clippy::needless_borrow, clippy::borrow_deref_ref)]
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::core::types::{Diagnostic, Range};
 use crate::symbols::{SymbolTable, TypeKind};
@@ -53,6 +53,7 @@ pub fn validate_module_structure(
         check_constant_expressions(&module_node, source, symbols, &mut diagnostics);
         check_data_segment_memory_indices(&module_node, source, symbols, &mut diagnostics);
         check_elem_segment_table_indices(&module_node, source, symbols, &mut diagnostics);
+        check_ref_func_declarations(&module_node, source, symbols, &mut diagnostics);
     }
 
     diagnostics
@@ -1158,6 +1159,218 @@ fn check_elem_segment_table_indices(
             diagnostics.push(Diagnostic::error(range, format!("unknown table {}", idx)));
         }
     });
+}
+
+// ============================================================================
+// ref.func declaration check
+// ============================================================================
+
+/// Check that all functions referenced by `ref.func` are declared in an element segment.
+///
+/// Per the WebAssembly spec, any function used with `ref.func` must appear in:
+/// - A declarative element segment: `(elem declare func $f ...)`
+/// - An active or passive element segment that lists the function
+///
+/// Functions used with `ref.func` but not declared in any element segment cause
+/// an "undeclared function reference" validation error.
+fn check_ref_func_declarations(
+    module: &Node,
+    source: &str,
+    symbols: &SymbolTable,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    // Step 1: Collect all functions declared in element segments
+    let mut declared_funcs: HashSet<usize> = HashSet::new();
+    for_each_module_field(module, |field| {
+        let fk = field.kind();
+        #[cfg(all(feature = "wasm", not(feature = "native")))]
+        let fk = fk.as_str();
+        if fk != "module_field_elem" {
+            return;
+        }
+        collect_elem_declared_funcs(field, source, symbols, &mut declared_funcs);
+    });
+
+    // Also collect functions referenced in inline elem expressions on tables
+    for_each_module_field(module, |field| {
+        let fk = field.kind();
+        #[cfg(all(feature = "wasm", not(feature = "native")))]
+        let fk = fk.as_str();
+        if fk != "module_field_table" {
+            return;
+        }
+        collect_inline_table_elem_funcs(field, source, symbols, &mut declared_funcs);
+    });
+
+    // Step 2: Walk all function bodies to find ref.func usage
+    collect_ref_func_errors(module, source, symbols, &declared_funcs, diagnostics);
+}
+
+/// Collect function indices declared in an element segment.
+fn collect_elem_declared_funcs(
+    elem_field: &Node,
+    source: &str,
+    symbols: &SymbolTable,
+    declared: &mut HashSet<usize>,
+) {
+    collect_func_refs_recursive(elem_field, source, symbols, declared);
+}
+
+/// Recursively collect function references from element segment nodes.
+/// Walks the entire subtree, picking up any identifier/index/nat that resolves
+/// to a function index.
+fn collect_func_refs_recursive(
+    node: &Node,
+    source: &str,
+    symbols: &SymbolTable,
+    declared: &mut HashSet<usize>,
+) {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        let ck = child.kind();
+        #[cfg(all(feature = "wasm", not(feature = "native")))]
+        let ck = ck.as_str();
+
+        if ck == "identifier" || ck == "index" {
+            let text = node_text(&child, source).trim();
+            if let Some(idx) = resolve_func_index(text, symbols) {
+                declared.insert(idx);
+            }
+        } else if ck == "nat" {
+            let text = node_text(&child, source).trim();
+            if let Ok(idx) = text.parse::<usize>() {
+                if idx < symbols.functions.len() {
+                    declared.insert(idx);
+                }
+            }
+        } else {
+            // Recurse into all other nodes to find nested identifiers
+            collect_func_refs_recursive(&child, source, symbols, declared);
+        }
+    }
+}
+
+/// Collect functions from inline table elem expressions.
+fn collect_inline_table_elem_funcs(
+    table_field: &Node,
+    source: &str,
+    symbols: &SymbolTable,
+    declared: &mut HashSet<usize>,
+) {
+    // Tables can have inline elem: (table funcref (elem $f1 $f2))
+    let text = node_text(table_field, source);
+    if !text.contains("elem") {
+        return;
+    }
+    collect_func_refs_recursive(table_field, source, symbols, declared);
+}
+
+/// Resolve a function reference (name or numeric index) to an index.
+fn resolve_func_index(text: &str, symbols: &SymbolTable) -> Option<usize> {
+    if text.starts_with('$') {
+        symbols.get_function_by_name(text).map(|f| f.index)
+    } else {
+        text.parse::<usize>()
+            .ok()
+            .filter(|&idx| idx < symbols.functions.len())
+    }
+}
+
+/// Walk all function bodies to find ref.func instructions and check they're declared.
+fn collect_ref_func_errors(
+    module: &Node,
+    source: &str,
+    symbols: &SymbolTable,
+    declared: &HashSet<usize>,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    // Walk the entire module AST looking for ref.func instructions
+    walk_for_ref_func(module, source, symbols, declared, diagnostics);
+}
+
+/// Recursively walk a node tree looking for ref.func instructions.
+fn walk_for_ref_func(
+    node: &Node,
+    source: &str,
+    symbols: &SymbolTable,
+    declared: &HashSet<usize>,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let kind = node.kind();
+    #[cfg(all(feature = "wasm", not(feature = "native")))]
+    let kind = kind.as_str();
+
+    // Check if this is a ref.func instruction
+    if kind == "instr_plain" || kind == "op_index" || kind == "op_nullary" {
+        let text = node_text(node, source).trim();
+        if text.starts_with("ref.func") {
+            // Find the function reference argument
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                let ck = child.kind();
+                #[cfg(all(feature = "wasm", not(feature = "native")))]
+                let ck = ck.as_str();
+
+                // Look inside op_ nodes for the index
+                if ck.starts_with("op_") {
+                    let mut inner_cursor = child.walk();
+                    for inner in child.children(&mut inner_cursor) {
+                        let ik = inner.kind();
+                        #[cfg(all(feature = "wasm", not(feature = "native")))]
+                        let ik = ik.as_str();
+                        if ik == "identifier" || ik == "index" || ik == "nat" {
+                            check_ref_func_target(
+                                &inner,
+                                node_text(&inner, source).trim(),
+                                symbols,
+                                declared,
+                                diagnostics,
+                            );
+                        }
+                    }
+                }
+                if ck == "identifier" || ck == "index" || ck == "nat" {
+                    check_ref_func_target(
+                        &child,
+                        node_text(&child, source).trim(),
+                        symbols,
+                        declared,
+                        diagnostics,
+                    );
+                }
+            }
+        }
+    }
+
+    // Skip element segments (don't flag ref.func inside elem expressions)
+    if kind == "module_field_elem" {
+        return;
+    }
+
+    // Recurse into children
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        walk_for_ref_func(&child, source, symbols, declared, diagnostics);
+    }
+}
+
+/// Check a single ref.func target against the declared set.
+fn check_ref_func_target(
+    node: &Node,
+    func_ref: &str,
+    symbols: &SymbolTable,
+    declared: &HashSet<usize>,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    if let Some(idx) = resolve_func_index(func_ref, symbols) {
+        if !declared.contains(&idx) {
+            let range = node_to_range(node);
+            diagnostics.push(
+                Diagnostic::error(range, format!("undeclared function reference {}", func_ref))
+                    .with_code("undeclared-func-ref"),
+            );
+        }
+    }
 }
 
 // ============================================================================

--- a/src/diagnostics_core/semantic.rs
+++ b/src/diagnostics_core/semantic.rs
@@ -147,6 +147,7 @@ fn process_block_node(node: &Node, source: &str, symbols: &SymbolTable, checker:
         checker.pop_expect(&ValueType::I32, node);
     }
 
+    let label = get_block_label(node, source);
     let params = get_block_param_types(node, source);
     let results = get_block_result_types(node, source);
 
@@ -171,7 +172,7 @@ fn process_block_node(node: &Node, source: &str, symbols: &SymbolTable, checker:
         checker.pop_vals_for_instr(&params, node, block_name);
     }
 
-    checker.push_ctrl(opcode, params, results);
+    checker.push_ctrl_labeled(opcode, params, results, label);
 
     // Process body
     process_block_body(node, source, symbols, checker);
@@ -185,6 +186,7 @@ fn process_if_node(node: &Node, source: &str, symbols: &SymbolTable, checker: &m
     // Pop i32 condition
     checker.pop_expect(&ValueType::I32, node);
 
+    let label = get_block_label(node, source);
     let params = get_block_param_types(node, source);
     let results = get_block_result_types(node, source);
 
@@ -193,7 +195,7 @@ fn process_if_node(node: &Node, source: &str, symbols: &SymbolTable, checker: &m
         checker.pop_vals_for_instr(&params, node, "if");
     }
 
-    checker.push_ctrl(CtrlOpcode::If, params, results);
+    checker.push_ctrl_labeled(CtrlOpcode::If, params, results, label);
 
     // Process body
     process_block_body(node, source, symbols, checker);
@@ -271,9 +273,8 @@ fn process_block_body(node: &Node, source: &str, symbols: &SymbolTable, checker:
                 // Reference checking is handled in tree_walk.rs.
             }
             "instr_else" | "else" => {
-                // At else, we need to reset to block params for the else branch
-                // The then branch's values should match end_types, then reset
-                // For simplicity, just process the else branch's instructions
+                // At else: validate then branch, reset stack for else branch
+                checker.else_transition(&child);
                 process_block_body(&child, source, symbols, checker);
             }
             // Direct instruction children
@@ -303,6 +304,42 @@ fn process_block_body(node: &Node, source: &str, symbols: &SymbolTable, checker:
             _ => {}
         }
     }
+}
+
+/// Extract a label name from a block/loop/if/try_table node.
+/// Searches immediate children and inner block children for an identifier.
+fn get_block_label(node: &Node, source: &str) -> Option<String> {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        #[cfg(feature = "native")]
+        let kind = child.kind();
+        #[cfg(all(feature = "wasm", not(feature = "native")))]
+        let kind = child.kind();
+
+        if kind == "identifier" {
+            return Some(source[child.byte_range()].trim().to_string());
+        }
+        // Check inside block_block, loop_block, block_if, block_try_table, etc.
+        let is_inner_block = kind == "block_block"
+            || kind == "loop_block"
+            || kind == "if_block"
+            || kind == "block_if"
+            || kind == "block_try_table"
+            || kind == "block_try";
+        if is_inner_block {
+            let mut inner_cursor = child.walk();
+            for inner_child in child.children(&mut inner_cursor) {
+                #[cfg(feature = "native")]
+                let ik = inner_child.kind();
+                #[cfg(all(feature = "wasm", not(feature = "native")))]
+                let ik = inner_child.kind();
+                if ik == "identifier" {
+                    return Some(source[inner_child.byte_range()].trim().to_string());
+                }
+            }
+        }
+    }
+    None
 }
 
 /// Check if a node is a loop (instr_loop or contains loop_block)
@@ -978,7 +1015,10 @@ fn get_branch_depth(node: &Node, source: &str, checker: &TypeChecker) -> Option<
             return Some(depth);
         }
     }
-    // Named labels not yet supported for depth resolution
+    // Try named label resolution
+    if index.starts_with('$') {
+        return checker.resolve_label_depth(&index);
+    }
     None
 }
 
@@ -1537,6 +1577,71 @@ pub fn get_call_indirect_result_types(
     vec![ValueType::Unknown]
 }
 
+/// Find the instr_plain node inside a folded expression (for branch depth resolution).
+#[cfg(feature = "native")]
+fn find_instr_plain_in_expr<'a>(expr: &'a Node) -> Option<Node<'a>> {
+    let mut cursor = expr.walk();
+    for child in expr.children(&mut cursor) {
+        #[cfg(feature = "native")]
+        let kind = child.kind();
+        #[cfg(all(feature = "wasm", not(feature = "native")))]
+        let kind = child.kind();
+
+        if kind == "expr1" || kind.starts_with("expr1_") {
+            let mut inner_cursor = child.walk();
+            for inner in child.children(&mut inner_cursor) {
+                #[cfg(feature = "native")]
+                let ik = inner.kind();
+                #[cfg(all(feature = "wasm", not(feature = "native")))]
+                let ik = inner.kind();
+
+                if ik == "instr_plain" {
+                    return Some(inner);
+                }
+                // Check inside nested expr1 wrapper
+                if ik.starts_with("expr1_") {
+                    let mut deep_cursor = inner.walk();
+                    for deep in inner.children(&mut deep_cursor) {
+                        if deep.kind() == "instr_plain" {
+                            return Some(deep);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Find the instr_plain node inside a folded expression (for branch depth resolution).
+#[cfg(all(feature = "wasm", not(feature = "native")))]
+fn find_instr_plain_in_expr(expr: &Node) -> Option<Node> {
+    let mut cursor = expr.walk();
+    for child in expr.children(&mut cursor) {
+        let kind = child.kind();
+
+        if kind == "expr1" || kind.starts_with("expr1_") {
+            let mut inner_cursor = child.walk();
+            for inner in child.children(&mut inner_cursor) {
+                let ik = inner.kind();
+
+                if ik == "instr_plain" {
+                    return Some(inner);
+                }
+                if ik.starts_with("expr1_") {
+                    let mut deep_cursor = inner.walk();
+                    for deep in inner.children(&mut deep_cursor) {
+                        if deep.kind() == "instr_plain" {
+                            return Some(deep);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
 /// Get instruction info from a folded expression
 /// Returns (instruction_name, explicit_operand_count)
 pub fn get_folded_expr_info(expr: &Node, source: &str) -> Option<(String, usize)> {
@@ -1665,6 +1770,313 @@ fn get_dynamic_operand_count_from_expr(
     0
 }
 
+/// Check if a folded expression is a block-type (block, loop, if, try_table).
+/// Returns the expr1_* node if found.
+#[cfg(feature = "native")]
+fn find_folded_block_child<'a>(expr: &'a Node, source: &str) -> Option<(Node<'a>, &'static str)> {
+    let _ = source;
+    let mut cursor = expr.walk();
+    for child in expr.children(&mut cursor) {
+        #[cfg(feature = "native")]
+        let kind = child.kind();
+        #[cfg(all(feature = "wasm", not(feature = "native")))]
+        let kind = child.kind();
+
+        match kind.as_ref() {
+            "expr1_block" => return Some((child, "block")),
+            "expr1_loop" => return Some((child, "loop")),
+            "expr1_if" => return Some((child, "if")),
+            "expr1_try_table" => return Some((child, "try_table")),
+            "expr1" => {
+                // Check inside expr1 wrapper
+                let mut inner_cursor = child.walk();
+                for inner in child.children(&mut inner_cursor) {
+                    #[cfg(feature = "native")]
+                    let ik = inner.kind();
+                    #[cfg(all(feature = "wasm", not(feature = "native")))]
+                    let ik = inner.kind();
+                    match ik.as_ref() {
+                        "expr1_block" => return Some((inner, "block")),
+                        "expr1_loop" => return Some((inner, "loop")),
+                        "expr1_if" => return Some((inner, "if")),
+                        "expr1_try_table" => return Some((inner, "try_table")),
+                        _ => {}
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Check if a folded expression is a block-type (block, loop, if, try_table).
+/// Returns the expr1_* node if found.
+#[cfg(all(feature = "wasm", not(feature = "native")))]
+fn find_folded_block_child(expr: &Node, source: &str) -> Option<(Node, &'static str)> {
+    let _ = source;
+    let mut cursor = expr.walk();
+    for child in expr.children(&mut cursor) {
+        let kind = child.kind();
+
+        match kind.as_ref() {
+            "expr1_block" => return Some((child, "block")),
+            "expr1_loop" => return Some((child, "loop")),
+            "expr1_if" => return Some((child, "if")),
+            "expr1_try_table" => return Some((child, "try_table")),
+            "expr1" => {
+                let mut inner_cursor = child.walk();
+                for inner in child.children(&mut inner_cursor) {
+                    let ik = inner.kind();
+                    match ik.as_ref() {
+                        "expr1_block" => return Some((inner, "block")),
+                        "expr1_loop" => return Some((inner, "loop")),
+                        "expr1_if" => return Some((inner, "if")),
+                        "expr1_try_table" => return Some((inner, "try_table")),
+                        _ => {}
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Process a folded block expression (block, loop, if, try_table) with control frames.
+fn process_folded_block_expr(
+    expr: &Node,
+    block_node: &Node,
+    block_kind: &str,
+    source: &str,
+    symbols: &SymbolTable,
+    checker: &mut TypeChecker,
+) {
+    let opcode = match block_kind {
+        "loop" => CtrlOpcode::Loop,
+        "if" => CtrlOpcode::If,
+        "try_table" => CtrlOpcode::TryTable,
+        _ => CtrlOpcode::Block,
+    };
+
+    let label = get_block_label(block_node, source);
+    let params = get_block_param_types(block_node, source);
+    let results = get_block_result_types(block_node, source);
+
+    // For folded if, the condition sub-expressions are inside if_block.
+    // Process them on the outer stack first, then pop the i32 condition.
+    if opcode == CtrlOpcode::If {
+        process_folded_if_conditions(block_node, source, symbols, checker);
+        checker.pop_expect(&ValueType::I32, expr);
+
+        if !params.is_empty() {
+            checker.pop_vals_for_instr(&params, expr, "if");
+        }
+
+        checker.push_ctrl_labeled(CtrlOpcode::If, params, results, label);
+
+        // Process only the then/else bodies (not condition exprs again)
+        process_folded_if_bodies(block_node, source, symbols, checker);
+
+        checker.pop_ctrl(expr);
+        return;
+    }
+
+    // Pop param types from outer stack
+    if !params.is_empty() {
+        checker.pop_vals_for_instr(&params, expr, block_kind);
+    }
+
+    checker.push_ctrl_labeled(opcode, params, results, label);
+
+    // Process body - find instr_list or direct instruction children
+    process_folded_block_body(block_node, source, symbols, checker);
+
+    // Pop control frame - validates end_types and detects excess values
+    checker.pop_ctrl(expr);
+}
+
+/// Process the body of a folded block expression by finding and processing child nodes.
+fn process_folded_block_body(
+    block_node: &Node,
+    source: &str,
+    symbols: &SymbolTable,
+    checker: &mut TypeChecker,
+) {
+    let mut cursor = block_node.walk();
+    for child in block_node.children(&mut cursor) {
+        #[cfg(feature = "native")]
+        let kind = child.kind();
+        #[cfg(all(feature = "wasm", not(feature = "native")))]
+        let kind = child.kind();
+
+        match kind.as_ref() {
+            "instr_list" => {
+                // Process all instructions in the list
+                let mut list_cursor = child.walk();
+                for list_child in child.children(&mut list_cursor) {
+                    process_folded_block_child(&list_child, source, symbols, checker);
+                }
+            }
+            "if_block" => {
+                // For folded if inside a block body (shouldn't normally occur here since
+                // folded ifs are handled by process_folded_block_expr, but handle as fallback)
+                process_folded_if_bodies_from_if_block(&child, source, symbols, checker);
+            }
+            // Direct instruction children (body without instr_list wrapper)
+            "instr" | "instr_plain" | "expr" | "instr_block" | "instr_loop" | "instr_if"
+            | "instr_call" | "instr_list_call" => {
+                process_folded_block_child(&child, source, symbols, checker);
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Process a single child node in a folded block body.
+fn process_folded_block_child(
+    child: &Node,
+    source: &str,
+    symbols: &SymbolTable,
+    checker: &mut TypeChecker,
+) {
+    #[cfg(feature = "native")]
+    let kind = child.kind();
+    #[cfg(all(feature = "wasm", not(feature = "native")))]
+    let kind = child.kind();
+
+    match kind.as_ref() {
+        "instr" => {
+            process_instr_node(child, source, symbols, checker);
+        }
+        "instr_plain" => {
+            if let Some(instr_name) = get_instruction_name(child, source) {
+                process_instruction(child, &instr_name, checker, symbols, source);
+            }
+        }
+        "expr" => {
+            process_folded_expr(child, source, symbols, checker);
+        }
+        "instr_block" | "instr_loop" => {
+            process_block_node(child, source, symbols, checker);
+        }
+        "instr_if" => {
+            process_if_node(child, source, symbols, checker);
+        }
+        "instr_call" => {
+            process_instr_call_node(child, source, symbols, checker);
+        }
+        "instr_list_call" => {
+            process_call_indirect_node(child, source, symbols, checker);
+        }
+        _ => {}
+    }
+}
+
+/// Process an if_block directly (conditions + bodies), used as fallback in block body processing.
+fn process_folded_if_bodies_from_if_block(
+    if_block: &Node,
+    source: &str,
+    symbols: &SymbolTable,
+    checker: &mut TypeChecker,
+) {
+    let mut cursor = if_block.walk();
+    for child in if_block.children(&mut cursor) {
+        #[cfg(feature = "native")]
+        let kind = child.kind();
+        #[cfg(all(feature = "wasm", not(feature = "native")))]
+        let kind = child.kind();
+
+        if kind == "instr_list" {
+            let mut list_cursor = child.walk();
+            for list_child in child.children(&mut list_cursor) {
+                process_folded_block_child(&list_child, source, symbols, checker);
+            }
+        }
+    }
+}
+
+/// Process the condition sub-expressions of a folded if on the OUTER stack.
+/// These are the `expr` children inside the `if_block` that appear before `(then ...)`.
+fn process_folded_if_conditions(
+    block_node: &Node,
+    source: &str,
+    symbols: &SymbolTable,
+    checker: &mut TypeChecker,
+) {
+    // Find the if_block child of expr1_if
+    let mut cursor = block_node.walk();
+    for child in block_node.children(&mut cursor) {
+        #[cfg(feature = "native")]
+        let kind = child.kind();
+        #[cfg(all(feature = "wasm", not(feature = "native")))]
+        let kind = child.kind();
+
+        if kind == "if_block" {
+            let mut if_cursor = child.walk();
+            for if_child in child.children(&mut if_cursor) {
+                #[cfg(feature = "native")]
+                let ik = if_child.kind();
+                #[cfg(all(feature = "wasm", not(feature = "native")))]
+                let ik = if_child.kind();
+
+                // Process condition expr children on the outer stack
+                if ik == "expr" {
+                    process_folded_expr(&if_child, source, symbols, checker);
+                }
+            }
+        }
+    }
+}
+
+/// Process only the then/else bodies of a folded if (not the condition exprs).
+/// Uses else_transition to properly reset the stack between then and else branches.
+fn process_folded_if_bodies(
+    block_node: &Node,
+    source: &str,
+    symbols: &SymbolTable,
+    checker: &mut TypeChecker,
+) {
+    // Find the if_block child of expr1_if
+    let mut cursor = block_node.walk();
+    for child in block_node.children(&mut cursor) {
+        #[cfg(feature = "native")]
+        let kind = child.kind();
+        #[cfg(all(feature = "wasm", not(feature = "native")))]
+        let kind = child.kind();
+
+        if kind == "if_block" {
+            let mut found_then = false;
+            let mut if_cursor = child.walk();
+            for if_child in child.children(&mut if_cursor) {
+                #[cfg(feature = "native")]
+                let ik = if_child.kind();
+                #[cfg(all(feature = "wasm", not(feature = "native")))]
+                let ik = if_child.kind();
+
+                if ik == "instr_list" {
+                    if !found_then {
+                        // Process then body
+                        let mut list_cursor = if_child.walk();
+                        for list_child in if_child.children(&mut list_cursor) {
+                            process_folded_block_child(&list_child, source, symbols, checker);
+                        }
+                        found_then = true;
+                        // Perform else transition: validate then, reset stack for else
+                        checker.else_transition(&if_child);
+                    } else {
+                        // Process else body
+                        let mut list_cursor = if_child.walk();
+                        for list_child in if_child.children(&mut list_cursor) {
+                            process_folded_block_child(&list_child, source, symbols, checker);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 /// Process a folded expression: consume implicit stack operands, produce results
 fn process_folded_expr(
     expr: &Node,
@@ -1672,6 +2084,13 @@ fn process_folded_expr(
     symbols: &SymbolTable,
     checker: &mut TypeChecker,
 ) {
+    // Check if this is a block-type expression (block, loop, if, try_table)
+    // These need control frame tracking for proper stack validation.
+    if let Some((block_node, block_kind)) = find_folded_block_child(expr, source) {
+        process_folded_block_expr(expr, &block_node, block_kind, source, symbols, checker);
+        return;
+    }
+
     if let Some((instr_name, explicit_operands)) = get_folded_expr_info(expr, source) {
         // Handle tail call instructions
         if matches!(
@@ -1693,8 +2112,74 @@ fn process_folded_expr(
             return;
         }
 
-        // Handle other terminating instructions
+        // Handle other terminating instructions (br, unreachable, return, throw, throw_ref)
         if is_terminating_instruction(&instr_name) {
+            // For folded br: (br $label values...)
+            // Need to consume label types from sub-expressions
+            if instr_name == "br" {
+                if let Some(instr_node) = find_instr_plain_in_expr(expr) {
+                    if let Some(depth) = get_branch_depth(&instr_node, source, checker) {
+                        if let Some(label_types) = checker.label_types(depth) {
+                            let label_count = label_types.len();
+                            // Sub-expressions provide label values; check if we need more from stack
+                            let from_stack = label_count.saturating_sub(explicit_operands);
+                            if from_stack > 0 {
+                                let consumed = vec![ValueType::Unknown; from_stack];
+                                checker.pop_vals_for_instr(&consumed, expr, &instr_name);
+                            }
+                        }
+                    }
+                }
+            }
+            checker.mark_unreachable();
+            return;
+        }
+
+        // Handle folded branch instructions with label types
+        if instr_name == "br_if" {
+            // (br_if $label value... condition)
+            // Consumes: label_types + i32 condition
+            // Produces: label_types (pushed back on fall-through)
+            if let Some(instr_node) = find_instr_plain_in_expr(expr) {
+                if let Some(depth) = get_branch_depth(&instr_node, source, checker) {
+                    if let Some(label_types) = checker.label_types(depth) {
+                        let label_types = label_types.to_vec();
+                        let total_expected = label_types.len() + 1; // label types + condition
+                        let from_stack = total_expected.saturating_sub(explicit_operands);
+                        if from_stack > 0 {
+                            let consumed = vec![ValueType::Unknown; from_stack];
+                            checker.pop_vals_for_instr(&consumed, expr, &instr_name);
+                        }
+                        // Push label types back for fall-through path
+                        checker.push_vals(&label_types);
+                        return;
+                    }
+                }
+            }
+            // Fallback: no label resolution, treat as consuming 1 (condition) producing 0
+            let from_stack = 1usize.saturating_sub(explicit_operands);
+            if from_stack > 0 {
+                checker.pop_vals_for_instr(&[ValueType::I32], expr, &instr_name);
+            }
+            return;
+        }
+
+        if instr_name == "br_table" {
+            // (br_table 0 1 2 default condition) — consumes label_types + i32 index
+            if let Some(instr_node) = find_instr_plain_in_expr(expr) {
+                let depths = get_all_branch_depths(&instr_node, source, checker);
+                if let Some(&default_depth) = depths.last() {
+                    if let Some(label_types) = checker.label_types(default_depth) {
+                        let label_count = label_types.len();
+                        let total_expected = label_count + 1; // label types + index
+                        let from_stack = total_expected.saturating_sub(explicit_operands);
+                        if from_stack > 0 {
+                            let consumed = vec![ValueType::Unknown; from_stack];
+                            checker.pop_vals_for_instr(&consumed, expr, &instr_name);
+                        }
+                    }
+                }
+            }
             checker.mark_unreachable();
             return;
         }
@@ -1707,12 +2192,6 @@ fn process_folded_expr(
             let consumed = vec![ValueType::Unknown; from_stack];
             checker.pop_vals_for_instr(&consumed, expr, &instr_name);
         }
-    }
-
-    // For block expressions, consume param types from outer stack
-    let block_params = get_block_param_types_from_expr(expr, source);
-    if !block_params.is_empty() {
-        checker.pop_vals(&block_params, expr);
     }
 
     // Check if expression always terminates
@@ -1869,44 +2348,6 @@ pub fn get_block_result_types(block_node: &Node, source: &str) -> Vec<ValueType>
 }
 
 /// Get block param types from a folded expression (expr node)
-fn get_block_param_types_from_expr(expr: &Node, source: &str) -> Vec<ValueType> {
-    let mut cursor = expr.walk();
-    for child in expr.children(&mut cursor) {
-        #[cfg(feature = "native")]
-        let kind = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let kind = child.kind();
-
-        if kind == "expr1_block"
-            || kind == "expr1_loop"
-            || kind == "expr1_if"
-            || kind == "expr1_try_table"
-            || kind == "expr1_try"
-        {
-            return get_block_param_types(&child, source);
-        }
-        if kind == "expr1" {
-            let mut inner_cursor = child.walk();
-            for inner_child in child.children(&mut inner_cursor) {
-                #[cfg(feature = "native")]
-                let inner_kind = inner_child.kind();
-                #[cfg(all(feature = "wasm", not(feature = "native")))]
-                let inner_kind = inner_child.kind();
-
-                if inner_kind == "expr1_block"
-                    || inner_kind == "expr1_loop"
-                    || inner_kind == "expr1_if"
-                    || inner_kind == "expr1_try_table"
-                    || inner_kind == "expr1_try"
-                {
-                    return get_block_param_types(&inner_child, source);
-                }
-            }
-        }
-    }
-    vec![]
-}
-
 /// Get param types from a block/loop/if node
 pub fn get_block_param_types(block_node: &Node, source: &str) -> Vec<ValueType> {
     let mut types = Vec::new();

--- a/src/diagnostics_core/type_check.rs
+++ b/src/diagnostics_core/type_check.rs
@@ -37,6 +37,8 @@ pub struct CtrlFrame {
     pub height: usize,
     /// True after unreachable/br/return — polymorphic stack bottom
     pub unreachable: bool,
+    /// Optional label name (e.g., "$loop1") for named branch resolution
+    pub label: Option<String>,
 }
 
 /// Core type checker state machine implementing Wasm spec validation.
@@ -389,6 +391,17 @@ impl TypeChecker {
         start_types: Vec<ValueType>,
         end_types: Vec<ValueType>,
     ) {
+        self.push_ctrl_labeled(opcode, start_types, end_types, None);
+    }
+
+    /// Enter a new control frame with an optional label name for named branch resolution.
+    pub fn push_ctrl_labeled(
+        &mut self,
+        opcode: CtrlOpcode,
+        start_types: Vec<ValueType>,
+        end_types: Vec<ValueType>,
+        label: Option<String>,
+    ) {
         let height = self.val_stack.len();
         self.ctrl_stack.push(CtrlFrame {
             opcode,
@@ -396,6 +409,7 @@ impl TypeChecker {
             end_types,
             height,
             unreachable: false,
+            label,
         });
         // Push start_types onto val_stack (block params become initial stack)
         self.push_vals(&start_types);
@@ -443,6 +457,47 @@ impl TypeChecker {
         Some(frame)
     }
 
+    /// Handle the else transition in an if block.
+    /// Validates the then branch produced end_types, resets stack to frame height,
+    /// and pushes start_types for the else branch.
+    pub fn else_transition(&mut self, node: &Node) {
+        if let Some(frame) = self.ctrl_stack.last() {
+            let end_types = frame.end_types.clone();
+            let start_types = frame.start_types.clone();
+            let height = frame.height;
+            let was_unreachable = frame.unreachable;
+
+            // Validate then branch produced the expected end types
+            if !was_unreachable {
+                self.pop_vals(&end_types, node);
+                // Check for excess values
+                if self.val_stack.len() > height {
+                    let extra = self.val_stack.len() - height;
+                    let range = node_to_range(node);
+                    self.diagnostics.push(
+                        Diagnostic::error(
+                            range,
+                            format!(
+                                "type mismatch: block leaves {} extra value(s) on stack",
+                                extra
+                            ),
+                        )
+                        .with_code("type-mismatch"),
+                    );
+                }
+            }
+
+            // Reset stack to frame height + start_types for else branch
+            self.val_stack.truncate(height);
+            self.push_vals(&start_types);
+
+            // Reset unreachable flag for else branch
+            if let Some(frame) = self.ctrl_stack.last_mut() {
+                frame.unreachable = false;
+            }
+        }
+    }
+
     /// Mark the current frame as unreachable.
     /// Truncates val_stack to frame height (polymorphic bottom).
     pub fn mark_unreachable(&mut self) {
@@ -475,6 +530,19 @@ impl TypeChecker {
             .last()
             .map(|f| f.unreachable)
             .unwrap_or(false)
+    }
+
+    /// Resolve a named label (e.g., "$loop1") to a control stack depth.
+    /// Returns the depth (0 = current frame) if found.
+    pub fn resolve_label_depth(&self, label: &str) -> Option<usize> {
+        for (i, frame) in self.ctrl_stack.iter().rev().enumerate() {
+            if let Some(ref name) = frame.label {
+                if name == label {
+                    return Some(i);
+                }
+            }
+        }
+        None
     }
 
     /// Get the current stack depth above the current frame height.


### PR DESCRIPTION
## Summary

- **Folded block type checking**: Added control frame tracking (`push_ctrl`/`pop_ctrl`) for folded block expressions (`(block ...)`, `(loop ...)`, `(if ...)`). Detects excess values on stack at block end and handles if/else stack transitions correctly.
- **Branch stack tracking**: `br`, `br_if`, and `br_table` now properly consume typed label values from the stack. Named label resolution added for branch targets.
- **ref.func declaration validation**: New module-level check ensures functions used with `ref.func` are declared in element segments (spec requirement).
- **Elem segment collection fix**: Fixed `collect_elem_declared_funcs` to fully recurse into expression-form elem entries (`(ref.func $name)`).
- **Playground example fixes**: Fixed `call_ref_type_annotation.wat`, `strings_data.wat`, and `trapping.wat` to pass `wasm-tools validate`.