### PR TITLE
feat: add elem segment type checks, type forward refs, implicit type resolution, and validation fixes

### DIFF
--- a/src/bin/wast-runner.rs
+++ b/src/bin/wast-runner.rs
@@ -121,13 +121,27 @@ struct GlobalSummary {
 // ---------------------------------------------------------------------------
 
 /// Find the matching close paren starting from an offset that points at or before '('.
+/// Skips block comments `(; ... ;)` (including nested ones) and line comments `;;`.
 fn find_matching_close_paren(source: &str, start: usize) -> Option<usize> {
     let bytes = source.as_bytes();
     // Find the opening paren at or after start
     let open = bytes.iter().skip(start).position(|&b| b == b'(')? + start;
     let mut depth = 0i32;
-    for (i, &byte) in bytes.iter().enumerate().skip(open) {
-        match byte {
+    let mut i = open;
+    while i < bytes.len() {
+        if i + 1 < bytes.len() && bytes[i] == b'(' && bytes[i + 1] == b';' {
+            // Block comment — skip, handling nesting
+            i = skip_block_comment(bytes, i)?;
+            continue;
+        }
+        if i + 1 < bytes.len() && bytes[i] == b';' && bytes[i + 1] == b';' {
+            // Line comment — skip to end of line
+            while i < bytes.len() && bytes[i] != b'\n' {
+                i += 1;
+            }
+            continue;
+        }
+        match bytes[i] {
             b'(' => depth += 1,
             b')' => {
                 depth -= 1;
@@ -137,8 +151,67 @@ fn find_matching_close_paren(source: &str, start: usize) -> Option<usize> {
             }
             _ => {}
         }
+        i += 1;
     }
     None
+}
+
+/// Walk backward from end of `text` to find the opening `(` that is NOT part of a block comment.
+fn rfind_open_paren_skip_comments(text: &str) -> Option<usize> {
+    let bytes = text.as_bytes();
+    let mut i = bytes.len();
+    while i > 0 {
+        i -= 1;
+        // Check for block comment end `;)` — walk backwards to find matching `(;`
+        if i > 0 && bytes[i] == b')' && bytes[i - 1] == b';' {
+            // Skip this block comment backwards
+            let mut depth = 1;
+            i -= 2; // Skip `;)`
+            while i > 0 && depth > 0 {
+                if bytes[i] == b';' && i > 0 && bytes[i - 1] == b'(' {
+                    depth -= 1;
+                    if depth > 0 {
+                        i -= 2;
+                    } else {
+                        i -= 1; // Move past the `(` of `(;`, then continue search
+                    }
+                } else if bytes[i] == b')' && i > 0 && bytes[i - 1] == b';' {
+                    depth += 1;
+                    i -= 2;
+                } else {
+                    i -= 1;
+                }
+            }
+            continue;
+        }
+        if bytes[i] == b'(' {
+            return Some(i);
+        }
+    }
+    None
+}
+
+/// Skip a block comment `(; ... ;)`, handling nested block comments.
+/// Returns the position right after the closing `;)`.
+fn skip_block_comment(bytes: &[u8], start: usize) -> Option<usize> {
+    let mut depth = 1;
+    let mut i = start + 2; // Skip opening `(;`
+    while i + 1 < bytes.len() && depth > 0 {
+        if bytes[i] == b'(' && bytes[i + 1] == b';' {
+            depth += 1;
+            i += 2;
+        } else if bytes[i] == b';' && bytes[i + 1] == b')' {
+            depth -= 1;
+            i += 2;
+        } else {
+            i += 1;
+        }
+    }
+    if depth == 0 {
+        Some(i)
+    } else {
+        None
+    }
 }
 
 /// Extract the WAT text for a QuoteWat directive from the original source.
@@ -148,7 +221,8 @@ fn extract_wat_text<'a>(qw: &wast::QuoteWat<'a>, source: &'a str) -> Option<Stri
             let span = wat.span();
             let offset = span.offset();
             // span points to 'module' or 'component' keyword — walk back to '('
-            let start = source[..offset].rfind('(')?;
+            // Must skip block comments like `(;comment;)` when searching backwards
+            let start = rfind_open_paren_skip_comments(&source[..offset])?;
             let end = find_matching_close_paren(source, start)?;
             Some(source[start..=end].to_string())
         }

--- a/src/diagnostics/semantic_diagnostics.rs
+++ b/src/diagnostics/semantic_diagnostics.rs
@@ -983,11 +983,9 @@ mod tests {
   (table 1 funcref)
   (elem (i32.const 0) $inc)
 
-  (func (export "dispatch") (param $i i32) (param $x i32) (result i32)
-    local.get $i
-    ref.func $inc
-    drop
+  (func (export "dispatch") (param $x i32) (result i32)
     local.get $x
+    ref.func $inc
     call_ref $t)
 )"#;
 

--- a/src/diagnostics_core/alignment_checks.rs
+++ b/src/diagnostics_core/alignment_checks.rs
@@ -21,6 +21,7 @@ pub fn check_alignment(node: &Node, source: &str) -> Vec<Diagnostic> {
     let mut diagnostics = Vec::new();
     let mut instr_name = None;
     let mut align_node = None;
+    let mut offset_node = None;
 
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
@@ -39,17 +40,32 @@ pub fn check_alignment(node: &Node, source: &str) -> Vec<Diagnostic> {
             "align_value" => {
                 align_node = Some(child);
             }
+            "offset_value" => {
+                offset_node = Some(child);
+            }
             _ => {}
         }
     }
 
-    // Only check if we have both a memory instruction and an align_value
+    // Check offset range (must fit in u32 for memory32)
+    if let Some(ref offset_nd) = offset_node {
+        if let Some(offset) = parse_offset_value(offset_nd, source) {
+            if offset > u32::MAX as u64 {
+                diagnostics.push(Diagnostic::error(
+                    node_to_range(offset_nd),
+                    "offset out of range".to_string(),
+                ));
+            }
+        }
+    }
+
+    // Only check alignment if we have both a memory instruction and an align_value
     let (Some(instr), Some(align_nd)) = (instr_name, align_node) else {
         return diagnostics;
     };
 
-    // Extract the numeric value from align_offset_value child
-    let align_val = parse_align_value(&align_nd, source);
+    // Extract the numeric value (u64 to detect overflow)
+    let align_val = parse_align_value_u64(&align_nd, source);
     let Some(align) = align_val else {
         return diagnostics;
     };
@@ -65,7 +81,7 @@ pub fn check_alignment(node: &Node, source: &str) -> Vec<Diagnostic> {
 
     // Check against natural alignment
     if let Some(natural) = natural_alignment(&instr) {
-        if align > natural {
+        if align > natural as u64 {
             diagnostics.push(Diagnostic::error(
                 node_to_range(&align_nd),
                 "alignment must not be larger than natural".to_string(),
@@ -76,9 +92,8 @@ pub fn check_alignment(node: &Node, source: &str) -> Vec<Diagnostic> {
     diagnostics
 }
 
-/// Parse the numeric alignment value from an `align_value` node.
-/// The node structure is: `align_value` -> `align_offset_value` (child with the number).
-fn parse_align_value(node: &Node, source: &str) -> Option<u32> {
+/// Parse the alignment value as u64 to detect values that overflow u32.
+fn parse_align_value_u64(node: &Node, source: &str) -> Option<u64> {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         let kind = child.kind();
@@ -89,23 +104,40 @@ fn parse_align_value(node: &Node, source: &str) -> Option<u32> {
 
         if kind_ref == "align_offset_value" {
             let text = &source[child.byte_range()];
-            return parse_alignment_number(text);
+            return parse_number_u64(text);
         }
     }
     None
 }
 
-/// Parse an alignment number, handling both decimal and hex formats.
-/// Underscores are allowed as digit separators.
-fn parse_alignment_number(text: &str) -> Option<u32> {
+/// Parse the numeric offset value from an `offset_value` node.
+fn parse_offset_value(node: &Node, source: &str) -> Option<u64> {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        let kind = child.kind();
+        #[cfg(feature = "native")]
+        let kind_ref = kind;
+        #[cfg(all(feature = "wasm", not(feature = "native")))]
+        let kind_ref = &*kind;
+
+        if kind_ref == "align_offset_value" {
+            let text = &source[child.byte_range()];
+            return parse_number_u64(text);
+        }
+    }
+    None
+}
+
+/// Parse a number as u64, handling decimal and hex formats with underscore separators.
+fn parse_number_u64(text: &str) -> Option<u64> {
     let cleaned: String = text.chars().filter(|c| *c != '_').collect();
     if let Some(hex) = cleaned
         .strip_prefix("0x")
         .or_else(|| cleaned.strip_prefix("0X"))
     {
-        u32::from_str_radix(hex, 16).ok()
+        u64::from_str_radix(hex, 16).ok()
     } else {
-        cleaned.parse::<u32>().ok()
+        cleaned.parse::<u64>().ok()
     }
 }
 
@@ -290,13 +322,14 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_alignment_number() {
-        assert_eq!(parse_alignment_number("1"), Some(1));
-        assert_eq!(parse_alignment_number("4"), Some(4));
-        assert_eq!(parse_alignment_number("16"), Some(16));
-        assert_eq!(parse_alignment_number("0x10"), Some(16));
-        assert_eq!(parse_alignment_number("0x1"), Some(1));
-        assert_eq!(parse_alignment_number("1_000"), Some(1000));
+    fn test_parse_number_u64() {
+        assert_eq!(parse_number_u64("1"), Some(1));
+        assert_eq!(parse_number_u64("4"), Some(4));
+        assert_eq!(parse_number_u64("16"), Some(16));
+        assert_eq!(parse_number_u64("0x10"), Some(16));
+        assert_eq!(parse_number_u64("0x1"), Some(1));
+        assert_eq!(parse_number_u64("1_000"), Some(1000));
+        assert_eq!(parse_number_u64("0x1_0000_0000"), Some(0x100000000));
     }
 
     #[cfg(feature = "native")]

--- a/src/diagnostics_core/module_checks.rs
+++ b/src/diagnostics_core/module_checks.rs
@@ -56,11 +56,15 @@ pub fn validate_module_structure(
         check_global_forward_refs(&module_node, source, symbols, &mut diagnostics);
         check_data_segment_memory_indices(&module_node, source, symbols, &mut diagnostics);
         check_elem_segment_table_indices(&module_node, source, symbols, &mut diagnostics);
+        check_elem_segment_types(&module_node, source, symbols, &mut diagnostics);
         check_ref_func_declarations(&module_node, source, symbols, &mut diagnostics);
         check_unknown_type_refs(&module_node, source, symbols, &mut diagnostics);
+        check_type_forward_refs(&module_node, source, symbols, &mut diagnostics);
         check_block_type_use_mismatches(&module_node, source, symbols, &mut diagnostics);
         check_table_non_nullable_refs(&module_node, source, &mut diagnostics);
         check_implicit_memory_refs(&module_node, source, symbols, &mut diagnostics);
+        check_call_indirect_table_requirements(&module_node, source, symbols, &mut diagnostics);
+        check_inline_elem_func_refs(&module_node, source, symbols, &mut diagnostics);
     }
 
     diagnostics
@@ -795,6 +799,7 @@ fn check_constant_expressions(
     symbols: &SymbolTable,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
+    let mut global_index = symbols.num_imported_globals;
     for_each_module_field(module, |field| {
         let fk = field.kind();
         #[cfg(all(feature = "wasm", not(feature = "native")))]
@@ -803,7 +808,9 @@ fn check_constant_expressions(
         match fk {
             "module_field_global" => {
                 // Check instructions after global_type
-                check_global_init_expr(field, source, symbols, diagnostics);
+                // In global init: only globals with index < current are available
+                check_global_init_expr(field, source, symbols, global_index, diagnostics);
+                global_index += 1;
             }
             "module_field_data" => {
                 // Check offset expression
@@ -827,6 +834,7 @@ fn check_global_init_expr(
     node: &Node,
     source: &str,
     symbols: &SymbolTable,
+    global_index: usize,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
     // Global: (global $id? type init_expr...)
@@ -842,7 +850,8 @@ fn check_global_init_expr(
             continue;
         }
         if past_global_type {
-            check_const_instruction_tree(&child, source, symbols, diagnostics);
+            // In global init: allow imported + earlier module-defined globals
+            check_const_instruction_tree(&child, source, symbols, global_index, diagnostics);
         }
     }
 }
@@ -853,13 +862,15 @@ fn check_offset_expr(
     symbols: &SymbolTable,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
+    // Data/elem offsets: all defined globals are available
+    let max_global = symbols.globals.len();
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         let ck = child.kind();
         #[cfg(all(feature = "wasm", not(feature = "native")))]
         let ck = ck.as_str();
         if ck == "offset" {
-            check_const_instruction_tree(&child, source, symbols, diagnostics);
+            check_const_instruction_tree(&child, source, symbols, max_global, diagnostics);
         }
     }
 }
@@ -870,13 +881,24 @@ fn check_elem_exprs(
     symbols: &SymbolTable,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
+    // Elem expressions: all defined globals are available
+    let max_global = symbols.globals.len();
+    // elem_expr nodes are inside elem_list, not direct children of module_field_elem
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         let ck = child.kind();
         #[cfg(all(feature = "wasm", not(feature = "native")))]
         let ck = ck.as_str();
-        if ck == "elem_expr" {
-            check_const_instruction_tree(&child, source, symbols, diagnostics);
+        if ck == "elem_list" {
+            let mut inner = child.walk();
+            for gc in child.children(&mut inner) {
+                let gk = gc.kind();
+                #[cfg(all(feature = "wasm", not(feature = "native")))]
+                let gk = gk.as_str();
+                if gk == "elem_expr" {
+                    check_const_instruction_tree(&gc, source, symbols, max_global, diagnostics);
+                }
+            }
         }
     }
 }
@@ -887,6 +909,8 @@ fn check_table_init_expr(
     symbols: &SymbolTable,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
+    // Table init: only imported globals (tables come before globals in binary format)
+    let max_global = symbols.num_imported_globals;
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         let ck = child.kind();
@@ -900,7 +924,7 @@ fn check_table_init_expr(
                 #[cfg(all(feature = "wasm", not(feature = "native")))]
                 let gk = gk.as_str();
                 if gk == "expr" {
-                    check_const_instruction_tree(&gc, source, symbols, diagnostics);
+                    check_const_instruction_tree(&gc, source, symbols, max_global, diagnostics);
                 }
             }
         }
@@ -908,10 +932,12 @@ fn check_table_init_expr(
 }
 
 /// Recursively check that all instructions in a tree are constant expressions.
+/// `max_allowed_global`: maximum global index that can be referenced by global.get.
 fn check_const_instruction_tree(
     node: &Node,
     source: &str,
     symbols: &SymbolTable,
+    max_allowed_global: usize,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
     let kind = node.kind();
@@ -929,7 +955,7 @@ fn check_const_instruction_tree(
                     format!("Constant expression required, but found '{}'", first_token),
                 ));
             } else if first_token == "global.get" {
-                check_global_get_in_const(node, source, symbols, diagnostics);
+                check_global_get_in_const(node, source, symbols, max_allowed_global, diagnostics);
             }
             return;
         }
@@ -949,13 +975,33 @@ fn check_const_instruction_tree(
                             format!("Constant expression required, but found '{}'", first_token),
                         ));
                     } else if first_token == "global.get" {
-                        check_global_get_in_const(&child, source, symbols, diagnostics);
+                        check_global_get_in_const(
+                            &child,
+                            source,
+                            symbols,
+                            max_allowed_global,
+                            diagnostics,
+                        );
                     }
                 } else if ck == "expr" {
                     // Check nested expressions for constness too
-                    check_const_instruction_tree(&child, source, symbols, diagnostics);
+                    check_const_instruction_tree(
+                        &child,
+                        source,
+                        symbols,
+                        max_allowed_global,
+                        diagnostics,
+                    );
                 }
             }
+            return;
+        }
+        // call/call_indirect instructions are never valid in const expressions
+        "instr_call" | "expr1_call" | "instr_list_call" => {
+            diagnostics.push(
+                Diagnostic::error(node_to_range(node), "constant expression required")
+                    .with_code("constant-expression-required"),
+            );
             return;
         }
         // block/if/loop instructions are never valid in const expressions
@@ -972,15 +1018,16 @@ fn check_const_instruction_tree(
     // Recurse into children
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        check_const_instruction_tree(&child, source, symbols, diagnostics);
+        check_const_instruction_tree(&child, source, symbols, max_allowed_global, diagnostics);
     }
 }
 
-/// Check that global.get in a constant expression references an immutable imported global.
+/// Check that global.get in a constant expression references a valid global.
 fn check_global_get_in_const(
     instr_node: &Node,
     source: &str,
     symbols: &SymbolTable,
+    max_allowed_global: usize,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
     // Find the index/identifier child
@@ -1020,9 +1067,16 @@ fn check_global_get_in_const(
                         node_to_range(instr_node),
                         "constant expression required: global.get of mutable global",
                     ));
+                } else if global.index >= max_allowed_global {
+                    // global.get can only reference globals defined before this point
+                    diagnostics.push(
+                        Diagnostic::error(
+                            node_to_range(instr_node),
+                            format!("unknown global {}", global.index),
+                        )
+                        .with_code("unknown-global"),
+                    );
                 }
-                // Note: extended const expressions (now part of the spec) allow
-                // global.get of any immutable global, not just imported ones.
             }
             return;
         }
@@ -1166,6 +1220,300 @@ fn check_elem_segment_table_indices(
 }
 
 // ============================================================================
+// Element segment type validation
+// ============================================================================
+
+/// Validate elem segment item types against declared elem type and target table type.
+fn check_elem_segment_types(
+    module: &Node,
+    source: &str,
+    symbols: &SymbolTable,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    for_each_module_field(module, |field| {
+        let fk = field.kind();
+        #[cfg(all(feature = "wasm", not(feature = "native")))]
+        let fk = fk.as_str();
+        if fk != "module_field_elem" {
+            return;
+        }
+
+        // Extract declared elem type from elem_list (e.g. funcref, externref)
+        let mut elem_type: Option<ValueType> = None;
+        let mut table_idx: Option<usize> = None;
+        let mut has_offset = false;
+
+        let mut cursor = field.walk();
+        for child in field.children(&mut cursor) {
+            let ck = child.kind();
+            #[cfg(all(feature = "wasm", not(feature = "native")))]
+            let ck = ck.as_str();
+
+            if ck == "offset" {
+                has_offset = true;
+            }
+            if ck == "table_use" {
+                let mut tc = child.walk();
+                for tc_child in child.children(&mut tc) {
+                    let tk = tc_child.kind();
+                    #[cfg(all(feature = "wasm", not(feature = "native")))]
+                    let tk = tk.as_str();
+                    if tk == "index" || tk == "identifier" || tk == "nat" {
+                        let text = node_text(&tc_child, source);
+                        if text.starts_with('$') {
+                            if let Some(tbl) = symbols.get_table_by_name(text.trim()) {
+                                table_idx = Some(tbl.index);
+                            }
+                        } else if let Ok(idx) = text.trim().parse::<usize>() {
+                            table_idx = Some(idx);
+                        }
+                    }
+                }
+            }
+            if ck == "elem_list" {
+                // Extract ref_type from elem_list
+                let mut ec = child.walk();
+                for ec_child in child.children(&mut ec) {
+                    let ek = ec_child.kind();
+                    #[cfg(all(feature = "wasm", not(feature = "native")))]
+                    let ek = ek.as_str();
+                    if ek == "ref_type" || ek == "value_type" {
+                        let text = node_text(&ec_child, source);
+                        elem_type = ValueType::try_parse(text.trim());
+                    }
+                }
+            }
+            // Also check for ref_type directly on the elem segment node
+            if ck == "ref_type" && elem_type.is_none() {
+                let text = node_text(&child, source);
+                elem_type = ValueType::try_parse(text.trim());
+            }
+        }
+
+        // Old-style elem segments without explicit type default to funcref
+        let elem_type = elem_type.unwrap_or(ValueType::Funcref);
+
+        // Check 1: elem type vs target table type (for active segments)
+        if has_offset {
+            let tbl_idx = table_idx.unwrap_or(0);
+            if let Some(table) = symbols.tables.get(tbl_idx) {
+                if !elem_ref_compatible(&elem_type, &table.ref_type) {
+                    diagnostics.push(
+                        Diagnostic::error(node_to_range(field), "type mismatch")
+                            .with_code("type-mismatch"),
+                    );
+                }
+            }
+        }
+
+        // Check 2: validate each elem expression item against the declared elem type
+        let mut cursor2 = field.walk();
+        for child in field.children(&mut cursor2) {
+            let ck = child.kind();
+            #[cfg(all(feature = "wasm", not(feature = "native")))]
+            let ck = ck.as_str();
+
+            if ck == "elem_list" {
+                check_elem_list_items(&child, &elem_type, source, symbols, diagnostics);
+            }
+        }
+    });
+}
+
+/// Check if elem ref type is compatible with table element type.
+fn elem_ref_compatible(elem_type: &ValueType, table_type: &ValueType) -> bool {
+    use ValueType::*;
+    if elem_type == table_type {
+        return true;
+    }
+    match (elem_type, table_type) {
+        // funcref subtypes match funcref or non-nullable funcref types
+        (Funcref | NullFuncref | Ref(_) | RefNull(_), Funcref | Ref(_) | RefNull(_)) => true,
+        // externref subtypes match externref
+        (Externref | NullExternref, Externref) => true,
+        // Cross-hierarchy is always incompatible
+        (Funcref | NullFuncref | Ref(_) | RefNull(_), Externref) => false,
+        (Externref | NullExternref, Funcref | Ref(_) | RefNull(_)) => false,
+        // For types we can't resolve (Structref fallback, etc.), be permissive
+        _ => true,
+    }
+}
+
+/// Check items in an elem_list against the declared elem type.
+fn check_elem_list_items(
+    elem_list: &Node,
+    declared_type: &ValueType,
+    source: &str,
+    symbols: &SymbolTable,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let mut cursor = elem_list.walk();
+    for child in elem_list.children(&mut cursor) {
+        let ck = child.kind();
+        #[cfg(all(feature = "wasm", not(feature = "native")))]
+        let ck = ck.as_str();
+
+        if ck == "elem_expr" {
+            check_single_elem_expr(&child, declared_type, source, symbols, diagnostics);
+        }
+    }
+}
+
+/// Check a single elem expression against the declared elem type.
+fn check_single_elem_expr(
+    elem_expr: &Node,
+    declared_type: &ValueType,
+    source: &str,
+    _symbols: &SymbolTable,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    // Count instruction-producing expressions
+    let mut instr_count = 0;
+    let mut inferred_type: Option<ValueType> = None;
+
+    let mut cursor = elem_expr.walk();
+    for child in elem_expr.children(&mut cursor) {
+        let ck = child.kind();
+        #[cfg(all(feature = "wasm", not(feature = "native")))]
+        let ck = ck.as_str();
+
+        match ck {
+            "elem_expr_item" => {
+                // (item instr...) — count instructions inside
+                let mut item_instrs = 0;
+                let mut item_type: Option<ValueType> = None;
+                let mut ic = child.walk();
+                for item_child in child.children(&mut ic) {
+                    if let Some(ty) = infer_elem_instr_type(&item_child, source) {
+                        item_instrs += 1;
+                        item_type = Some(ty);
+                    }
+                }
+                if item_instrs > 1 {
+                    diagnostics.push(
+                        Diagnostic::error(node_to_range(elem_expr), "type mismatch")
+                            .with_code("type-mismatch"),
+                    );
+                    return;
+                }
+                if let Some(ref ty) = item_type {
+                    if !ref_type_matches(ty, declared_type) {
+                        diagnostics.push(
+                            Diagnostic::error(node_to_range(elem_expr), "type mismatch")
+                                .with_code("type-mismatch"),
+                        );
+                    }
+                }
+                return;
+            }
+            "elem_expr_expr" | "expr" => {
+                instr_count += 1;
+                inferred_type = infer_elem_expr_type(&child, source);
+            }
+            _ => {}
+        }
+    }
+
+    if instr_count > 1 {
+        diagnostics.push(
+            Diagnostic::error(node_to_range(elem_expr), "type mismatch").with_code("type-mismatch"),
+        );
+        return;
+    }
+    if let Some(ref ty) = inferred_type {
+        if !ref_type_matches(ty, declared_type) {
+            diagnostics.push(
+                Diagnostic::error(node_to_range(elem_expr), "type mismatch")
+                    .with_code("type-mismatch"),
+            );
+        }
+    }
+}
+
+/// Infer the type produced by an instruction in an elem context.
+/// Returns None for non-instruction nodes (parens, keywords, etc.)
+fn infer_elem_instr_type(node: &Node, source: &str) -> Option<ValueType> {
+    let kind = node.kind();
+    #[cfg(all(feature = "wasm", not(feature = "native")))]
+    let kind = kind.as_str();
+
+    match kind {
+        "instr_plain" | "expr1_plain" => {
+            let text = node_text(node, source);
+            let first_token = text.split_whitespace().next()?;
+            infer_const_instr_result_type(first_token, &text)
+        }
+        "expr" | "expr1" | "instr" => {
+            // Recurse to find the instruction inside
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                if let Some(ty) = infer_elem_instr_type(&child, source) {
+                    return Some(ty);
+                }
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
+/// Infer the result type of an elem expression (which is an expr node).
+fn infer_elem_expr_type(node: &Node, source: &str) -> Option<ValueType> {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if let Some(ty) = infer_elem_instr_type(&child, source) {
+            return Some(ty);
+        }
+    }
+    None
+}
+
+/// Infer the result type of a const instruction by its name and full text.
+fn infer_const_instr_result_type(name: &str, full_text: &str) -> Option<ValueType> {
+    match name {
+        "ref.func" => Some(ValueType::Funcref),
+        "ref.null" => {
+            // Determine null type from argument: ref.null func, ref.null extern, etc.
+            let arg = full_text.split_whitespace().nth(1).unwrap_or("func");
+            match arg {
+                "extern" | "noextern" => Some(ValueType::Externref),
+                _ => Some(ValueType::Funcref), // func, nofunc, and concrete types
+            }
+        }
+        "i32.const" => Some(ValueType::I32),
+        "i64.const" => Some(ValueType::I64),
+        "f32.const" => Some(ValueType::F32),
+        "f64.const" => Some(ValueType::F64),
+        _ => None,
+    }
+}
+
+/// Check if a value type matches the declared elem ref type.
+fn ref_type_matches(actual: &ValueType, expected: &ValueType) -> bool {
+    use ValueType::*;
+    if actual == expected {
+        return true;
+    }
+    match (actual, expected) {
+        // funcref (from ref.null or ref.func) matches funcref
+        (Funcref, Funcref) => true,
+        (NullFuncref, Funcref) => true,
+        // externref matches externref
+        (Externref, Externref) => true,
+        (NullExternref, Externref) => true,
+        // funcref subtypes match funcref
+        (Ref(_) | RefNull(_), Funcref) => true,
+        // non-ref types don't match ref types
+        (I32 | I64 | F32 | F64 | V128, _) => false,
+        // funcref doesn't match externref and vice versa
+        (Funcref, Externref) | (Externref, Funcref) => false,
+        // Unknown matches anything
+        (Unknown, _) | (_, Unknown) => true,
+        _ => true, // Be permissive for types we don't fully track
+    }
+}
+
+// ============================================================================
 // ref.func declaration check
 // ============================================================================
 
@@ -1217,8 +1565,94 @@ fn check_ref_func_declarations(
         }
     });
 
+    // Also collect exported functions — per spec, exported functions are considered "declared"
+    for_each_module_field(module, |field| {
+        let fk = field.kind();
+        #[cfg(all(feature = "wasm", not(feature = "native")))]
+        let fk = fk.as_str();
+        match fk {
+            "module_field_export" => {
+                // Standalone export: (export "name" (func $idx))
+                collect_exported_func(field, source, symbols, &mut declared_funcs);
+            }
+            "module_field_func" => {
+                // Inline export: (func $f (export "name") ...)
+                let mut cursor = field.walk();
+                let mut has_export = false;
+                for child in field.children(&mut cursor) {
+                    let ck = child.kind();
+                    #[cfg(all(feature = "wasm", not(feature = "native")))]
+                    let ck = ck.as_str();
+                    if ck == "export" {
+                        has_export = true;
+                        break;
+                    }
+                }
+                if has_export {
+                    // Find the function's index from its identifier or position
+                    let mut cursor2 = field.walk();
+                    for child in field.children(&mut cursor2) {
+                        let ck = child.kind();
+                        #[cfg(all(feature = "wasm", not(feature = "native")))]
+                        let ck = ck.as_str();
+                        if ck == "identifier" {
+                            let name = node_text(&child, source).trim();
+                            if let Some(idx) = resolve_func_index(name, symbols) {
+                                declared_funcs.insert(idx);
+                            }
+                            break;
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    });
+
     // Step 2: Walk all function bodies to find ref.func usage
     collect_ref_func_errors(module, source, symbols, &declared_funcs, diagnostics);
+}
+
+/// Collect function index from a standalone export node: (export "name" (func $idx))
+fn collect_exported_func(
+    export_node: &Node,
+    source: &str,
+    symbols: &SymbolTable,
+    declared: &mut HashSet<usize>,
+) {
+    // Walk recursively to find export_desc_func (nested inside export_desc)
+    find_exported_func_recursive(export_node, source, symbols, declared);
+}
+
+fn find_exported_func_recursive(
+    node: &Node,
+    source: &str,
+    symbols: &SymbolTable,
+    declared: &mut HashSet<usize>,
+) {
+    let kind = node.kind();
+    #[cfg(all(feature = "wasm", not(feature = "native")))]
+    let kind = kind.as_str();
+    if kind == "export_desc_func" {
+        // (func $idx) — find the index child
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            let ck = child.kind();
+            #[cfg(all(feature = "wasm", not(feature = "native")))]
+            let ck = ck.as_str();
+            if ck == "index" {
+                let idx_text = node_text(&child, source).trim();
+                if let Some(idx) = resolve_func_index(idx_text, symbols) {
+                    declared.insert(idx);
+                }
+            }
+        }
+        return;
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        find_exported_func_recursive(&child, source, symbols, declared);
+    }
 }
 
 /// Collect function indices referenced by ref.func in a global init expression.
@@ -1602,9 +2036,171 @@ fn check_unknown_type_refs(
     symbols: &SymbolTable,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
-    // Account for implicit types from function/tag declarations
-    let max_type_count = symbols.types.len() + symbols.functions.len();
+    // Compute actual type count: explicit types + unique implicit types from functions.
+    // Functions with a type_use or matching an existing signature don't create new implicit types.
+    let max_type_count = symbols.types.len() + count_unique_implicit_types(symbols);
     walk_for_unknown_type_refs(module, source, max_type_count, diagnostics);
+}
+
+/// Check for forward type references in type definitions.
+/// Outside of `(rec ...)` groups, type definitions can only reference
+/// previously-defined types (no forward or self references).
+fn check_type_forward_refs(
+    module: &Node,
+    source: &str,
+    symbols: &SymbolTable,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let mut type_index = 0usize;
+    for_each_module_field(module, |node| {
+        let kind = node.kind();
+        #[cfg(all(feature = "wasm", not(feature = "native")))]
+        let kind = kind.as_str();
+
+        if kind == "module_field_type" {
+            check_type_body_for_forward_refs(node, source, symbols, type_index, diagnostics);
+            type_index += 1;
+        } else if kind == "module_field_rec" {
+            // Count types inside rec group but skip forward ref checks
+            // (forward references within rec groups are allowed)
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                let ck = child.kind();
+                #[cfg(all(feature = "wasm", not(feature = "native")))]
+                let ck = ck.as_str();
+                if ck == "module_field_type" {
+                    type_index += 1;
+                }
+            }
+        }
+    });
+}
+
+/// Walk a type definition body and check for forward type references.
+fn check_type_body_for_forward_refs(
+    node: &Node,
+    source: &str,
+    symbols: &SymbolTable,
+    current_type_index: usize,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let kind = node.kind();
+    #[cfg(all(feature = "wasm", not(feature = "native")))]
+    let kind = kind.as_str();
+
+    // Look for type references in ref_type, _heap_type_or_ref, value_type_ref_type
+    if kind == "ref_type" || kind == "_heap_type_or_ref" || kind == "value_type_ref_type" {
+        check_ref_for_forward_type(node, source, symbols, current_type_index, diagnostics);
+        return; // Don't recurse into children — already checked
+    }
+
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        check_type_body_for_forward_refs(&child, source, symbols, current_type_index, diagnostics);
+    }
+}
+
+/// Check if a ref_type or similar node contains a forward type reference.
+fn check_ref_for_forward_type(
+    node: &Node,
+    source: &str,
+    symbols: &SymbolTable,
+    current_type_index: usize,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        let ck = child.kind();
+        #[cfg(all(feature = "wasm", not(feature = "native")))]
+        let ck = ck.as_str();
+
+        if ck == "identifier" {
+            let name = node_text(&child, source);
+            if let Some(td) = symbols.get_type_by_name(name) {
+                if td.index > current_type_index {
+                    diagnostics.push(
+                        Diagnostic::error(node_to_range(&child), format!("unknown type {}", name))
+                            .with_code("unknown-type"),
+                    );
+                }
+            }
+            return;
+        }
+
+        if ck == "index" {
+            // Check for numeric or identifier children
+            let mut ic = child.walk();
+            for idx_child in child.children(&mut ic) {
+                let ik = idx_child.kind();
+                #[cfg(all(feature = "wasm", not(feature = "native")))]
+                let ik = ik.as_str();
+
+                if ik == "identifier" {
+                    let name = node_text(&idx_child, source);
+                    if let Some(td) = symbols.get_type_by_name(name) {
+                        if td.index > current_type_index {
+                            diagnostics.push(
+                                Diagnostic::error(
+                                    node_to_range(&idx_child),
+                                    format!("unknown type {}", name),
+                                )
+                                .with_code("unknown-type"),
+                            );
+                        }
+                    }
+                } else if ik == "nat" || ik == "dec_nat" || ik == "hex_nat" {
+                    if let Ok(idx) = parse_nat(node_text(&idx_child, source)) {
+                        if idx > current_type_index {
+                            diagnostics.push(
+                                Diagnostic::error(
+                                    node_to_range(&idx_child),
+                                    format!("unknown type {}", idx),
+                                )
+                                .with_code("unknown-type"),
+                            );
+                        }
+                    }
+                }
+            }
+            return;
+        }
+
+        // Recurse into children (e.g., nested ref types)
+        check_ref_for_forward_type(&child, source, symbols, current_type_index, diagnostics);
+    }
+}
+
+/// Count unique implicit function types (signatures not matching any explicit type).
+/// Only functions with inline signatures (no type_use) create implicit types.
+fn count_unique_implicit_types(symbols: &SymbolTable) -> usize {
+    // Collect known signatures: (params, results) pairs
+    let mut known_sigs: Vec<(Vec<ValueType>, Vec<ValueType>)> = Vec::new();
+    for type_def in &symbols.types {
+        if let TypeKind::Func { params, results } = &type_def.kind {
+            known_sigs.push((params.clone(), results.clone()));
+        }
+    }
+
+    let mut implicit_count = 0;
+    for func in &symbols.functions {
+        // Functions with type_use reference an existing type, not create a new one
+        if func.has_type_use {
+            continue;
+        }
+        let params: Vec<ValueType> = func
+            .parameters
+            .iter()
+            .map(|p| p.param_type.clone())
+            .collect();
+        let already_known = known_sigs
+            .iter()
+            .any(|(kp, kr)| kp == &params && kr == &func.results);
+        if !already_known {
+            known_sigs.push((params, func.results.clone()));
+            implicit_count += 1;
+        }
+    }
+    implicit_count
 }
 
 /// Recursively walk the AST looking for numeric type indices in ref types and type_use.
@@ -1769,26 +2365,31 @@ fn parse_nat(text: &str) -> Result<usize, ()> {
 // ============================================================================
 
 fn check_table_limits(symbols: &SymbolTable, diagnostics: &mut Vec<Diagnostic>) {
-    const MAX_TABLE_SIZE: u64 = 0xFFFF_FFFF; // 2^32 - 1
+    const MAX_TABLE32_SIZE: u64 = 0xFFFF_FFFF; // 2^32 - 1
 
     for table in &symbols.tables {
+        // table64 has a much higher limit; skip the 32-bit check
+        if table.is_table64 {
+            continue;
+        }
+
         let range = table
             .range
             .unwrap_or_else(|| Range::from_coords(table.line, 0, table.line, 0));
 
-        if table.limits.0 as u64 > MAX_TABLE_SIZE {
-            diagnostics.push(Diagnostic::error(
-                range,
-                "Size minimum must not be greater than 4294967295",
-            ));
+        if table.limits.0 > MAX_TABLE32_SIZE {
+            diagnostics.push(
+                Diagnostic::error(range, "table size must be at most 2^32-1")
+                    .with_code("table-size"),
+            );
         }
 
         if let Some(max) = table.limits.1 {
-            if max as u64 > MAX_TABLE_SIZE {
-                diagnostics.push(Diagnostic::error(
-                    range,
-                    "Size minimum must not be greater than 4294967295",
-                ));
+            if max > MAX_TABLE32_SIZE {
+                diagnostics.push(
+                    Diagnostic::error(range, "table size must be at most 2^32-1")
+                        .with_code("table-size"),
+                );
             }
         }
     }
@@ -1823,8 +2424,8 @@ fn infer_const_instr_type(
                 Some("struct") | Some("structref") => Some(ValueType::Structref),
                 Some("array") | Some("arrayref") => Some(ValueType::Arrayref),
                 Some("none") | Some("nullref") => Some(ValueType::Nullref),
-                Some("noextern") | Some("nullexternref") => Some(ValueType::Externref),
-                Some("nofunc") | Some("nullfuncref") => Some(ValueType::Funcref),
+                Some("noextern") | Some("nullexternref") => Some(ValueType::NullExternref),
+                Some("nofunc") | Some("nullfuncref") => Some(ValueType::NullFuncref),
                 Some(s) if s.starts_with('$') => {
                     // Named type — resolve to Ref(n)
                     if let Some(t) = symbols.get_type_by_name(s) {
@@ -2206,6 +2807,13 @@ fn const_types_compatible(actual: &ValueType, expected: &ValueType) -> bool {
             | ValueType::Funcref
             | ValueType::Externref,
         ) => true,
+        // NullFuncref is bottom for func hierarchy
+        (
+            ValueType::NullFuncref,
+            ValueType::Funcref | ValueType::RefNull(_) | ValueType::Ref(_),
+        ) => true,
+        // NullExternref is bottom for extern hierarchy
+        (ValueType::NullExternref, ValueType::Externref) => true,
         _ => false,
     }
 }
@@ -2647,6 +3255,8 @@ fn walk_for_block_type_use_mismatches(
             | "instr_block"
             | "instr_loop"
             | "instr_if"
+            | "expr1_block"
+            | "expr1_loop"
     ) {
         check_block_node_type_use(node, source, symbols, diagnostics);
     }
@@ -2930,6 +3540,202 @@ fn walk_for_memory_instrs(node: &Node, source: &str, diagnostics: &mut Vec<Diagn
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         walk_for_memory_instrs(&child, source, diagnostics);
+    }
+}
+
+// ============================================================================
+// call_indirect / return_call_indirect table requirement checks
+// ============================================================================
+
+/// Check that call_indirect/return_call_indirect instructions have a valid table.
+/// - If no table exists: "unknown table"
+/// - If table exists but is externref: "type mismatch" (needs funcref table)
+fn check_call_indirect_table_requirements(
+    module: &Node,
+    source: &str,
+    symbols: &SymbolTable,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    for_each_module_field(module, |field| {
+        let fk = field.kind();
+        #[cfg(all(feature = "wasm", not(feature = "native")))]
+        let fk = fk.as_str();
+        if fk == "module_field_func" {
+            walk_for_call_indirect_checks(field, source, symbols, diagnostics);
+        }
+    });
+}
+
+/// Resolve which table a call_indirect node targets.
+/// For multi-table, the first index/identifier child that matches a table name
+/// (or numeric index) is used. Falls back to table 0.
+fn resolve_call_indirect_table_idx(node: &Node, source: &str, symbols: &SymbolTable) -> usize {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        let ck = child.kind();
+        #[cfg(all(feature = "wasm", not(feature = "native")))]
+        let ck = ck.as_str();
+        if ck == "index" || ck == "identifier" {
+            let text = source[child.byte_range()].trim();
+            // Check if this is a table name
+            if text.starts_with('$') {
+                if let Some((i, _)) = symbols
+                    .tables
+                    .iter()
+                    .enumerate()
+                    .find(|(_, t)| t.name.as_deref() == Some(text))
+                {
+                    return i;
+                }
+                // Not a table name — could be a type name, skip
+            } else if let Ok(idx) = parse_nat(text) {
+                // Numeric index — if it's within table count, it's a table index
+                // (For single-table modules, the first numeric index is the type index)
+                if idx < symbols.tables.len() && symbols.tables.len() > 1 {
+                    return idx;
+                }
+            }
+        }
+    }
+    0 // default to table 0
+}
+
+fn check_call_indirect_table(
+    node: &Node,
+    report_node: &Node,
+    source: &str,
+    symbols: &SymbolTable,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    if symbols.tables.is_empty() {
+        diagnostics.push(
+            Diagnostic::error(node_to_range(report_node), "unknown table".to_string())
+                .with_code("unknown-table"),
+        );
+    } else {
+        let table_idx = resolve_call_indirect_table_idx(node, source, symbols);
+        if let Some(table) = symbols.tables.get(table_idx) {
+            if table.ref_type == ValueType::Externref {
+                diagnostics.push(
+                    Diagnostic::error(node_to_range(report_node), "type mismatch".to_string())
+                        .with_code("type-mismatch"),
+                );
+            }
+        }
+    }
+}
+
+fn walk_for_call_indirect_checks(
+    node: &Node,
+    source: &str,
+    symbols: &SymbolTable,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let kind = node.kind();
+    #[cfg(all(feature = "wasm", not(feature = "native")))]
+    let kind = kind.as_str();
+
+    if kind == "instr_plain" {
+        let text = node_text(node, source);
+        let first_token = text.split_whitespace().next().unwrap_or("");
+        if first_token == "call_indirect" || first_token == "return_call_indirect" {
+            check_call_indirect_table(node, node, source, symbols, diagnostics);
+        }
+        return;
+    }
+
+    // Also check folded form
+    if kind == "expr1_plain" {
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            let ck = child.kind();
+            #[cfg(all(feature = "wasm", not(feature = "native")))]
+            let ck = ck.as_str();
+            if ck == "instr_plain" {
+                let text = node_text(&child, source);
+                let first_token = text.split_whitespace().next().unwrap_or("");
+                if first_token == "call_indirect" || first_token == "return_call_indirect" {
+                    check_call_indirect_table(&child, node, source, symbols, diagnostics);
+                }
+            }
+        }
+        return;
+    }
+
+    // Also handle expr1_call and instr_call nodes (grammar-specific for call_indirect)
+    if kind == "expr1_call" || kind == "instr_call" || kind == "instr_list_call" {
+        let text = node_text(node, source);
+        let first_token = text.split_whitespace().next().unwrap_or("");
+        if first_token == "call_indirect" || first_token == "return_call_indirect" {
+            check_call_indirect_table(node, node, source, symbols, diagnostics);
+        }
+        return;
+    }
+
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        walk_for_call_indirect_checks(&child, source, symbols, diagnostics);
+    }
+}
+
+/// Check inline elem segments for unknown function references.
+/// e.g., (table funcref (elem 0 0)) with no functions defined → "unknown function 0"
+fn check_inline_elem_func_refs(
+    module: &Node,
+    source: &str,
+    symbols: &SymbolTable,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    for_each_module_field(module, |field| {
+        let fk = field.kind();
+        #[cfg(all(feature = "wasm", not(feature = "native")))]
+        let fk = fk.as_str();
+        if fk != "module_field_table" {
+            return;
+        }
+
+        // Look for inline elem segments: table_fields_elem → (elem index*)
+        let mut cursor = field.walk();
+        for child in field.children(&mut cursor) {
+            let ck = child.kind();
+            #[cfg(all(feature = "wasm", not(feature = "native")))]
+            let ck = ck.as_str();
+            if ck == "table_fields_elem" {
+                check_inline_table_elem_refs(&child, source, symbols, diagnostics);
+            }
+        }
+    });
+}
+
+fn check_inline_table_elem_refs(
+    node: &Node,
+    source: &str,
+    symbols: &SymbolTable,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        let ck = child.kind();
+        #[cfg(all(feature = "wasm", not(feature = "native")))]
+        let ck = ck.as_str();
+        if ck == "nat" || ck == "index" {
+            let text = node_text(&child, source).trim().to_string();
+            if let Ok(idx) = text.parse::<usize>() {
+                if idx >= symbols.functions.len() {
+                    diagnostics.push(
+                        Diagnostic::error(
+                            node_to_range(&child),
+                            format!("unknown function {}", idx),
+                        )
+                        .with_code("unknown-function"),
+                    );
+                }
+            }
+        }
+        // Also recurse to handle nested structures
+        if ck == "elem_list" || ck == "elem_expr" || ck == "elem_expr_item" {
+            check_inline_table_elem_refs(&child, source, symbols, diagnostics);
+        }
     }
 }
 
@@ -3298,8 +4104,8 @@ mod tests {
     }
 
     #[test]
-    fn test_global_get_const_non_imported_ok() {
-        // Extended const expressions allow global.get of any immutable global
+    fn test_global_get_const_earlier_global_ok() {
+        // global.get of earlier immutable module-defined global is valid
         let source = r#"(module
             (global $g i32 (i32.const 0))
             (global $h i32 (global.get $g))
@@ -3307,7 +4113,37 @@ mod tests {
         let diags = get_diagnostics(source);
         assert!(
             diags.is_empty(),
-            "Expected no errors for immutable global.get in const, got: {:?}",
+            "Expected no errors for global.get of earlier global, got: {:?}",
+            diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_global_get_const_forward_ref_error() {
+        // global.get of later-defined global is an error (forward reference)
+        let source = r#"(module
+            (global $g1 i32 (global.get $g2))
+            (global $g2 i32 (i32.const 0))
+        )"#;
+        let diags = get_diagnostics(source);
+        assert!(
+            diags.iter().any(|d| d.message.contains("unknown global")),
+            "Expected 'unknown global' for forward ref, got: {:?}",
+            diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_table_init_non_imported_global_error() {
+        // Table init can only use imported globals
+        let source = r#"(module
+            (global $g funcref (ref.null func))
+            (table $t 10 funcref (global.get $g))
+        )"#;
+        let diags = get_diagnostics(source);
+        assert!(
+            diags.iter().any(|d| d.message.contains("unknown global")),
+            "Expected 'unknown global' for non-imported global in table init, got: {:?}",
             diags.iter().map(|d| &d.message).collect::<Vec<_>>()
         );
     }

--- a/src/diagnostics_core/semantic.rs
+++ b/src/diagnostics_core/semantic.rs
@@ -16,11 +16,12 @@ use crate::core::types::Diagnostic;
 use crate::instruction_metadata::{
     infer_simd_instruction_arity, is_terminating_instruction, lookup_instruction_arity, OperandMode,
 };
-use crate::symbols::{SymbolTable, TypeDef, TypeKind, ValueType};
+use crate::symbols::{SymbolTable, Table, TypeDef, TypeKind, ValueType};
 use crate::utils::node_to_range;
 
 use super::sequence_always_terminates;
-use super::type_check::{CtrlOpcode, TypeChecker};
+use super::type_check::{types_compatible_with_symbols, CtrlOpcode, TypeChecker};
+use crate::parser::parse_wat_nat;
 
 // Use the appropriate tree-sitter types based on feature
 #[cfg(feature = "native")]
@@ -501,7 +502,10 @@ fn process_instruction(
     source: &str,
 ) {
     // Handle tail call instructions
-    if matches!(instr_name, "return_call" | "return_call_ref") {
+    if matches!(
+        instr_name,
+        "return_call" | "return_call_ref" | "return_call_indirect"
+    ) {
         let consumed = get_instruction_consumed_types(node, instr_name, symbols, source);
         if !consumed.is_empty() {
             checker.pop_vals_for_instr(&consumed, node, instr_name);
@@ -542,6 +546,7 @@ fn process_instruction(
     if instr_name == "br_table" {
         // Pop i32 index
         checker.pop_expect(&ValueType::I32, node);
+        let is_unreachable = checker.is_unreachable();
         let depths = get_all_branch_depths(node, source, checker);
         if let Some(&default_depth) = depths.last() {
             // Type-check using the default (last) label
@@ -549,7 +554,9 @@ fn process_instruction(
                 let label_types = label_types.to_vec();
                 checker.pop_vals_for_instr(&label_types, node, instr_name);
             }
-            // Validate all non-default labels have consistent types with default
+            // Validate all non-default labels have consistent arity with default.
+            // Arity must always match. Type compatibility is only checked when reachable
+            // (after unreachable, the polymorphic stack bottom satisfies any type).
             if let Some(default_types) = checker.label_types(default_depth) {
                 let default_types = default_types.to_vec();
                 let default_arity = default_types.len();
@@ -570,7 +577,7 @@ fn process_instruction(
                                 .with_code("type-mismatch"),
                             );
                             reported = true;
-                        } else {
+                        } else if !is_unreachable {
                             for (t, d) in target_types.iter().zip(default_types.iter()) {
                                 if !types_compatible(t, d) {
                                     checker.diagnostics.push(
@@ -618,43 +625,78 @@ fn process_instruction(
     if instr_name == "select" && get_select_result_type(node, source).is_none() {
         // Bare select (no type annotation): first two operands must be same numeric type
         // Stack: [val1, val2, i32_cond] — peek(0)=cond, peek(1)=val2, peek(2)=val1
-        if let (Some(val2), Some(val1)) = (checker.peek(1), checker.peek(2)) {
-            let is_numeric = |t: &ValueType| {
-                matches!(
-                    t,
-                    ValueType::I32
-                        | ValueType::I64
-                        | ValueType::F32
-                        | ValueType::F64
-                        | ValueType::V128
-                        | ValueType::Unknown
-                )
-            };
-            if !is_numeric(val1) || !is_numeric(val2) {
-                checker.diagnostics.push(
-                    Diagnostic::error(
-                        node_to_range(node),
-                        "type mismatch: select without type annotation requires numeric operands"
-                            .to_string(),
-                    )
-                    .with_code("type-mismatch"),
-                );
-            } else if val1 != &ValueType::Unknown
-                && val2 != &ValueType::Unknown
-                && !types_compatible(val1, val2)
-            {
-                checker.diagnostics.push(
-                    Diagnostic::error(
-                        node_to_range(node),
-                        format!(
-                            "type mismatch: select operands have different types ({:?} vs {:?})",
-                            val1, val2
-                        ),
-                    )
-                    .with_code("type-mismatch"),
-                );
+        let val2 = checker.peek(1).map(|v| (*v).clone());
+        let val1 = checker.peek(2).map(|v| (*v).clone());
+        let is_numeric = |t: &ValueType| {
+            matches!(
+                t,
+                ValueType::I32
+                    | ValueType::I64
+                    | ValueType::F32
+                    | ValueType::F64
+                    | ValueType::V128
+                    | ValueType::Unknown
+            )
+        };
+        // Determine result type from peeked operands
+        let result_type = match (&val1, &val2) {
+            (Some(v1), Some(v2)) => {
+                if !is_numeric(v1) || !is_numeric(v2) {
+                    checker.diagnostics.push(
+                        Diagnostic::error(
+                            node_to_range(node),
+                            "type mismatch: select without type annotation requires numeric operands"
+                                .to_string(),
+                        )
+                        .with_code("type-mismatch"),
+                    );
+                    ValueType::Unknown
+                } else if *v1 != ValueType::Unknown
+                    && *v2 != ValueType::Unknown
+                    && !types_compatible(v1, v2)
+                {
+                    checker.diagnostics.push(
+                        Diagnostic::error(
+                            node_to_range(node),
+                            format!(
+                                "type mismatch: select operands have different types ({:?} vs {:?})",
+                                v1, v2
+                            ),
+                        )
+                        .with_code("type-mismatch"),
+                    );
+                    ValueType::Unknown
+                } else if *v1 != ValueType::Unknown {
+                    v1.clone()
+                } else {
+                    v2.clone()
+                }
             }
-        }
+            (None, Some(v2)) => {
+                // Only val2 available (val1 is in unreachable bottom).
+                if !is_numeric(v2) {
+                    checker.diagnostics.push(
+                        Diagnostic::error(
+                            node_to_range(node),
+                            "type mismatch: select without type annotation requires numeric operands"
+                                .to_string(),
+                        )
+                        .with_code("type-mismatch"),
+                    );
+                }
+                v2.clone()
+            }
+            _ => ValueType::Unknown,
+        };
+        // Pop: i32 condition + two operands (typed as Unknown to avoid double-reporting)
+        checker.pop_vals_for_instr(
+            &[ValueType::Unknown, ValueType::Unknown, ValueType::I32],
+            node,
+            instr_name,
+        );
+        // Push the actual result type (not Unknown)
+        checker.push_val(result_type);
+        return;
     }
 
     // Regular instructions: consume typed operands, produce typed results
@@ -876,21 +918,20 @@ fn derive_consumed_types_from_name(
             None // fall back to untyped
         }
 
-        // Call_ref — consume param types + typed funcref
-        // Use Unknown for the funcref operand to be lenient (exact ref type varies)
+        // Call_ref — consume param types + typed funcref (ref null $type)
         "call_ref" | "return_call_ref" => {
             if let Some(type_ref) = get_index_from_node(node, source) {
                 if let Some(type_def) = symbols.get_type_by_name(&type_ref) {
                     if let TypeKind::Func { params, .. } = &type_def.kind {
                         let mut types: Vec<ValueType> = params.clone();
-                        types.push(ValueType::Unknown); // typed funcref (lenient)
+                        types.push(ValueType::RefNull(type_def.index as u32));
                         return Some(types);
                     }
-                } else if let Ok(idx) = type_ref.parse::<usize>() {
-                    if let Some(type_def) = symbols.get_type_by_index(idx) {
+                } else if let Some(idx) = parse_wat_nat(&type_ref) {
+                    if let Some(type_def) = symbols.get_type_by_index(idx as usize) {
                         if let TypeKind::Func { params, .. } = &type_def.kind {
                             let mut types: Vec<ValueType> = params.clone();
-                            types.push(ValueType::Unknown);
+                            types.push(ValueType::RefNull(type_def.index as u32));
                             return Some(types);
                         }
                     }
@@ -1007,16 +1048,27 @@ fn derive_consumed_types_from_name(
         "memory.init" => Some(vec![ValueType::I32, ValueType::I32, ValueType::I32]),
         "data.drop" | "elem.drop" => Some(vec![]),
 
-        // Table operations (use Unknown for index type to support table64)
-        "table.get" => Some(vec![ValueType::Unknown]),
-        "table.set" => Some(vec![ValueType::Unknown, ValueType::Unknown]),
+        // Table operations — resolve element type and index type from symbol table
+        "table.get" => {
+            let idx_type = get_table_index_type(node, symbols, source);
+            Some(vec![idx_type])
+        }
+        "table.set" => {
+            let idx_type = get_table_index_type(node, symbols, source);
+            let elem_type = get_table_elem_type(node, symbols, source);
+            Some(vec![idx_type, elem_type])
+        }
         "table.size" => Some(vec![]),
-        "table.grow" => Some(vec![ValueType::Unknown, ValueType::Unknown]),
-        "table.fill" => Some(vec![
-            ValueType::Unknown,
-            ValueType::Unknown,
-            ValueType::Unknown,
-        ]),
+        "table.grow" => {
+            let idx_type = get_table_index_type(node, symbols, source);
+            let elem_type = get_table_elem_type(node, symbols, source);
+            Some(vec![elem_type, idx_type])
+        }
+        "table.fill" => {
+            let idx_type = get_table_index_type(node, symbols, source);
+            let elem_type = get_table_elem_type(node, symbols, source);
+            Some(vec![idx_type.clone(), elem_type, idx_type])
+        }
         "table.copy" => Some(vec![
             ValueType::Unknown,
             ValueType::Unknown,
@@ -1069,14 +1121,20 @@ fn get_call_indirect_consumed_types(
     source: &str,
 ) -> Vec<ValueType> {
     // call_indirect consumes: param_types... + table index (i32 or i64 for table64)
-    // Use Unknown for table index to support both table32 and table64
+    let table_idx_type = get_table_index_type(node, symbols, source);
     // First, try to resolve from type_use (handles multi-table where first index is table ref)
     if let Some(td) = resolve_call_indirect_type(node, source, symbols) {
         if let TypeKind::Func { params, .. } = &td.kind {
             let mut types = params.clone();
-            types.push(ValueType::Unknown); // table index (i32 or i64)
+            types.push(table_idx_type);
             return types;
         }
+    }
+    // Try implicit type resolution (for modules without explicit type declarations)
+    if let Some(sig) = resolve_call_indirect_type_implicit(node, source, symbols) {
+        let mut types = sig.0;
+        types.push(table_idx_type);
+        return types;
     }
     // Check for explicit func_type_params_many (inline params without type_use)
     let mut params = Vec::new();
@@ -1091,7 +1149,7 @@ fn get_call_indirect_consumed_types(
             params.extend(parse_func_type_results(&child, source));
         }
     }
-    params.push(ValueType::Unknown); // table index (i32 or i64)
+    params.push(table_idx_type);
     params
 }
 
@@ -1100,17 +1158,20 @@ fn get_call_indirect_consumed_types(
 /// Named label resolution failure is handled by the reference checker.
 fn get_branch_depth(node: &Node, source: &str, checker: &mut TypeChecker) -> Option<usize> {
     let index = get_index_from_node(node, source)?;
-    // Try as numeric index first
-    if let Ok(depth) = index.parse::<usize>() {
-        if depth < checker.ctrl_depth() {
-            return Some(depth);
+    // Try as numeric index first (supports hex like 0x10000001 and underscore separators)
+    if !index.starts_with('$') {
+        if let Some(depth) = parse_wat_nat(&index) {
+            let depth = depth as usize;
+            if depth < checker.ctrl_depth() {
+                return Some(depth);
+            }
+            // Out-of-range label depth
+            checker.diagnostics.push(
+                Diagnostic::error(node_to_range(node), format!("unknown label {}", depth))
+                    .with_code("unknown-label"),
+            );
+            return None;
         }
-        // Out-of-range label depth
-        checker.diagnostics.push(
-            Diagnostic::error(node_to_range(node), format!("unknown label {}", depth))
-                .with_code("unknown-label"),
-        );
-        return None;
     }
     // Try named label resolution
     if index.starts_with('$') {
@@ -1151,7 +1212,12 @@ fn get_all_branch_depths(node: &Node, source: &str, checker: &mut TypeChecker) -
     let ctrl_depth = checker.ctrl_depth();
     let mut result = Vec::new();
     for idx_str in &indices {
-        if let Ok(depth) = idx_str.parse::<usize>() {
+        if idx_str.starts_with('$') {
+            if let Some(depth) = checker.resolve_label_depth(idx_str) {
+                result.push(depth);
+            }
+        } else if let Some(depth) = parse_wat_nat(idx_str) {
+            let depth = depth as usize;
             if depth < ctrl_depth {
                 result.push(depth);
             } else {
@@ -1489,10 +1555,13 @@ pub fn infer_instruction_result_types(
             get_call_indirect_result_types(node, symbols, source)
         }
 
+        "table.get" => vec![get_table_elem_type(node, symbols, source)],
+        "table.grow" | "table.size" => vec![get_table_index_type(node, symbols, source)],
+
         "drop" | "local.set" | "global.set" | "return" | "br" | "unreachable" | "nop" => vec![],
 
         "ref.null" => vec![ValueType::Unknown],
-        "ref.func" => vec![ValueType::Funcref],
+        "ref.func" => get_ref_func_result_type(node, symbols, source),
         "ref.extern" => vec![ValueType::Externref],
         "ref.is_null" => vec![ValueType::I32],
 
@@ -1591,6 +1660,73 @@ pub fn get_global_type_from_node(
     None
 }
 
+/// Get the element type of the table referenced by a table instruction node.
+/// Falls back to table 0 if no explicit index.
+fn resolve_table<'a>(node: &Node, symbols: &'a SymbolTable, source: &str) -> Option<&'a Table> {
+    if let Some(index) = get_index_from_node(node, source) {
+        if let Some(table) = symbols.get_table_by_name(&index) {
+            return Some(table);
+        }
+        if let Some(idx) = parse_wat_nat(&index) {
+            if let Some(table) = symbols.tables.get(idx as usize) {
+                return Some(table);
+            }
+        }
+    }
+    symbols.tables.first()
+}
+
+fn get_table_elem_type(node: &Node, symbols: &SymbolTable, source: &str) -> ValueType {
+    resolve_table(node, symbols, source)
+        .map(|t| t.ref_type.clone())
+        .unwrap_or(ValueType::Funcref)
+}
+
+/// Get the index type for table operations (i32 for regular tables, i64 for table64)
+fn get_table_index_type(node: &Node, symbols: &SymbolTable, source: &str) -> ValueType {
+    resolve_table(node, symbols, source)
+        .map(|t| {
+            if t.is_table64 {
+                ValueType::I64
+            } else {
+                ValueType::I32
+            }
+        })
+        .unwrap_or(ValueType::I32)
+}
+
+/// Get result type for ref.func instruction.
+/// Returns Ref(type_index) when the function's type can be resolved, otherwise Funcref.
+fn get_ref_func_result_type(node: &Node, symbols: &SymbolTable, source: &str) -> Vec<ValueType> {
+    if let Some(func_ref) = get_index_from_node(node, source) {
+        // Look up the function to find its type
+        let func = if let Some(f) = symbols.get_function_by_name(&func_ref) {
+            Some(f)
+        } else if let Ok(idx) = func_ref.parse::<usize>() {
+            symbols.get_function_by_index(idx)
+        } else {
+            None
+        };
+
+        if let Some(func) = func {
+            // Find a matching type definition for this function's signature
+            let func_params: Vec<ValueType> = func
+                .parameters
+                .iter()
+                .map(|p| p.param_type.clone())
+                .collect();
+            for type_def in &symbols.types {
+                if let TypeKind::Func { params, results } = &type_def.kind {
+                    if *params == func_params && *results == func.results {
+                        return vec![ValueType::Ref(type_def.index as u32)];
+                    }
+                }
+            }
+        }
+    }
+    vec![ValueType::Funcref]
+}
+
 /// Get result types for a call instruction
 pub fn get_call_result_types(node: &Node, symbols: &SymbolTable, source: &str) -> Vec<ValueType> {
     if let Some(func_ref) = get_index_from_node(node, source) {
@@ -1675,6 +1811,10 @@ pub fn get_call_indirect_result_types(
             return res.clone();
         }
     }
+    // Try implicit type resolution
+    if let Some(sig) = resolve_call_indirect_type_implicit(node, source, symbols) {
+        return sig.1;
+    }
     // Check for explicit func_type_results (inline result types without type_use)
     let mut results = Vec::new();
     let mut cursor = node.walk();
@@ -1689,6 +1829,39 @@ pub fn get_call_indirect_result_types(
         }
     }
     results
+}
+
+/// Try to resolve call_indirect type via implicit function types.
+/// Falls back to implicit types when explicit type lookup fails.
+fn resolve_call_indirect_type_implicit(
+    node: &Node,
+    source: &str,
+    symbols: &SymbolTable,
+) -> Option<(Vec<ValueType>, Vec<ValueType>)> {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        #[cfg(feature = "native")]
+        let kind = child.kind();
+        #[cfg(all(feature = "wasm", not(feature = "native")))]
+        let kind = child.kind();
+
+        if kind == "type_use" {
+            // Extract index from type_use
+            let mut inner_cursor = child.walk();
+            for inner in child.children(&mut inner_cursor) {
+                let ik = inner.kind();
+                #[cfg(all(feature = "wasm", not(feature = "native")))]
+                let ik = ik.as_str();
+                if ik == "index" || ik == "identifier" {
+                    let idx_text = source[inner.byte_range()].trim();
+                    if let Ok(idx) = idx_text.parse::<usize>() {
+                        return resolve_type_index_to_func_sig(idx, symbols);
+                    }
+                }
+            }
+        }
+    }
+    None
 }
 
 /// Find the instr_plain node inside a folded expression (for branch depth resolution).
@@ -2560,6 +2733,49 @@ fn resolve_type_use_node<'a>(
     None
 }
 
+/// Resolve a numeric type index to a function signature, including implicit types.
+///
+/// WebAssembly modules can have implicit types created from function signatures.
+/// When a function uses `(type N)` where N >= explicit type count, the index may
+/// refer to an implicit type derived from function signatures.
+///
+/// Returns (params, results) for function types, None for non-function types.
+fn resolve_type_index_to_func_sig(
+    idx: usize,
+    symbols: &SymbolTable,
+) -> Option<(Vec<ValueType>, Vec<ValueType>)> {
+    // First, try explicit types
+    if let Some(td) = symbols.get_type_by_index(idx) {
+        if let TypeKind::Func { params, results } = &td.kind {
+            return Some((params.clone(), results.clone()));
+        }
+        return None;
+    }
+
+    // Build implicit type table: explicit type sigs + unique function sigs
+    let mut sigs: Vec<(Vec<ValueType>, Vec<ValueType>)> = Vec::new();
+    for type_def in &symbols.types {
+        if let TypeKind::Func { params, results } = &type_def.kind {
+            sigs.push((params.clone(), results.clone()));
+        }
+    }
+    for func in &symbols.functions {
+        if func.has_type_use {
+            continue;
+        }
+        let params: Vec<ValueType> = func
+            .parameters
+            .iter()
+            .map(|p| p.param_type.clone())
+            .collect();
+        let sig = (params, func.results.clone());
+        if !sigs.iter().any(|s| s == &sig) {
+            sigs.push(sig);
+        }
+    }
+    sigs.get(idx).cloned()
+}
+
 /// Get result types from a block/loop/if node
 pub fn get_block_result_types(
     block_node: &Node,
@@ -2839,11 +3055,17 @@ fn validate_tail_call_return_types(
         _ => return None,
     };
 
-    if callee_results.is_empty() || callee_results.contains(&ValueType::Unknown) {
+    if callee_results.contains(&ValueType::Unknown) {
         return None;
     }
 
-    if callee_results != *enclosing_results {
+    // Check result type compatibility using subtyping
+    let types_mismatch = callee_results.len() != enclosing_results.len()
+        || callee_results
+            .iter()
+            .zip(enclosing_results.iter())
+            .any(|(callee, enclosing)| !types_compatible_with_symbols(callee, enclosing, symbols));
+    if types_mismatch {
         let callee_name = get_index_from_node(node, source).unwrap_or_default();
         let label = if callee_name.is_empty() {
             instr_name.to_string()
@@ -2855,13 +3077,13 @@ fn validate_tail_call_return_types(
             Diagnostic::error(
                 range,
                 format!(
-                    "Tail call return type mismatch: '{}' returns {} but enclosing function returns {}",
+                    "type mismatch: '{}' returns {} but enclosing function returns {}",
                     label,
                     format_types(&callee_results),
                     format_types(enclosing_results),
                 ),
             )
-            .with_code("tail-call-type-mismatch"),
+            .with_code("type-mismatch"),
         );
     }
 

--- a/src/diagnostics_core/type_check.rs
+++ b/src/diagnostics_core/type_check.rs
@@ -82,8 +82,15 @@ fn is_ref_subtype(sub: &ValueType, sup: &ValueType) -> bool {
         // Ref(n) / RefNull(n) — without symbol table, assume func hierarchy only
         (Ref(_), Funcref) => true,
         (RefNull(_), Funcref) => true,
+        // NullFuncref is bottom of func hierarchy — subtype of all func refs
+        (NullFuncref, RefNull(_) | Ref(_) | Structref) => true,
         // Non-null <: nullable for same index
         (Ref(a), RefNull(b)) if a == b => true,
+        // Structref is used as placeholder for unresolved named ref types (e.g., (ref $mytype))
+        // in the parser (extract_ref_type can't resolve named indices without SymbolTable).
+        // Treat as compatible with concrete indexed refs to avoid false positives.
+        (Structref, Ref(_) | RefNull(_)) => true,
+        (Ref(_) | RefNull(_), Structref) => true,
         _ => false,
     }
 }
@@ -507,6 +514,14 @@ impl TypeChecker {
         }
     }
 
+    /// Check if the current frame is in an unreachable state (polymorphic stack).
+    pub fn is_unreachable(&self) -> bool {
+        self.ctrl_stack
+            .last()
+            .map(|f| f.unreachable)
+            .unwrap_or(false)
+    }
+
     /// Get the label types for a frame at the given depth.
     /// For loops, label types are start_types (br restarts with params).
     /// For everything else, label types are end_types.
@@ -722,9 +737,12 @@ mod tests {
     }
 
     #[test]
-    fn test_concrete_func_ref_not_subtype_of_structref() {
+    fn test_concrete_ref_compatible_with_structref_placeholder() {
+        // Structref is used as a placeholder for unresolved named ref types in the parser,
+        // so Ref(n) <-> Structref is treated as compatible (see is_ref_subtype).
+        // This means we can't distinguish "real" structref from unresolved named refs.
         let symbols = make_symbols_with_types(vec![func_type(0, Some("$f"))]);
-        assert!(!types_compatible_with_symbols(
+        assert!(types_compatible_with_symbols(
             &ValueType::Ref(0),
             &ValueType::Structref,
             &symbols

--- a/src/features/hover/tests.rs
+++ b/src/features/hover/tests.rs
@@ -318,6 +318,7 @@ fn test_format_function_signature() {
         end_byte: 150,
         range: None,
         doc_comment: None,
+        has_type_use: false,
     };
 
     let sig = format_function_signature(&func);

--- a/src/features/signature/tests.rs
+++ b/src/features/signature/tests.rs
@@ -168,6 +168,7 @@ fn test_format_function_signature_simple() {
         end_byte: 100,
         range: None,
         doc_comment: None,
+        has_type_use: false,
     };
 
     let sig = format_function_signature(&func);
@@ -194,6 +195,7 @@ fn test_format_function_signature_with_params() {
         end_byte: 100,
         range: None,
         doc_comment: None,
+        has_type_use: false,
     };
 
     let sig = format_function_signature(&func);
@@ -217,6 +219,7 @@ fn test_format_function_signature_with_results() {
         end_byte: 100,
         range: None,
         doc_comment: None,
+        has_type_use: false,
     };
 
     let sig = format_function_signature(&func);
@@ -245,6 +248,7 @@ fn test_format_function_signature_unnamed_params() {
         end_byte: 100,
         range: None,
         doc_comment: None,
+        has_type_use: false,
     };
 
     let sig = format_function_signature(&func);

--- a/src/features/symbols/mod.rs
+++ b/src/features/symbols/mod.rs
@@ -164,6 +164,8 @@ pub struct Function {
     pub end_byte: usize,
     pub range: Option<Range>,
     pub doc_comment: Option<String>,
+    /// True if this function uses `(type N)` — such functions don't create implicit types
+    pub has_type_use: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -182,7 +184,8 @@ pub struct Table {
     pub name: Option<String>,
     pub index: usize,
     pub ref_type: ValueType,
-    pub limits: (u32, Option<u32>),
+    pub limits: (u64, Option<u64>),
+    pub is_table64: bool,
     pub line: u32,
     pub range: Option<Range>,
 }

--- a/src/features/symbols/tests.rs
+++ b/src/features/symbols/tests.rs
@@ -26,6 +26,7 @@ fn test_add_function() {
         end_byte: 100,
         range: None,
         doc_comment: None,
+        has_type_use: false,
     };
 
     table.add_function(func);
@@ -71,6 +72,7 @@ fn test_add_table() {
         index: 0,
         ref_type: ValueType::Funcref,
         limits: (10, Some(100)),
+        is_table64: false,
         line: 0,
         range: None,
     };
@@ -135,6 +137,7 @@ fn test_get_function_by_index() {
             end_byte: 100,
             range: None,
             doc_comment: None,
+            has_type_use: false,
         };
         table.add_function(func);
     }
@@ -186,6 +189,7 @@ fn test_unnamed_symbols() {
         end_byte: 100,
         range: None,
         doc_comment: None,
+        has_type_use: false,
     };
     table.add_function(func);
 
@@ -213,6 +217,7 @@ fn test_multiple_symbols_same_type() {
             end_byte: 100,
             range: None,
             doc_comment: None,
+            has_type_use: false,
         };
         table.add_function(func);
     }
@@ -316,6 +321,7 @@ fn test_complex_function() {
         end_byte: 500,
         range: None,
         doc_comment: None,
+        has_type_use: false,
     };
 
     assert_eq!(func.parameters.len(), 2);

--- a/src/features/test_utils.rs
+++ b/src/features/test_utils.rs
@@ -67,6 +67,7 @@ pub fn create_test_symbols() -> SymbolTable {
         end_byte: 300,
         range: None,
         doc_comment: None,
+        has_type_use: false,
     };
     table.add_function(func);
 
@@ -88,6 +89,7 @@ pub fn create_test_symbols() -> SymbolTable {
         index: 0,
         ref_type: ValueType::Funcref,
         limits: (10, None),
+        is_table64: false,
         line: 0,
         range: None,
     };
@@ -149,6 +151,7 @@ pub fn create_signature_test_symbols() -> SymbolTable {
         end_byte: 300,
         range: None,
         doc_comment: None,
+        has_type_use: false,
     };
     table.add_function(multi_param_func);
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -37,16 +37,18 @@ fn extract_symbols(tree: &Tree, source: &str) -> Result<SymbolTable, String> {
     let mut symbol_table = SymbolTable::new();
     let root = tree.root_node();
 
-    // Extract imports FIRST - imports get indices before regular declarations
+    // Extract types FIRST so they're available for type_use resolution in imports and functions
+    extract_types(&root, source, &mut symbol_table);
+
+    // Extract imports - imports get indices before regular declarations
     // Returns counters for each kind of import
     let import_counts = extract_imports(&root, source, &mut symbol_table);
     symbol_table.num_imported_globals = import_counts.globals;
 
-    // Extract in order: globals, types, tables, memories, functions
+    // Extract in order: globals, tables, memories, functions
     // (Order matters for index assignment)
     // Pass import counts to offset the indices
     extract_globals_with_offset(&root, source, &mut symbol_table, import_counts.globals);
-    extract_types(&root, source, &mut symbol_table);
     extract_tables_with_offset(&root, source, &mut symbol_table, import_counts.tables);
     extract_memories_with_offset(&root, source, &mut symbol_table, import_counts.memories);
     extract_tags_with_offset(&root, source, &mut symbol_table, import_counts.tags);
@@ -211,6 +213,7 @@ fn extract_inline_import_func(
         end_byte: func_node.end_byte(),
         range: name_range,
         doc_comment: None,
+        has_type_use: has_type_use_child(func_node),
     })
 }
 
@@ -251,9 +254,12 @@ fn extract_single_import(
                 match kind {
                     "import_desc_func_type" | "import_desc_type_use" => {
                         // Imported function: (func $name? ...)
-                        if let Some(func) =
-                            extract_imported_function(&desc_child, source, counts.functions)
-                        {
+                        if let Some(func) = extract_imported_function(
+                            &desc_child,
+                            source,
+                            counts.functions,
+                            symbol_table,
+                        ) {
                             symbol_table.add_function(func);
                             counts.functions += 1;
                         }
@@ -300,7 +306,12 @@ fn extract_single_import(
 }
 
 /// Extract an imported function
-fn extract_imported_function(desc_node: &Node, source: &str, index: usize) -> Option<Function> {
+fn extract_imported_function(
+    desc_node: &Node,
+    source: &str,
+    index: usize,
+    symbol_table: &SymbolTable,
+) -> Option<Function> {
     let (name, name_range) = if let Some(id_node) = find_identifier_node(desc_node) {
         (
             Some(node_text(&id_node, source)),
@@ -357,6 +368,17 @@ fn extract_imported_function(desc_node: &Node, source: &str, index: usize) -> Op
         results = extract_results(desc_node, source);
     }
 
+    // Resolve type_use if no explicit params/results
+    if results.is_empty() {
+        if let Some((type_params, type_results)) = resolve_type_use(desc_node, source, symbol_table)
+        {
+            results = type_results;
+            if parameters.is_empty() {
+                parameters = type_params;
+            }
+        }
+    }
+
     Some(Function {
         name,
         index,
@@ -370,6 +392,7 @@ fn extract_imported_function(desc_node: &Node, source: &str, index: usize) -> Op
         end_byte: desc_node.end_byte(),
         range: name_range,
         doc_comment: None, // Imported functions don't have doc comments
+        has_type_use: has_type_use_child(desc_node),
     })
 }
 
@@ -434,8 +457,9 @@ fn extract_imported_table(desc_node: &Node, source: &str, index: usize) -> Optio
     };
 
     let mut ref_type = ValueType::Funcref;
-    let mut min_limit = 0;
-    let mut max_limit = None;
+    let mut min_limit: u64 = 0;
+    let mut max_limit: Option<u64> = None;
+    let mut is_table64 = false;
 
     let mut cursor = desc_node.walk();
     for child in desc_node.children(&mut cursor) {
@@ -448,7 +472,7 @@ fn extract_imported_table(desc_node: &Node, source: &str, index: usize) -> Optio
                     for limit_child in type_child.children(&mut limits_cursor) {
                         if limit_child.kind() == "nat" {
                             let text = node_text(&limit_child, source);
-                            if let Ok(num) = text.parse::<u32>() {
+                            if let Some(num) = parse_wat_nat(&text) {
                                 if nat_index == 0 {
                                     min_limit = num;
                                 } else {
@@ -460,6 +484,8 @@ fn extract_imported_table(desc_node: &Node, source: &str, index: usize) -> Optio
                     }
                 } else if type_child.kind() == "ref_type" {
                     ref_type = extract_ref_type(&type_child, source);
+                } else if type_child.kind() == "table64_type" {
+                    is_table64 = true;
                 }
             }
         }
@@ -470,6 +496,7 @@ fn extract_imported_table(desc_node: &Node, source: &str, index: usize) -> Optio
         index,
         ref_type,
         limits: (min_limit, max_limit),
+        is_table64,
         line: desc_node.range().start_point.row as u32,
         range: name_range,
     })
@@ -826,6 +853,7 @@ fn extract_function(
     let mut results = extract_results(func_node, source);
     let locals = extract_locals(func_node, source);
     let blocks = extract_blocks(func_node, source);
+    let has_type_use = has_type_use_child(func_node);
 
     // If results (and/or params) are empty but there's a (type $t) reference, resolve from the type
     if results.is_empty() {
@@ -854,6 +882,7 @@ fn extract_function(
         end_byte: func_node.end_byte(),
         range: name_range,
         doc_comment,
+        has_type_use,
     })
 }
 
@@ -936,6 +965,17 @@ fn extract_results(func_node: &Node, source: &str) -> Vec<ValueType> {
     results
 }
 
+/// Check if a node has a `type_use` child (i.e., `(type ...)` reference).
+fn has_type_use_child(node: &Node) -> bool {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "type_use" {
+            return true;
+        }
+    }
+    false
+}
+
 /// Resolve params and results from a `(type $t)` reference on a function node.
 /// Returns `Some((params, results))` if a type_use was found and resolved.
 fn resolve_type_use(
@@ -978,11 +1018,61 @@ fn resolve_type_use(
                             return Some((parameters, results.clone()));
                         }
                     }
+
+                    // Fallback: try implicit type resolution for numeric indices
+                    // beyond the explicit type count (e.g., types created by inline
+                    // function signatures)
+                    if let Ok(idx) = type_ref.parse::<usize>() {
+                        if let Some((params, results)) = resolve_implicit_type(idx, symbol_table) {
+                            let parameters = params
+                                .iter()
+                                .enumerate()
+                                .map(|(i, vt)| Parameter {
+                                    name: None,
+                                    param_type: vt.clone(),
+                                    index: i,
+                                    range: None,
+                                })
+                                .collect();
+                            return Some((parameters, results));
+                        }
+                    }
                 }
             }
         }
     }
     None
+}
+
+/// Resolve a type index that may refer to an implicit type created by
+/// inline function signatures. Builds the implicit type table:
+/// explicit func types + unique function signatures not matching any explicit type.
+/// Only functions without type_use create implicit types.
+fn resolve_implicit_type(
+    idx: usize,
+    symbol_table: &SymbolTable,
+) -> Option<(Vec<ValueType>, Vec<ValueType>)> {
+    let mut sigs: Vec<(Vec<ValueType>, Vec<ValueType>)> = Vec::new();
+    for type_def in &symbol_table.types {
+        if let TypeKind::Func { params, results } = &type_def.kind {
+            sigs.push((params.clone(), results.clone()));
+        }
+    }
+    for func in &symbol_table.functions {
+        if func.has_type_use {
+            continue;
+        }
+        let params: Vec<ValueType> = func
+            .parameters
+            .iter()
+            .map(|p| p.param_type.clone())
+            .collect();
+        let sig = (params, func.results.clone());
+        if !sigs.iter().any(|s| s == &sig) {
+            sigs.push(sig);
+        }
+    }
+    sigs.get(idx).cloned()
 }
 
 /// Extract local variables from a function node
@@ -1805,8 +1895,9 @@ fn extract_table(table_node: &Node, source: &str, index: usize) -> Option<Table>
     };
 
     let mut ref_type = ValueType::Funcref;
-    let mut min_limit = 0;
-    let mut max_limit = None;
+    let mut min_limit: u64 = 0;
+    let mut max_limit: Option<u64> = None;
+    let mut is_table64 = false;
 
     let mut cursor = table_node.walk();
     for child in table_node.children(&mut cursor) {
@@ -1823,7 +1914,7 @@ fn extract_table(table_node: &Node, source: &str, index: usize) -> Option<Table>
                             for limit_child in type_child.children(&mut limits_cursor) {
                                 if limit_child.kind() == "nat" {
                                     let text = node_text(&limit_child, source);
-                                    if let Some(num) = parse_wat_nat(&text).map(|n| n as u32) {
+                                    if let Some(num) = parse_wat_nat(&text) {
                                         if nat_index == 0 {
                                             min_limit = num;
                                         } else {
@@ -1836,6 +1927,8 @@ fn extract_table(table_node: &Node, source: &str, index: usize) -> Option<Table>
                         } else if type_child.kind() == "ref_type" {
                             // Extract ref type from nested structure
                             ref_type = extract_ref_type(&type_child, source);
+                        } else if type_child.kind() == "table64_type" {
+                            is_table64 = true;
                         }
                     }
                 }
@@ -1850,7 +1943,7 @@ fn extract_table(table_node: &Node, source: &str, index: usize) -> Option<Table>
                     for limit_child in type_child.children(&mut limits_cursor) {
                         if limit_child.kind() == "nat" {
                             let text = node_text(&limit_child, source);
-                            if let Ok(num) = text.parse::<u32>() {
+                            if let Some(num) = parse_wat_nat(&text) {
                                 if nat_index == 0 {
                                     min_limit = num;
                                 } else {
@@ -1862,6 +1955,8 @@ fn extract_table(table_node: &Node, source: &str, index: usize) -> Option<Table>
                     }
                 } else if type_child.kind() == "ref_type" {
                     ref_type = extract_ref_type(&type_child, source);
+                } else if type_child.kind() == "table64_type" {
+                    is_table64 = true;
                 }
             }
         }
@@ -1872,6 +1967,7 @@ fn extract_table(table_node: &Node, source: &str, index: usize) -> Option<Table>
         index,
         ref_type,
         limits: (min_limit, max_limit),
+        is_table64,
         line: table_node.range().start_point.row as u32,
         range: name_range,
     })
@@ -2111,7 +2207,7 @@ fn node_text(node: &Node, source: &str) -> String {
 }
 
 /// Parse a WAT natural number, handling hex (0x...) and underscore separators.
-fn parse_wat_nat(text: &str) -> Option<u64> {
+pub(crate) fn parse_wat_nat(text: &str) -> Option<u64> {
     let text = text.trim().replace('_', "");
     if text.starts_with("0x") || text.starts_with("0X") {
         u64::from_str_radix(&text[2..], 16).ok()
@@ -2304,9 +2400,57 @@ fn extract_ref_type(ref_type_node: &Node, source: &str) -> ValueType {
             }
             "ref_type_ref" => {
                 // (ref null? kind) or (ref null? $type)
-                // Similar logic
-                return ValueType::Structref; // Fallback
+                // Walk children to extract nullable and index
+                let mut concrete_cursor = child.walk();
+                let mut index_val = None;
+                let mut nullable = false;
+                let mut ref_kind = None;
+
+                for c in child.children(&mut concrete_cursor) {
+                    let ck = c.kind();
+                    #[cfg(all(feature = "wasm", not(feature = "native")))]
+                    let ck = ck.as_str();
+                    if ck == "index" {
+                        let idx_text = node_text(&c, source);
+                        if let Ok(idx) = idx_text.parse::<u32>() {
+                            index_val = Some(idx);
+                        }
+                        // Named index: leave index_val as None, fallback to Structref
+                    } else if ck == "null" || node_text(&c, source) == "null" {
+                        nullable = true;
+                    } else if ck == "ref_kind" {
+                        ref_kind = Some(node_text(&c, source));
+                    }
+                }
+
+                // If it's a ref_kind like (ref func), (ref extern), etc.
+                if let Some(kind) = ref_kind {
+                    return match kind.as_str() {
+                        "func" => ValueType::Funcref,
+                        "extern" => ValueType::Externref,
+                        "any" => ValueType::Anyref,
+                        "eq" => ValueType::Eqref,
+                        "i31" => ValueType::I31ref,
+                        "struct" => ValueType::Structref,
+                        "array" => ValueType::Arrayref,
+                        "null" | "none" => ValueType::Nullref,
+                        "nofunc" => ValueType::NullFuncref,
+                        "noextern" => ValueType::NullExternref,
+                        _ => ValueType::Funcref,
+                    };
+                }
+
+                if let Some(idx) = index_val {
+                    return if nullable {
+                        ValueType::RefNull(idx)
+                    } else {
+                        ValueType::Ref(idx)
+                    };
+                }
+                return ValueType::Structref; // Fallback for named types
             }
+            // Handle intermediate ref_type wrapper node (e.g. value_type_ref_type → ref_type)
+            "ref_type" => return extract_ref_type(&child, source),
             _ => {
                 let text = node_text(&child, source);
                 if let Some(vt) = simple_type_from_str(&text) {

--- a/src/symbol_lookup.rs
+++ b/src/symbol_lookup.rs
@@ -230,6 +230,7 @@ mod tests {
             end_byte: 100,
             range: Some(Range::from_coords(1, 6, 1, 10)),
             doc_comment: None,
+            has_type_use: false,
         });
         symbols.add_global(Global {
             name: Some("$counter".to_string()),

--- a/src/wast_parser.rs
+++ b/src/wast_parser.rs
@@ -63,6 +63,7 @@ fn extract_symbols(wat: &wast::Wat, source: &str) -> Result<SymbolTable, String>
                             end_byte: import.span.offset(),
                             range,
                             doc_comment: None, // Imported functions don't have doc comments
+                            has_type_use: false,
                         });
                         func_index += 1;
                     }
@@ -84,6 +85,7 @@ fn extract_symbols(wat: &wast::Wat, source: &str) -> Result<SymbolTable, String>
                             index: table_index,
                             ref_type: ValueType::Funcref,
                             limits: (0, None),
+                            is_table64: false,
                             line,
                             range,
                         });
@@ -138,6 +140,7 @@ fn extract_symbols(wat: &wast::Wat, source: &str) -> Result<SymbolTable, String>
                     end_byte: func.span.offset(),
                     range: func.id.map(|id| id_to_range(id, source)),
                     doc_comment: None, // wast parser doesn't extract comments
+                    has_type_use: false,
                 });
                 func_index += 1;
             }
@@ -159,6 +162,7 @@ fn extract_symbols(wat: &wast::Wat, source: &str) -> Result<SymbolTable, String>
                     index: table_index,
                     ref_type: ValueType::Funcref,
                     limits: (0, None),
+                    is_table64: false,
                     line: span_to_line(table.span, source),
                     range: table.id.map(|id| id_to_range(id, source)),
                 });


### PR DESCRIPTION
## Summary

- Add elem segment type validation (item types vs declared type and target table type)
- Add type forward reference checks (disallow forward refs outside rec groups)
- Add call_indirect table requirement checks and inline elem func ref validation
- Track `has_type_use` on Function for accurate implicit type counting and resolution
- Extract types before imports so type_use in imported functions can be resolved
- Parse alignment/offset as u64 to detect overflow; table limits now u64
- Resolve table element types from symbol table for table.get/set/grow/fill
- Return typed Ref(n) from ref.func; exported functions count as declared
- Fix br_table and select handling in unreachable contexts
- Add NullFuncref/Structref subtype compatibility in type checker
- Improve ref_type_ref parsing and comment-aware paren matching in wast-runner