### PR TITLE
defrag: add node_kind! macro, derive Copy on ValueType, fix O(n²) dedup

### DIFF
--- a/src/diagnostics_core/module_checks.rs
+++ b/src/diagnostics_core/module_checks.rs
@@ -114,9 +114,7 @@ fn find_module_node(root: &Node) -> Option<Node> {
 fn for_each_module_field(module: &Node, mut f: impl FnMut(&Node)) {
     let mut cursor = module.walk();
     for child in module.children(&mut cursor) {
-        let ck = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let ck = ck.as_str();
+        node_kind!(ck = child);
         if ck == "module_field" {
             // Each module_field wraps one actual field
             let mut fc = child.walk();
@@ -219,9 +217,7 @@ fn check_multiple_starts(module: &Node, source: &str, diagnostics: &mut Vec<Diag
     let _ = source;
     let mut seen_start = false;
     for_each_module_field(module, |field| {
-        let fk = field.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let fk = fk.as_str();
+        node_kind!(fk = field);
         if fk == "module_field_start" {
             if seen_start {
                 diagnostics.push(Diagnostic::error(
@@ -246,9 +242,7 @@ fn check_start_signature(
     diagnostics: &mut Vec<Diagnostic>,
 ) {
     for_each_module_field(module, |field| {
-        let fk = field.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let fk = fk.as_str();
+        node_kind!(fk = field);
         if fk != "module_field_start" {
             return;
         }
@@ -256,9 +250,7 @@ fn check_start_signature(
         // Find the function index referenced by start
         let mut cursor = field.walk();
         for child in field.children(&mut cursor) {
-            let ck = child.kind();
-            #[cfg(all(feature = "wasm", not(feature = "native")))]
-            let ck = ck.as_str();
+            node_kind!(ck = child);
             if ck == "index" || ck == "identifier" {
                 let text = node_text(&child, source);
                 let func = if text.starts_with('$') {
@@ -270,9 +262,7 @@ fn check_start_signature(
                     let mut ic = child.walk();
                     let mut found = None;
                     for idx_child in child.children(&mut ic) {
-                        let ik = idx_child.kind();
-                        #[cfg(all(feature = "wasm", not(feature = "native")))]
-                        let ik = ik.as_str();
+                        node_kind!(ik = idx_child);
                         if ik == "identifier" {
                             let id_text = node_text(&idx_child, source);
                             found = symbols.get_function_by_name(id_text);
@@ -305,9 +295,7 @@ fn check_duplicate_exports(module: &Node, source: &str, diagnostics: &mut Vec<Di
     let mut seen_exports: HashMap<String, Range> = HashMap::new();
 
     for_each_module_field(module, |field| {
-        let fk = field.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let fk = fk.as_str();
+        node_kind!(fk = field);
 
         match fk {
             // Standalone export: (export "name" (func $idx))
@@ -324,9 +312,7 @@ fn check_duplicate_exports(module: &Node, source: &str, diagnostics: &mut Vec<Di
             | "module_field_tag" => {
                 let mut cursor = field.walk();
                 for child in field.children(&mut cursor) {
-                    let ck = child.kind();
-                    #[cfg(all(feature = "wasm", not(feature = "native")))]
-                    let ck = ck.as_str();
+                    node_kind!(ck = child);
                     if ck == "export" {
                         if let Some(name) = extract_name_child(&child, source) {
                             check_export_name(name, &child, &mut seen_exports, diagnostics);
@@ -346,9 +332,7 @@ fn extract_export_name<'a>(node: &Node, source: &'a str) -> Option<&'a str> {
 fn extract_name_child<'a>(node: &Node, source: &'a str) -> Option<&'a str> {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        let ck = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let ck = ck.as_str();
+        node_kind!(ck = child);
         if ck == "name" {
             let text = node_text(&child, source);
             // name node wraps a string node; strip outer quotes
@@ -387,9 +371,7 @@ fn check_import_ordering(module: &Node, source: &str, diagnostics: &mut Vec<Diag
     let mut seen_non_import = false;
 
     for_each_module_field(module, |field| {
-        let fk = field.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let fk = fk.as_str();
+        node_kind!(fk = field);
 
         match fk {
             "module_field_import" => {
@@ -432,9 +414,7 @@ fn check_import_ordering(module: &Node, source: &str, diagnostics: &mut Vec<Diag
 fn has_inline_import(node: &Node) -> bool {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        let ck = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let ck = ck.as_str();
+        node_kind!(ck = child);
         if ck == "import" {
             return true;
         }
@@ -442,9 +422,7 @@ fn has_inline_import(node: &Node) -> bool {
         if ck == "memory_fields_type" || ck == "table_fields_type" {
             let mut inner = child.walk();
             for gc in child.children(&mut inner) {
-                let gck = gc.kind();
-                #[cfg(all(feature = "wasm", not(feature = "native")))]
-                let gck = gck.as_str();
+                node_kind!(gck = gc);
                 if gck == "import" {
                     return true;
                 }
@@ -467,9 +445,7 @@ fn check_duplicate_identifiers(module: &Node, source: &str, diagnostics: &mut Ve
     let mut seen_tag: HashMap<String, Range> = HashMap::new();
 
     for_each_module_field(module, |field| {
-        let fk = field.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let fk = fk.as_str();
+        node_kind!(fk = field);
 
         match fk {
             "module_field_func" => {
@@ -498,9 +474,7 @@ fn check_duplicate_identifiers(module: &Node, source: &str, diagnostics: &mut Ve
                     // (rec (type $id? type_field) ...)
                     // But the inner nodes are anonymous sequences, so we look for identifier
                     // children or children that look like type definitions.
-                    let ck = child.kind();
-                    #[cfg(all(feature = "wasm", not(feature = "native")))]
-                    let ck = ck.as_str();
+                    node_kind!(ck = child);
                     if ck == "module_field_type" {
                         check_identifier_dup(&child, source, &mut seen_type, "type", diagnostics);
                     }
@@ -560,15 +534,11 @@ fn check_import_identifier_dup(
 ) {
     let mut cursor = import_node.walk();
     for child in import_node.children(&mut cursor) {
-        let ck = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let ck = ck.as_str();
+        node_kind!(ck = child);
         if ck == "import_desc" {
             let mut dc = child.walk();
             for desc in child.children(&mut dc) {
-                let dk = desc.kind();
-                #[cfg(all(feature = "wasm", not(feature = "native")))]
-                let dk = dk.as_str();
+                node_kind!(dk = desc);
                 match dk {
                     "import_desc_func_type" | "import_desc_type_use" => {
                         check_identifier_dup(&desc, source, seen_func, "func", diagnostics);
@@ -592,28 +562,17 @@ fn check_import_identifier_dup(
     }
 }
 
+/// Find identifier child node. Delegates to shared `find_child_by_kind`.
 #[cfg(feature = "native")]
-fn find_identifier_child<'a>(node: &Node<'a>) -> Option<Node<'a>> {
-    let mut cursor = node.walk();
-    #[allow(clippy::manual_find)]
-    for child in node.children(&mut cursor) {
-        if child.kind() == "identifier" {
-            return Some(child);
-        }
-    }
-    None
+#[inline]
+fn find_identifier_child<'a>(node: &'a Node<'a>) -> Option<Node<'a>> {
+    crate::utils::find_child_by_kind(node, "identifier")
 }
 
 #[cfg(all(feature = "wasm", not(feature = "native")))]
+#[inline]
 fn find_identifier_child(node: &Node) -> Option<Node> {
-    let mut cursor = node.walk();
-    #[allow(clippy::manual_find)]
-    for child in node.children(&mut cursor) {
-        if child.kind() == "identifier" {
-            return Some(child);
-        }
-    }
-    None
+    crate::utils::find_child_by_kind(node, "identifier")
 }
 
 // ============================================================================
@@ -627,9 +586,7 @@ fn check_inline_type_mismatches(
     diagnostics: &mut Vec<Diagnostic>,
 ) {
     for_each_module_field(module, |field| {
-        let fk = field.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let fk = fk.as_str();
+        node_kind!(fk = field);
 
         if fk != "module_field_func" {
             return;
@@ -643,9 +600,7 @@ fn check_inline_type_mismatches(
 
         let mut cursor = field.walk();
         for child in field.children(&mut cursor) {
-            let ck = child.kind();
-            #[cfg(all(feature = "wasm", not(feature = "native")))]
-            let ck = ck.as_str();
+            node_kind!(ck = child);
             match ck {
                 "type_use" => {
                     #[cfg(feature = "native")]
@@ -706,9 +661,7 @@ fn extract_result_types(node: &Node, source: &str, out: &mut Vec<String>) {
 fn collect_value_types_recursive(node: &Node, source: &str, out: &mut Vec<String>) {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        let ck = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let ck = ck.as_str();
+        node_kind!(ck = child);
         if ck == "value_type" || ck == "ref_type" {
             out.push(node_text(&child, source).to_string());
         } else {
@@ -725,9 +678,7 @@ fn resolve_type_use<'a>(
     // type_use: (type $idx) or (type 0)
     let mut cursor = type_use.walk();
     for child in type_use.children(&mut cursor) {
-        let ck = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let ck = ck.as_str();
+        node_kind!(ck = child);
         if ck == "index" {
             let text = node_text(&child, source);
             // Try as name reference
@@ -741,9 +692,7 @@ fn resolve_type_use<'a>(
             // Index may contain an identifier child
             let mut ic = child.walk();
             for idx_child in child.children(&mut ic) {
-                let ik = idx_child.kind();
-                #[cfg(all(feature = "wasm", not(feature = "native")))]
-                let ik = ik.as_str();
+                node_kind!(ik = idx_child);
                 if ik == "identifier" {
                     let id_text = node_text(&idx_child, source);
                     return symbols.get_type_by_name(id_text);
@@ -801,9 +750,7 @@ fn check_constant_expressions(
 ) {
     let mut global_index = symbols.num_imported_globals;
     for_each_module_field(module, |field| {
-        let fk = field.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let fk = fk.as_str();
+        node_kind!(fk = field);
 
         match fk {
             "module_field_global" => {
@@ -842,9 +789,7 @@ fn check_global_init_expr(
     let mut past_global_type = false;
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        let ck = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let ck = ck.as_str();
+        node_kind!(ck = child);
         if ck == "global_type" {
             past_global_type = true;
             continue;
@@ -866,9 +811,7 @@ fn check_offset_expr(
     let max_global = symbols.globals.len();
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        let ck = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let ck = ck.as_str();
+        node_kind!(ck = child);
         if ck == "offset" {
             check_const_instruction_tree(&child, source, symbols, max_global, diagnostics);
         }
@@ -886,15 +829,11 @@ fn check_elem_exprs(
     // elem_expr nodes are inside elem_list, not direct children of module_field_elem
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        let ck = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let ck = ck.as_str();
+        node_kind!(ck = child);
         if ck == "elem_list" {
             let mut inner = child.walk();
             for gc in child.children(&mut inner) {
-                let gk = gc.kind();
-                #[cfg(all(feature = "wasm", not(feature = "native")))]
-                let gk = gk.as_str();
+                node_kind!(gk = gc);
                 if gk == "elem_expr" {
                     check_const_instruction_tree(&gc, source, symbols, max_global, diagnostics);
                 }
@@ -913,16 +852,12 @@ fn check_table_init_expr(
     let max_global = symbols.num_imported_globals;
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        let ck = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let ck = ck.as_str();
+        node_kind!(ck = child);
         // table_fields_type may contain an expr child
         if ck == "table_fields_type" {
             let mut inner = child.walk();
             for gc in child.children(&mut inner) {
-                let gk = gc.kind();
-                #[cfg(all(feature = "wasm", not(feature = "native")))]
-                let gk = gk.as_str();
+                node_kind!(gk = gc);
                 if gk == "expr" {
                     check_const_instruction_tree(&gc, source, symbols, max_global, diagnostics);
                 }
@@ -940,9 +875,7 @@ fn check_const_instruction_tree(
     max_allowed_global: usize,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
-    let kind = node.kind();
-    #[cfg(all(feature = "wasm", not(feature = "native")))]
-    let kind = kind.as_str();
+    node_kind!(kind = node);
 
     match kind {
         "instr_plain" => {
@@ -963,9 +896,7 @@ fn check_const_instruction_tree(
             // Folded expression: first child is instr_plain, check its opcode
             let mut cursor = node.walk();
             for child in node.children(&mut cursor) {
-                let ck = child.kind();
-                #[cfg(all(feature = "wasm", not(feature = "native")))]
-                let ck = ck.as_str();
+                node_kind!(ck = child);
                 if ck == "instr_plain" {
                     let text = node_text(&child, source);
                     let first_token = text.split_whitespace().next().unwrap_or("");
@@ -1033,9 +964,7 @@ fn check_global_get_in_const(
     // Find the index/identifier child
     let mut cursor = instr_node.walk();
     for child in instr_node.children(&mut cursor) {
-        let ck = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let ck = ck.as_str();
+        node_kind!(ck = child);
         if ck == "index" || ck == "identifier" {
             let text = node_text(&child, source);
             let global = if text.starts_with('$') {
@@ -1047,9 +976,7 @@ fn check_global_get_in_const(
                 let mut ic = child.walk();
                 let mut found = None;
                 for idx_child in child.children(&mut ic) {
-                    let ik = idx_child.kind();
-                    #[cfg(all(feature = "wasm", not(feature = "native")))]
-                    let ik = ik.as_str();
+                    node_kind!(ik = idx_child);
                     if ik == "identifier" {
                         found = symbols.get_global_by_name(node_text(&idx_child, source));
                     } else if ik == "nat" {
@@ -1094,9 +1021,7 @@ fn check_data_segment_memory_indices(
     diagnostics: &mut Vec<Diagnostic>,
 ) {
     for_each_module_field(module, |field| {
-        let fk = field.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let fk = fk.as_str();
+        node_kind!(fk = field);
         if fk != "module_field_data" {
             return;
         }
@@ -1109,9 +1034,7 @@ fn check_data_segment_memory_indices(
 
         let mut cursor = field.walk();
         for child in field.children(&mut cursor) {
-            let ck = child.kind();
-            #[cfg(all(feature = "wasm", not(feature = "native")))]
-            let ck = ck.as_str();
+            node_kind!(ck = child);
             if ck == "offset" {
                 has_offset = true;
             }
@@ -1119,9 +1042,7 @@ fn check_data_segment_memory_indices(
                 // (memory $idx) or (memory N)
                 let mut mc = child.walk();
                 for mc_child in child.children(&mut mc) {
-                    let mk = mc_child.kind();
-                    #[cfg(all(feature = "wasm", not(feature = "native")))]
-                    let mk = mk.as_str();
+                    node_kind!(mk = mc_child);
                     if mk == "index" || mk == "identifier" || mk == "nat" {
                         let text = node_text(&mc_child, source);
                         memory_node_range = Some(node_to_range(&child));
@@ -1164,9 +1085,7 @@ fn check_elem_segment_table_indices(
     diagnostics: &mut Vec<Diagnostic>,
 ) {
     for_each_module_field(module, |field| {
-        let fk = field.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let fk = fk.as_str();
+        node_kind!(fk = field);
         if fk != "module_field_elem" {
             return;
         }
@@ -1178,18 +1097,14 @@ fn check_elem_segment_table_indices(
 
         let mut cursor = field.walk();
         for child in field.children(&mut cursor) {
-            let ck = child.kind();
-            #[cfg(all(feature = "wasm", not(feature = "native")))]
-            let ck = ck.as_str();
+            node_kind!(ck = child);
             if ck == "offset" {
                 has_offset = true;
             }
             if ck == "table_use" {
                 let mut tc = child.walk();
                 for tc_child in child.children(&mut tc) {
-                    let tk = tc_child.kind();
-                    #[cfg(all(feature = "wasm", not(feature = "native")))]
-                    let tk = tk.as_str();
+                    node_kind!(tk = tc_child);
                     if tk == "index" || tk == "identifier" || tk == "nat" {
                         let text = node_text(&tc_child, source);
                         table_node_range = Some(node_to_range(&child));
@@ -1231,9 +1146,7 @@ fn check_elem_segment_types(
     diagnostics: &mut Vec<Diagnostic>,
 ) {
     for_each_module_field(module, |field| {
-        let fk = field.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let fk = fk.as_str();
+        node_kind!(fk = field);
         if fk != "module_field_elem" {
             return;
         }
@@ -1245,9 +1158,7 @@ fn check_elem_segment_types(
 
         let mut cursor = field.walk();
         for child in field.children(&mut cursor) {
-            let ck = child.kind();
-            #[cfg(all(feature = "wasm", not(feature = "native")))]
-            let ck = ck.as_str();
+            node_kind!(ck = child);
 
             if ck == "offset" {
                 has_offset = true;
@@ -1255,9 +1166,7 @@ fn check_elem_segment_types(
             if ck == "table_use" {
                 let mut tc = child.walk();
                 for tc_child in child.children(&mut tc) {
-                    let tk = tc_child.kind();
-                    #[cfg(all(feature = "wasm", not(feature = "native")))]
-                    let tk = tk.as_str();
+                    node_kind!(tk = tc_child);
                     if tk == "index" || tk == "identifier" || tk == "nat" {
                         let text = node_text(&tc_child, source);
                         if text.starts_with('$') {
@@ -1274,9 +1183,7 @@ fn check_elem_segment_types(
                 // Extract ref_type from elem_list
                 let mut ec = child.walk();
                 for ec_child in child.children(&mut ec) {
-                    let ek = ec_child.kind();
-                    #[cfg(all(feature = "wasm", not(feature = "native")))]
-                    let ek = ek.as_str();
+                    node_kind!(ek = ec_child);
                     if ek == "ref_type" || ek == "value_type" {
                         let text = node_text(&ec_child, source);
                         elem_type = ValueType::try_parse(text.trim());
@@ -1309,9 +1216,7 @@ fn check_elem_segment_types(
         // Check 2: validate each elem expression item against the declared elem type
         let mut cursor2 = field.walk();
         for child in field.children(&mut cursor2) {
-            let ck = child.kind();
-            #[cfg(all(feature = "wasm", not(feature = "native")))]
-            let ck = ck.as_str();
+            node_kind!(ck = child);
 
             if ck == "elem_list" {
                 check_elem_list_items(&child, &elem_type, source, symbols, diagnostics);
@@ -1349,9 +1254,7 @@ fn check_elem_list_items(
 ) {
     let mut cursor = elem_list.walk();
     for child in elem_list.children(&mut cursor) {
-        let ck = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let ck = ck.as_str();
+        node_kind!(ck = child);
 
         if ck == "elem_expr" {
             check_single_elem_expr(&child, declared_type, source, symbols, diagnostics);
@@ -1373,9 +1276,7 @@ fn check_single_elem_expr(
 
     let mut cursor = elem_expr.walk();
     for child in elem_expr.children(&mut cursor) {
-        let ck = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let ck = ck.as_str();
+        node_kind!(ck = child);
 
         match ck {
             "elem_expr_item" => {
@@ -1433,9 +1334,7 @@ fn check_single_elem_expr(
 /// Infer the type produced by an instruction in an elem context.
 /// Returns None for non-instruction nodes (parens, keywords, etc.)
 fn infer_elem_instr_type(node: &Node, source: &str) -> Option<ValueType> {
-    let kind = node.kind();
-    #[cfg(all(feature = "wasm", not(feature = "native")))]
-    let kind = kind.as_str();
+    node_kind!(kind = node);
 
     match kind {
         "instr_plain" | "expr1_plain" => {
@@ -1534,9 +1433,7 @@ fn check_ref_func_declarations(
     // Step 1: Collect all functions declared in element segments
     let mut declared_funcs: HashSet<usize> = HashSet::new();
     for_each_module_field(module, |field| {
-        let fk = field.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let fk = fk.as_str();
+        node_kind!(fk = field);
         if fk != "module_field_elem" {
             return;
         }
@@ -1545,9 +1442,7 @@ fn check_ref_func_declarations(
 
     // Also collect functions referenced in inline elem expressions on tables
     for_each_module_field(module, |field| {
-        let fk = field.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let fk = fk.as_str();
+        node_kind!(fk = field);
         if fk != "module_field_table" {
             return;
         }
@@ -1557,9 +1452,7 @@ fn check_ref_func_declarations(
     // Also collect functions referenced via ref.func in global/table init expressions
     // Per spec, ref.func in const init contexts counts as a function declaration
     for_each_module_field(module, |field| {
-        let fk = field.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let fk = fk.as_str();
+        node_kind!(fk = field);
         if fk == "module_field_global" || fk == "module_field_table" {
             collect_ref_func_in_const_expr(field, source, symbols, &mut declared_funcs);
         }
@@ -1567,9 +1460,7 @@ fn check_ref_func_declarations(
 
     // Also collect exported functions — per spec, exported functions are considered "declared"
     for_each_module_field(module, |field| {
-        let fk = field.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let fk = fk.as_str();
+        node_kind!(fk = field);
         match fk {
             "module_field_export" => {
                 // Standalone export: (export "name" (func $idx))
@@ -1580,9 +1471,7 @@ fn check_ref_func_declarations(
                 let mut cursor = field.walk();
                 let mut has_export = false;
                 for child in field.children(&mut cursor) {
-                    let ck = child.kind();
-                    #[cfg(all(feature = "wasm", not(feature = "native")))]
-                    let ck = ck.as_str();
+                    node_kind!(ck = child);
                     if ck == "export" {
                         has_export = true;
                         break;
@@ -1592,9 +1481,7 @@ fn check_ref_func_declarations(
                     // Find the function's index from its identifier or position
                     let mut cursor2 = field.walk();
                     for child in field.children(&mut cursor2) {
-                        let ck = child.kind();
-                        #[cfg(all(feature = "wasm", not(feature = "native")))]
-                        let ck = ck.as_str();
+                        node_kind!(ck = child);
                         if ck == "identifier" {
                             let name = node_text(&child, source).trim();
                             if let Some(idx) = resolve_func_index(name, symbols) {
@@ -1630,16 +1517,12 @@ fn find_exported_func_recursive(
     symbols: &SymbolTable,
     declared: &mut HashSet<usize>,
 ) {
-    let kind = node.kind();
-    #[cfg(all(feature = "wasm", not(feature = "native")))]
-    let kind = kind.as_str();
+    node_kind!(kind = node);
     if kind == "export_desc_func" {
         // (func $idx) — find the index child
         let mut cursor = node.walk();
         for child in node.children(&mut cursor) {
-            let ck = child.kind();
-            #[cfg(all(feature = "wasm", not(feature = "native")))]
-            let ck = ck.as_str();
+            node_kind!(ck = child);
             if ck == "index" {
                 let idx_text = node_text(&child, source).trim();
                 if let Some(idx) = resolve_func_index(idx_text, symbols) {
@@ -1662,9 +1545,7 @@ fn collect_ref_func_in_const_expr(
     symbols: &SymbolTable,
     declared: &mut HashSet<usize>,
 ) {
-    let kind = node.kind();
-    #[cfg(all(feature = "wasm", not(feature = "native")))]
-    let kind = kind.as_str();
+    node_kind!(kind = node);
 
     if kind == "instr_plain" {
         let text = node_text(node, source);
@@ -1672,9 +1553,7 @@ fn collect_ref_func_in_const_expr(
             // Find the function reference
             let mut cursor = node.walk();
             for child in node.children(&mut cursor) {
-                let ck = child.kind();
-                #[cfg(all(feature = "wasm", not(feature = "native")))]
-                let ck = ck.as_str();
+                node_kind!(ck = child);
                 if ck == "index" || ck == "identifier" || ck == "nat" {
                     let ref_text = node_text(&child, source).trim();
                     if let Some(idx) = resolve_func_index(ref_text, symbols) {
@@ -1713,9 +1592,7 @@ fn collect_func_refs_recursive(
 ) {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        let ck = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let ck = ck.as_str();
+        node_kind!(ck = child);
 
         if ck == "identifier" || ck == "index" {
             let text = node_text(&child, source).trim();
@@ -1782,9 +1659,7 @@ fn walk_for_ref_func(
     declared: &HashSet<usize>,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
-    let kind = node.kind();
-    #[cfg(all(feature = "wasm", not(feature = "native")))]
-    let kind = kind.as_str();
+    node_kind!(kind = node);
 
     // Check if this is a ref.func instruction
     if kind == "instr_plain" || kind == "op_index" || kind == "op_nullary" {
@@ -1793,17 +1668,13 @@ fn walk_for_ref_func(
             // Find the function reference argument
             let mut cursor = node.walk();
             for child in node.children(&mut cursor) {
-                let ck = child.kind();
-                #[cfg(all(feature = "wasm", not(feature = "native")))]
-                let ck = ck.as_str();
+                node_kind!(ck = child);
 
                 // Look inside op_ nodes for the index
                 if ck.starts_with("op_") {
                     let mut inner_cursor = child.walk();
                     for inner in child.children(&mut inner_cursor) {
-                        let ik = inner.kind();
-                        #[cfg(all(feature = "wasm", not(feature = "native")))]
-                        let ik = ik.as_str();
+                        node_kind!(ik = inner);
                         if ik == "identifier" || ik == "index" || ik == "nat" {
                             check_ref_func_target(
                                 &inner,
@@ -1866,9 +1737,7 @@ fn check_ref_func_target(
 /// Check that end labels match opening labels on block/loop/if statements.
 pub fn check_block_label_mismatch(node: &Node, source: &str) -> Vec<Diagnostic> {
     let mut diagnostics = Vec::new();
-    let kind = node.kind();
-    #[cfg(all(feature = "wasm", not(feature = "native")))]
-    let kind = kind.as_str();
+    node_kind!(kind = node);
 
     if !matches!(kind, "block_block" | "block_loop" | "block_if") {
         return diagnostics;
@@ -1890,9 +1759,7 @@ pub fn check_block_label_mismatch(node: &Node, source: &str) -> Vec<Diagnostic> 
     // First pass: find the opening label
     // Opening label is the first identifier that appears right after the block keyword
     for (i, child) in children.iter().enumerate() {
-        let ck = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let ck = ck.as_str();
+        node_kind!(ck = child);
         if ck == "identifier" {
             // Make sure this is not after "end" or "else"
             if i > 0 {
@@ -1912,9 +1779,7 @@ pub fn check_block_label_mismatch(node: &Node, source: &str) -> Vec<Diagnostic> 
     let mut after_else = false;
 
     for child in &children {
-        let ck = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let ck = ck.as_str();
+        node_kind!(ck = child);
 
         // Check for anonymous "end" and "else" tokens
         if child.is_named() {
@@ -2053,9 +1918,7 @@ fn check_type_forward_refs(
 ) {
     let mut type_index = 0usize;
     for_each_module_field(module, |node| {
-        let kind = node.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let kind = kind.as_str();
+        node_kind!(kind = node);
 
         if kind == "module_field_type" {
             check_type_body_for_forward_refs(node, source, symbols, type_index, diagnostics);
@@ -2065,9 +1928,7 @@ fn check_type_forward_refs(
             // (forward references within rec groups are allowed)
             let mut cursor = node.walk();
             for child in node.children(&mut cursor) {
-                let ck = child.kind();
-                #[cfg(all(feature = "wasm", not(feature = "native")))]
-                let ck = ck.as_str();
+                node_kind!(ck = child);
                 if ck == "module_field_type" {
                     type_index += 1;
                 }
@@ -2084,9 +1945,7 @@ fn check_type_body_for_forward_refs(
     current_type_index: usize,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
-    let kind = node.kind();
-    #[cfg(all(feature = "wasm", not(feature = "native")))]
-    let kind = kind.as_str();
+    node_kind!(kind = node);
 
     // Look for type references in ref_type, _heap_type_or_ref, value_type_ref_type
     if kind == "ref_type" || kind == "_heap_type_or_ref" || kind == "value_type_ref_type" {
@@ -2110,9 +1969,7 @@ fn check_ref_for_forward_type(
 ) {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        let ck = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let ck = ck.as_str();
+        node_kind!(ck = child);
 
         if ck == "identifier" {
             let name = node_text(&child, source);
@@ -2131,9 +1988,7 @@ fn check_ref_for_forward_type(
             // Check for numeric or identifier children
             let mut ic = child.walk();
             for idx_child in child.children(&mut ic) {
-                let ik = idx_child.kind();
-                #[cfg(all(feature = "wasm", not(feature = "native")))]
-                let ik = ik.as_str();
+                node_kind!(ik = idx_child);
 
                 if ik == "identifier" {
                     let name = node_text(&idx_child, source);
@@ -2173,30 +2028,21 @@ fn check_ref_for_forward_type(
 /// Count unique implicit function types (signatures not matching any explicit type).
 /// Only functions with inline signatures (no type_use) create implicit types.
 fn count_unique_implicit_types(symbols: &SymbolTable) -> usize {
-    // Collect known signatures: (params, results) pairs
-    let mut known_sigs: Vec<(Vec<ValueType>, Vec<ValueType>)> = Vec::new();
+    // Use HashSet for O(1) dedup instead of O(n) Vec.any()
+    let mut seen = std::collections::HashSet::new();
     for type_def in &symbols.types {
         if let TypeKind::Func { params, results } = &type_def.kind {
-            known_sigs.push((params.clone(), results.clone()));
+            seen.insert((params.clone(), results.clone()));
         }
     }
 
     let mut implicit_count = 0;
     for func in &symbols.functions {
-        // Functions with type_use reference an existing type, not create a new one
         if func.has_type_use {
             continue;
         }
-        let params: Vec<ValueType> = func
-            .parameters
-            .iter()
-            .map(|p| p.param_type.clone())
-            .collect();
-        let already_known = known_sigs
-            .iter()
-            .any(|(kp, kr)| kp == &params && kr == &func.results);
-        if !already_known {
-            known_sigs.push((params, func.results.clone()));
+        let params: Vec<ValueType> = func.parameters.iter().map(|p| p.param_type).collect();
+        if seen.insert((params, func.results.clone())) {
             implicit_count += 1;
         }
     }
@@ -2210,9 +2056,7 @@ fn walk_for_unknown_type_refs(
     max_type_count: usize,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
-    let kind = node.kind();
-    #[cfg(all(feature = "wasm", not(feature = "native")))]
-    let kind = kind.as_str();
+    node_kind!(kind = node);
 
     // Check ref_type nodes for numeric heap type indices
     if kind == "ref_type" || kind == "_heap_type_or_ref" {
@@ -2264,9 +2108,7 @@ fn find_type_index_in_ref(
 ) {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        let ck = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let ck = ck.as_str();
+        node_kind!(ck = child);
 
         // A nat/dec_nat/hex_nat inside a ref type is a numeric type index
         if ck == "nat" || ck == "dec_nat" || ck == "hex_nat" {
@@ -2301,17 +2143,13 @@ fn check_type_use_index(
 ) {
     let mut cursor = type_use_node.walk();
     for child in type_use_node.children(&mut cursor) {
-        let ck = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let ck = ck.as_str();
+        node_kind!(ck = child);
 
         if ck == "index" {
             // Check the index node's children for a numeric value
             let mut idx_cursor = child.walk();
             for idx_child in child.children(&mut idx_cursor) {
-                let ick = idx_child.kind();
-                #[cfg(all(feature = "wasm", not(feature = "native")))]
-                let ick = ick.as_str();
+                node_kind!(ick = idx_child);
 
                 if ick == "nat" || ick == "dec_nat" || ick == "hex_nat" {
                     let text = node_text(&idx_child, source);
@@ -2475,9 +2313,7 @@ fn infer_const_instr_type(
 fn get_const_instr_type_index(node: &Node, source: &str, symbols: &SymbolTable) -> Option<usize> {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        let ck = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let ck = ck.as_str();
+        node_kind!(ck = child);
         if ck == "index" || ck == "identifier" {
             let text = node_text(&child, source);
             if text.starts_with('$') {
@@ -2489,9 +2325,7 @@ fn get_const_instr_type_index(node: &Node, source: &str, symbols: &SymbolTable) 
             // Check children
             let mut ic = child.walk();
             for idx_child in child.children(&mut ic) {
-                let ik = idx_child.kind();
-                #[cfg(all(feature = "wasm", not(feature = "native")))]
-                let ik = ik.as_str();
+                node_kind!(ik = idx_child);
                 if ik == "identifier" {
                     return symbols
                         .get_type_by_name(node_text(&idx_child, source))
@@ -2514,9 +2348,7 @@ fn get_const_instr_type_index(node: &Node, source: &str, symbols: &SymbolTable) 
 fn resolve_ref_null_heap_type(node: &Node, source: &str) -> Option<String> {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        let ck = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let ck = ck.as_str();
+        node_kind!(ck = child);
         // The heap type can appear as various node kinds
         if matches!(
             ck,
@@ -2531,9 +2363,7 @@ fn resolve_ref_null_heap_type(node: &Node, source: &str) -> Option<String> {
         if ck == "index" {
             let mut ic = child.walk();
             for idx_child in child.children(&mut ic) {
-                let ik = idx_child.kind();
-                #[cfg(all(feature = "wasm", not(feature = "native")))]
-                let ik = ik.as_str();
+                node_kind!(ik = idx_child);
                 if matches!(ik, "identifier" | "nat") {
                     let text = node_text(&idx_child, source).trim().to_string();
                     if !text.is_empty() {
@@ -2555,30 +2385,26 @@ fn resolve_ref_null_heap_type(node: &Node, source: &str) -> Option<String> {
 fn resolve_global_get_type(node: &Node, source: &str, symbols: &SymbolTable) -> Option<ValueType> {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        let ck = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let ck = ck.as_str();
+        node_kind!(ck = child);
         if ck == "index" || ck == "identifier" {
             let text = node_text(&child, source);
             if text.starts_with('$') {
-                return symbols.get_global_by_name(text).map(|g| g.var_type.clone());
+                return symbols.get_global_by_name(text).map(|g| g.var_type);
             }
             if let Ok(idx) = text.parse::<usize>() {
-                return symbols.get_global_by_index(idx).map(|g| g.var_type.clone());
+                return symbols.get_global_by_index(idx).map(|g| g.var_type);
             }
             let mut ic = child.walk();
             for idx_child in child.children(&mut ic) {
-                let ik = idx_child.kind();
-                #[cfg(all(feature = "wasm", not(feature = "native")))]
-                let ik = ik.as_str();
+                node_kind!(ik = idx_child);
                 if ik == "identifier" {
                     return symbols
                         .get_global_by_name(node_text(&idx_child, source))
-                        .map(|g| g.var_type.clone());
+                        .map(|g| g.var_type);
                 }
                 if ik == "nat" {
                     if let Ok(idx) = node_text(&idx_child, source).parse::<usize>() {
-                        return symbols.get_global_by_index(idx).map(|g| g.var_type.clone());
+                        return symbols.get_global_by_index(idx).map(|g| g.var_type);
                     }
                 }
             }
@@ -2594,9 +2420,7 @@ fn count_const_instrs_deep(
     source: &str,
     symbols: &SymbolTable,
 ) -> (usize, Option<ValueType>) {
-    let kind = node.kind();
-    #[cfg(all(feature = "wasm", not(feature = "native")))]
-    let kind = kind.as_str();
+    node_kind!(kind = node);
 
     match kind {
         "instr_plain" => {
@@ -2609,9 +2433,7 @@ fn count_const_instrs_deep(
             // Folded expression: the instruction itself produces one value
             let mut cursor = node.walk();
             for child in node.children(&mut cursor) {
-                let ck = child.kind();
-                #[cfg(all(feature = "wasm", not(feature = "native")))]
-                let ck = ck.as_str();
+                node_kind!(ck = child);
                 if ck == "instr_plain" {
                     let text = node_text(&child, source);
                     let first_token = text.split_whitespace().next().unwrap_or("");
@@ -2647,9 +2469,7 @@ fn check_constant_expression_types(
 ) {
     let mut global_idx = 0usize;
     for_each_module_field(module, |field| {
-        let fk = field.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let fk = fk.as_str();
+        node_kind!(fk = field);
 
         match fk {
             "module_field_global" => {
@@ -2683,15 +2503,11 @@ fn check_constant_expression_types(
                 // Count imported globals for forward ref checking
                 let mut cursor = field.walk();
                 for child in field.children(&mut cursor) {
-                    let ck = child.kind();
-                    #[cfg(all(feature = "wasm", not(feature = "native")))]
-                    let ck = ck.as_str();
+                    node_kind!(ck = child);
                     if ck == "import_desc" {
                         let mut dc = child.walk();
                         for desc in child.children(&mut dc) {
-                            let dk = desc.kind();
-                            #[cfg(all(feature = "wasm", not(feature = "native")))]
-                            let dk = dk.as_str();
+                            node_kind!(dk = desc);
                             if dk == "import_desc_global_type" {
                                 global_idx += 1;
                             }
@@ -2708,9 +2524,7 @@ fn check_constant_expression_types(
 fn extract_global_value_type(node: &Node, source: &str) -> Option<ValueType> {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        let ck = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let ck = ck.as_str();
+        node_kind!(ck = child);
         if ck == "global_type" {
             // Search for value_type or ref_type inside global_type
             return extract_type_from_global_type(&child, source);
@@ -2723,9 +2537,7 @@ fn extract_global_value_type(node: &Node, source: &str) -> Option<ValueType> {
 fn extract_type_from_global_type(node: &Node, source: &str) -> Option<ValueType> {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        let ck = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let ck = ck.as_str();
+        node_kind!(ck = child);
         if ck == "global_type_imm"
             || ck == "global_type_mut"
             || ck == "value_type"
@@ -2758,9 +2570,7 @@ fn extract_type_from_global_type(node: &Node, source: &str) -> Option<ValueType>
 fn extract_value_type_recursive(node: &Node, source: &str) -> Option<ValueType> {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        let ck = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let ck = ck.as_str();
+        node_kind!(ck = child);
         if ck == "value_type" || ck == "ref_type" {
             let text = node_text(&child, source);
             if let Some(vt) = ValueType::try_parse(text.trim()) {
@@ -2832,9 +2642,7 @@ fn check_const_expr_type_for_global(
     let mut last_type: Option<ValueType> = None;
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        let ck = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let ck = ck.as_str();
+        node_kind!(ck = child);
         if ck == "global_type" {
             past_global_type = true;
             continue;
@@ -2877,9 +2685,7 @@ fn check_data_offset_type(
 ) {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        let ck = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let ck = ck.as_str();
+        node_kind!(ck = child);
         if ck == "offset" {
             let (count, ty) = count_const_instrs_deep(&child, source, symbols);
             // Expected: i32 for memory32, i64 for memory64
@@ -2910,9 +2716,7 @@ fn check_elem_offset_type(
 ) {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        let ck = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let ck = ck.as_str();
+        node_kind!(ck = child);
         if ck == "offset" {
             let (count, ty) = count_const_instrs_deep(&child, source, symbols);
             let expected = ValueType::I32;
@@ -2943,15 +2747,11 @@ fn check_table_init_type(
     // Find the table's ref type and init expression
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        let ck = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let ck = ck.as_str();
+        node_kind!(ck = child);
         if ck == "table_fields_type" {
             let mut inner = child.walk();
             for gc in child.children(&mut inner) {
-                let gk = gc.kind();
-                #[cfg(all(feature = "wasm", not(feature = "native")))]
-                let gk = gk.as_str();
+                node_kind!(gk = gc);
                 if gk == "expr" {
                     let (count, ty) = count_const_instrs_deep(&gc, source, symbols);
                     // Get expected type from the table's ref_type
@@ -2977,9 +2777,7 @@ fn check_table_init_type(
 fn extract_table_ref_type(node: &Node, source: &str) -> Option<ValueType> {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        let ck = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let ck = ck.as_str();
+        node_kind!(ck = child);
         if ck == "table_type" {
             return extract_ref_type_from_node(&child, source);
         }
@@ -2995,9 +2793,7 @@ fn extract_table_ref_type(node: &Node, source: &str) -> Option<ValueType> {
 fn extract_ref_type_from_node(node: &Node, source: &str) -> Option<ValueType> {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        let ck = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let ck = ck.as_str();
+        node_kind!(ck = child);
         if ck == "ref_type" || ck == "value_type" {
             let text = node_text(&child, source);
             if let Some(vt) = ValueType::try_parse(text.trim()) {
@@ -3033,24 +2829,18 @@ fn check_global_forward_refs(
     let mut current_global_idx = 0usize;
 
     for_each_module_field(module, |field| {
-        let fk = field.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let fk = fk.as_str();
+        node_kind!(fk = field);
 
         match fk {
             "module_field_import" => {
                 // Count imported globals
                 let mut cursor = field.walk();
                 for child in field.children(&mut cursor) {
-                    let ck = child.kind();
-                    #[cfg(all(feature = "wasm", not(feature = "native")))]
-                    let ck = ck.as_str();
+                    node_kind!(ck = child);
                     if ck == "import_desc" {
                         let mut dc = child.walk();
                         for desc in child.children(&mut dc) {
-                            let dk = desc.kind();
-                            #[cfg(all(feature = "wasm", not(feature = "native")))]
-                            let dk = dk.as_str();
+                            node_kind!(dk = desc);
                             if dk == "import_desc_global_type" {
                                 current_global_idx += 1;
                             }
@@ -3087,9 +2877,7 @@ fn check_global_get_forward_ref(
     let mut past_global_type = false;
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        let ck = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let ck = ck.as_str();
+        node_kind!(ck = child);
         if ck == "global_type" {
             past_global_type = true;
             continue;
@@ -3114,9 +2902,7 @@ fn check_global_get_forward_ref_recursive(
     current_idx: usize,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
-    let kind = node.kind();
-    #[cfg(all(feature = "wasm", not(feature = "native")))]
-    let kind = kind.as_str();
+    node_kind!(kind = node);
 
     if kind == "instr_plain" {
         let text = node_text(node, source);
@@ -3141,9 +2927,7 @@ fn check_global_get_forward_ref_recursive(
     if kind == "expr1_plain" {
         let mut cursor = node.walk();
         for child in node.children(&mut cursor) {
-            let ck = child.kind();
-            #[cfg(all(feature = "wasm", not(feature = "native")))]
-            let ck = ck.as_str();
+            node_kind!(ck = child);
             if ck == "instr_plain" {
                 let text = node_text(&child, source);
                 let first_token = text.split_whitespace().next().unwrap_or("");
@@ -3188,9 +2972,7 @@ fn resolve_global_ref_index(
 ) -> Option<usize> {
     let mut cursor = instr_node.walk();
     for child in instr_node.children(&mut cursor) {
-        let ck = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let ck = ck.as_str();
+        node_kind!(ck = child);
         if ck == "index" || ck == "identifier" {
             let text = node_text(&child, source);
             if text.starts_with('$') {
@@ -3201,9 +2983,7 @@ fn resolve_global_ref_index(
             }
             let mut ic = child.walk();
             for idx_child in child.children(&mut ic) {
-                let ik = idx_child.kind();
-                #[cfg(all(feature = "wasm", not(feature = "native")))]
-                let ik = ik.as_str();
+                node_kind!(ik = idx_child);
                 if ik == "identifier" {
                     return symbols
                         .get_global_by_name(node_text(&idx_child, source))
@@ -3240,9 +3020,7 @@ fn walk_for_block_type_use_mismatches(
     symbols: &SymbolTable,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
-    let kind = node.kind();
-    #[cfg(all(feature = "wasm", not(feature = "native")))]
-    let kind = kind.as_str();
+    node_kind!(kind = node);
 
     if matches!(
         kind,
@@ -3394,9 +3172,7 @@ fn check_block_children_for_type_use(
 /// Also validate table init expression type matches table element type.
 fn check_table_non_nullable_refs(module: &Node, source: &str, diagnostics: &mut Vec<Diagnostic>) {
     for_each_module_field(module, |field| {
-        let fk = field.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let fk = fk.as_str();
+        node_kind!(fk = field);
         if fk != "module_field_table" {
             return;
         }
@@ -3406,9 +3182,7 @@ fn check_table_non_nullable_refs(module: &Node, source: &str, diagnostics: &mut 
 
         let mut cursor = field.walk();
         for child in field.children(&mut cursor) {
-            let ck = child.kind();
-            #[cfg(all(feature = "wasm", not(feature = "native")))]
-            let ck = ck.as_str();
+            node_kind!(ck = child);
             if ck == "table_fields_type" {
                 let text = node_text(&child, source);
                 // Check if this table has a non-nullable ref type
@@ -3422,9 +3196,7 @@ fn check_table_non_nullable_refs(module: &Node, source: &str, diagnostics: &mut 
                 let mut init_expr = None;
                 let mut inner = child.walk();
                 for gc in child.children(&mut inner) {
-                    let gk = gc.kind();
-                    #[cfg(all(feature = "wasm", not(feature = "native")))]
-                    let gk = gk.as_str();
+                    node_kind!(gk = gc);
                     if gk == "expr" {
                         init_expr = Some(gc);
                         break;
@@ -3511,9 +3283,7 @@ fn check_implicit_memory_refs(
 
     // Walk all function bodies looking for memory instructions
     for_each_module_field(module, |field| {
-        let fk = field.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let fk = fk.as_str();
+        node_kind!(fk = field);
         if fk == "module_field_func" {
             walk_for_memory_instrs(field, source, diagnostics);
         }
@@ -3521,9 +3291,7 @@ fn check_implicit_memory_refs(
 }
 
 fn walk_for_memory_instrs(node: &Node, source: &str, diagnostics: &mut Vec<Diagnostic>) {
-    let kind = node.kind();
-    #[cfg(all(feature = "wasm", not(feature = "native")))]
-    let kind = kind.as_str();
+    node_kind!(kind = node);
 
     if kind == "instr_plain" {
         let text = node_text(node, source);
@@ -3557,9 +3325,7 @@ fn check_call_indirect_table_requirements(
     diagnostics: &mut Vec<Diagnostic>,
 ) {
     for_each_module_field(module, |field| {
-        let fk = field.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let fk = fk.as_str();
+        node_kind!(fk = field);
         if fk == "module_field_func" {
             walk_for_call_indirect_checks(field, source, symbols, diagnostics);
         }
@@ -3572,9 +3338,7 @@ fn check_call_indirect_table_requirements(
 fn resolve_call_indirect_table_idx(node: &Node, source: &str, symbols: &SymbolTable) -> usize {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        let ck = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let ck = ck.as_str();
+        node_kind!(ck = child);
         if ck == "index" || ck == "identifier" {
             let text = source[child.byte_range()].trim();
             // Check if this is a table name
@@ -3631,9 +3395,7 @@ fn walk_for_call_indirect_checks(
     symbols: &SymbolTable,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
-    let kind = node.kind();
-    #[cfg(all(feature = "wasm", not(feature = "native")))]
-    let kind = kind.as_str();
+    node_kind!(kind = node);
 
     if kind == "instr_plain" {
         let text = node_text(node, source);
@@ -3648,9 +3410,7 @@ fn walk_for_call_indirect_checks(
     if kind == "expr1_plain" {
         let mut cursor = node.walk();
         for child in node.children(&mut cursor) {
-            let ck = child.kind();
-            #[cfg(all(feature = "wasm", not(feature = "native")))]
-            let ck = ck.as_str();
+            node_kind!(ck = child);
             if ck == "instr_plain" {
                 let text = node_text(&child, source);
                 let first_token = text.split_whitespace().next().unwrap_or("");
@@ -3687,9 +3447,7 @@ fn check_inline_elem_func_refs(
     diagnostics: &mut Vec<Diagnostic>,
 ) {
     for_each_module_field(module, |field| {
-        let fk = field.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let fk = fk.as_str();
+        node_kind!(fk = field);
         if fk != "module_field_table" {
             return;
         }
@@ -3697,9 +3455,7 @@ fn check_inline_elem_func_refs(
         // Look for inline elem segments: table_fields_elem → (elem index*)
         let mut cursor = field.walk();
         for child in field.children(&mut cursor) {
-            let ck = child.kind();
-            #[cfg(all(feature = "wasm", not(feature = "native")))]
-            let ck = ck.as_str();
+            node_kind!(ck = child);
             if ck == "table_fields_elem" {
                 check_inline_table_elem_refs(&child, source, symbols, diagnostics);
             }
@@ -3715,9 +3471,7 @@ fn check_inline_table_elem_refs(
 ) {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        let ck = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let ck = ck.as_str();
+        node_kind!(ck = child);
         if ck == "nat" || ck == "index" {
             let text = node_text(&child, source).trim().to_string();
             if let Ok(idx) = text.parse::<usize>() {

--- a/src/diagnostics_core/references.rs
+++ b/src/diagnostics_core/references.rs
@@ -35,10 +35,7 @@ pub fn check_catch_clause_references(
     let indices: Vec<_> = node
         .children(&mut cursor)
         .filter(|c| {
-            #[cfg(feature = "native")]
-            let kind = c.kind();
-            #[cfg(all(feature = "wasm", not(feature = "native")))]
-            let kind = c.kind();
+            node_kind!(kind = c);
             kind == "index"
         })
         .collect();
@@ -68,10 +65,7 @@ pub fn check_try_catch_clause_references(
 ) -> Vec<Diagnostic> {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        #[cfg(feature = "native")]
-        let kind = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let kind = child.kind();
+        node_kind!(kind = child);
 
         if kind == "index" {
             return find_undefined_identifiers(&child, source, symbols, &InstructionContext::Tag);
@@ -90,10 +84,7 @@ pub fn check_try_delegate_clause_references(
 ) -> Vec<Diagnostic> {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        #[cfg(feature = "native")]
-        let kind = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let kind = child.kind();
+        node_kind!(kind = child);
 
         if kind == "index" {
             return find_undefined_identifiers(
@@ -113,10 +104,7 @@ pub fn check_try_delegate_clause_references(
 pub fn check_start_references(node: &Node, source: &str, symbols: &SymbolTable) -> Vec<Diagnostic> {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        #[cfg(feature = "native")]
-        let kind = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let kind = child.kind();
+        node_kind!(kind = child);
 
         if kind == "index" {
             return find_undefined_identifiers(&child, source, symbols, &InstructionContext::Call);
@@ -138,10 +126,7 @@ pub fn find_first_index_identifier(
 
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        #[cfg(feature = "native")]
-        let kind = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let kind = child.kind();
+        node_kind!(kind = child);
 
         if kind == "index" {
             // Found the first index, check its identifier
@@ -166,10 +151,7 @@ pub fn find_undefined_identifiers(
 ) -> Vec<Diagnostic> {
     let mut diagnostics = Vec::new();
 
-    #[cfg(feature = "native")]
-    let kind = node.kind();
-    #[cfg(all(feature = "wasm", not(feature = "native")))]
-    let kind = node.kind();
+    node_kind!(kind = node);
 
     if kind == "identifier" {
         let identifier_name = &source[node.byte_range()];
@@ -454,10 +436,7 @@ pub fn check_module_level_references(
     source: &str,
     symbols: &SymbolTable,
 ) -> Vec<Diagnostic> {
-    #[cfg(feature = "native")]
-    let kind = node.kind();
-    #[cfg(all(feature = "wasm", not(feature = "native")))]
-    let kind = node.kind();
+    node_kind!(kind = node);
 
     let context = match &*kind {
         "export_desc_func" => InstructionContext::Call,
@@ -478,10 +457,7 @@ pub fn check_module_level_references(
             let is_field = &*kind == "module_field_elem";
             let mut seen_offset = false;
             for child in node.children(&mut cursor) {
-                #[cfg(feature = "native")]
-                let child_kind = child.kind();
-                #[cfg(all(feature = "wasm", not(feature = "native")))]
-                let child_kind = child.kind();
+                node_kind!(child_kind = child);
 
                 if is_field {
                     // Track when we pass the offset — only index nodes after
@@ -514,10 +490,7 @@ pub fn check_module_level_references(
     // and validate its identifier
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        #[cfg(feature = "native")]
-        let child_kind = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let child_kind = child.kind();
+        node_kind!(child_kind = child);
 
         if child_kind == "index" {
             return find_undefined_identifiers(&child, source, symbols, &context);
@@ -531,18 +504,12 @@ pub fn check_module_level_references(
 pub fn is_nested_in_expr(node: &Node) -> bool {
     let mut current = node.parent();
     while let Some(parent) = current {
-        #[cfg(feature = "native")]
-        let kind = parent.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let kind = parent.kind();
+        node_kind!(kind = parent);
 
         if kind == "expr" {
             // Found parent expr, check if its parent is also expr
             if let Some(grandparent) = parent.parent() {
-                #[cfg(feature = "native")]
-                let gp_kind = grandparent.kind();
-                #[cfg(all(feature = "wasm", not(feature = "native")))]
-                let gp_kind = grandparent.kind();
+                node_kind!(gp_kind = grandparent);
 
                 if gp_kind == "expr" || gp_kind.starts_with("expr1_") {
                     return true;

--- a/src/diagnostics_core/semantic.rs
+++ b/src/diagnostics_core/semantic.rs
@@ -59,10 +59,7 @@ pub fn track_stack_in_instr_list(
     // Process all children
     let mut cursor = instr_list.walk();
     for child in instr_list.children(&mut cursor) {
-        #[cfg(feature = "native")]
-        let kind = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let kind = child.kind();
+        node_kind!(kind = child);
 
         match kind.as_ref() {
             "instr" => {
@@ -107,10 +104,7 @@ fn process_instr_node(
 ) {
     let mut cursor = instr_node.walk();
     for child in instr_node.children(&mut cursor) {
-        #[cfg(feature = "native")]
-        let kind = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let kind = child.kind();
+        node_kind!(kind = child);
 
         match kind.as_ref() {
             "instr_plain" => {
@@ -208,20 +202,14 @@ fn process_if_node(node: &Node, source: &str, symbols: &SymbolTable, checker: &m
 fn process_block_body(node: &Node, source: &str, symbols: &SymbolTable, checker: &mut TypeChecker) {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        #[cfg(feature = "native")]
-        let kind = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let kind = child.kind();
+        node_kind!(kind = child);
 
         match kind.as_ref() {
             "instr_list" => {
                 // Process all instructions in the list
                 let mut list_cursor = child.walk();
                 for list_child in child.children(&mut list_cursor) {
-                    #[cfg(feature = "native")]
-                    let list_kind = list_child.kind();
-                    #[cfg(all(feature = "wasm", not(feature = "native")))]
-                    let list_kind = list_child.kind();
+                    node_kind!(list_kind = list_child);
 
                     match list_kind.as_ref() {
                         "instr" => {
@@ -312,10 +300,7 @@ fn process_block_body(node: &Node, source: &str, symbols: &SymbolTable, checker:
 fn get_block_label(node: &Node, source: &str) -> Option<String> {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        #[cfg(feature = "native")]
-        let kind = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let kind = child.kind();
+        node_kind!(kind = child);
 
         if kind == "identifier" {
             return Some(source[child.byte_range()].trim().to_string());
@@ -330,10 +315,7 @@ fn get_block_label(node: &Node, source: &str) -> Option<String> {
         if is_inner_block {
             let mut inner_cursor = child.walk();
             for inner_child in child.children(&mut inner_cursor) {
-                #[cfg(feature = "native")]
-                let ik = inner_child.kind();
-                #[cfg(all(feature = "wasm", not(feature = "native")))]
-                let ik = inner_child.kind();
+                node_kind!(ik = inner_child);
                 if ik == "identifier" {
                     return Some(source[inner_child.byte_range()].trim().to_string());
                 }
@@ -345,20 +327,14 @@ fn get_block_label(node: &Node, source: &str) -> Option<String> {
 
 /// Check if a node is a loop (instr_loop or contains loop_block)
 fn is_loop_node(node: &Node) -> bool {
-    #[cfg(feature = "native")]
-    let kind = node.kind();
-    #[cfg(all(feature = "wasm", not(feature = "native")))]
-    let kind = node.kind();
+    node_kind!(kind = node);
 
     if kind == "instr_loop" {
         return true;
     }
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        #[cfg(feature = "native")]
-        let ck = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let ck = child.kind();
+        node_kind!(ck = child);
         if ck == "loop_block" {
             return true;
         }
@@ -370,10 +346,7 @@ fn is_loop_node(node: &Node) -> bool {
 fn contains_block_if(node: &Node) -> bool {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        #[cfg(feature = "native")]
-        let kind = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let kind = child.kind();
+        node_kind!(kind = child);
 
         if kind == "block_if" {
             return true;
@@ -384,10 +357,7 @@ fn contains_block_if(node: &Node) -> bool {
 
 /// Check if a node is or contains a try_table block
 fn is_try_table_node(node: &Node) -> bool {
-    #[cfg(feature = "native")]
-    let kind = node.kind();
-    #[cfg(all(feature = "wasm", not(feature = "native")))]
-    let kind = node.kind();
+    node_kind!(kind = node);
 
     if kind == "block_try_table" {
         return true;
@@ -405,10 +375,7 @@ fn is_try_table_node(node: &Node) -> bool {
 pub fn get_instruction_name(instr_node: &Node, source: &str) -> Option<String> {
     let mut cursor = instr_node.walk();
     for child in instr_node.children(&mut cursor) {
-        #[cfg(feature = "native")]
-        let kind = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let kind = child.kind();
+        node_kind!(kind = child);
 
         // Handle different instruction types
         if kind.starts_with("op_") {
@@ -416,10 +383,7 @@ pub fn get_instruction_name(instr_node: &Node, source: &str) -> Option<String> {
             if kind == "op_const" {
                 let mut inner_cursor = child.walk();
                 for inner_child in child.children(&mut inner_cursor) {
-                    #[cfg(feature = "native")]
-                    let inner_kind = inner_child.kind();
-                    #[cfg(all(feature = "wasm", not(feature = "native")))]
-                    let inner_kind = inner_child.kind();
+                    node_kind!(inner_kind = inner_child);
 
                     // pat01 contains "i32.const", "i64.const", etc.
                     if inner_kind == "pat01" || inner_kind.contains("const") {
@@ -482,10 +446,7 @@ fn process_instr_call_node(
     // Find and process the trailing instr child (the swallowed instruction)
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        #[cfg(feature = "native")]
-        let kind = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let kind = child.kind();
+        node_kind!(kind = child);
 
         if kind == "instr" {
             process_instr_node(&child, source, symbols, checker);
@@ -625,8 +586,8 @@ fn process_instruction(
     if instr_name == "select" && get_select_result_type(node, source).is_none() {
         // Bare select (no type annotation): first two operands must be same numeric type
         // Stack: [val1, val2, i32_cond] — peek(0)=cond, peek(1)=val2, peek(2)=val1
-        let val2 = checker.peek(1).map(|v| (*v).clone());
-        let val1 = checker.peek(2).map(|v| (*v).clone());
+        let val2 = checker.peek(1).copied();
+        let val1 = checker.peek(2).copied();
         let is_numeric = |t: &ValueType| {
             matches!(
                 t,
@@ -667,9 +628,9 @@ fn process_instruction(
                     );
                     ValueType::Unknown
                 } else if *v1 != ValueType::Unknown {
-                    v1.clone()
+                    *v1
                 } else {
-                    v2.clone()
+                    *v2
                 }
             }
             (None, Some(v2)) => {
@@ -684,7 +645,7 @@ fn process_instruction(
                         .with_code("type-mismatch"),
                     );
                 }
-                v2.clone()
+                *v2
             }
             _ => ValueType::Unknown,
         };
@@ -870,7 +831,7 @@ fn derive_consumed_types_from_name(
         // Typed select: (select (result T)) uses declared type for operands
         "select" => {
             let ty = get_select_result_type(node, source).unwrap_or(ValueType::Unknown);
-            Some(vec![ty.clone(), ty, ValueType::I32])
+            Some(vec![ty, ty, ValueType::I32])
         }
 
         // Local/global get — consume nothing
@@ -898,20 +859,10 @@ fn derive_consumed_types_from_name(
         "call" | "return_call" => {
             if let Some(func_ref) = get_index_from_node(node, source) {
                 if let Some(func) = symbols.get_function_by_name(&func_ref) {
-                    return Some(
-                        func.parameters
-                            .iter()
-                            .map(|p| p.param_type.clone())
-                            .collect(),
-                    );
+                    return Some(func.parameters.iter().map(|p| p.param_type).collect());
                 } else if let Ok(idx) = func_ref.parse::<usize>() {
                     if let Some(func) = symbols.get_function_by_index(idx) {
-                        return Some(
-                            func.parameters
-                                .iter()
-                                .map(|p| p.param_type.clone())
-                                .collect(),
-                        );
+                        return Some(func.parameters.iter().map(|p| p.param_type).collect());
                     }
                 }
             }
@@ -1067,7 +1018,7 @@ fn derive_consumed_types_from_name(
         "table.fill" => {
             let idx_type = get_table_index_type(node, symbols, source);
             let elem_type = get_table_elem_type(node, symbols, source);
-            Some(vec![idx_type.clone(), elem_type, idx_type])
+            Some(vec![idx_type, elem_type, idx_type])
         }
         "table.copy" => Some(vec![
             ValueType::Unknown,
@@ -1094,7 +1045,7 @@ fn derive_consumed_types_from_name(
         // Scalar binary operations — 2 operands of prefix type
         name if is_binary_scalar(name) => {
             if let Some(ty) = type_from_prefix(name) {
-                Some(vec![ty.clone(), ty])
+                Some(vec![ty, ty])
             } else {
                 None
             }
@@ -1140,10 +1091,7 @@ fn get_call_indirect_consumed_types(
     let mut params = Vec::new();
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        #[cfg(feature = "native")]
-        let kind = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let kind = child.kind();
+        node_kind!(kind = child);
 
         if kind == "func_type_params_many" {
             params.extend(parse_func_type_results(&child, source));
@@ -1186,10 +1134,7 @@ fn get_all_branch_depths(node: &Node, source: &str, checker: &mut TypeChecker) -
     let mut indices = Vec::new();
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        #[cfg(feature = "native")]
-        let kind = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let kind = child.kind();
+        node_kind!(kind = child);
 
         if kind == "index" || kind == "identifier" || kind == "nat" {
             indices.push(source[child.byte_range()].trim().to_string());
@@ -1197,10 +1142,7 @@ fn get_all_branch_depths(node: &Node, source: &str, checker: &mut TypeChecker) -
         if kind.starts_with("op_") {
             let mut inner_cursor = child.walk();
             for inner_child in child.children(&mut inner_cursor) {
-                #[cfg(feature = "native")]
-                let inner_kind = inner_child.kind();
-                #[cfg(all(feature = "wasm", not(feature = "native")))]
-                let inner_kind = inner_child.kind();
+                node_kind!(inner_kind = inner_child);
 
                 if inner_kind == "index" || inner_kind == "identifier" || inner_kind == "nat" {
                     indices.push(source[inner_child.byte_range()].trim().to_string());
@@ -1244,27 +1186,18 @@ fn types_compatible(a: &ValueType, b: &ValueType) -> bool {
 fn get_select_result_type(node: &Node, source: &str) -> Option<ValueType> {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        #[cfg(feature = "native")]
-        let kind = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let kind = child.kind();
+        node_kind!(kind = child);
 
         if kind == "op_select" {
             let mut inner_cursor = child.walk();
             for inner_child in child.children(&mut inner_cursor) {
-                #[cfg(feature = "native")]
-                let inner_kind = inner_child.kind();
-                #[cfg(all(feature = "wasm", not(feature = "native")))]
-                let inner_kind = inner_child.kind();
+                node_kind!(inner_kind = inner_child);
 
                 if inner_kind == "func_type_results" {
                     // Look for value_type or ref_type children inside (result T)
                     let mut vt_cursor = inner_child.walk();
                     for vt_child in inner_child.children(&mut vt_cursor) {
-                        #[cfg(feature = "native")]
-                        let vt_kind = vt_child.kind();
-                        #[cfg(all(feature = "wasm", not(feature = "native")))]
-                        let vt_kind = vt_child.kind();
+                        node_kind!(vt_kind = vt_child);
 
                         if vt_kind == "value_type" || vt_kind == "ref_type" {
                             let text = &source[vt_child.byte_range()];
@@ -1373,10 +1306,7 @@ pub fn get_dynamic_operand_count(
 pub fn get_index_from_node(node: &Node, source: &str) -> Option<String> {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        #[cfg(feature = "native")]
-        let kind = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let kind = child.kind();
+        node_kind!(kind = child);
 
         if kind == "index" || kind == "identifier" {
             return Some(source[child.byte_range()].trim().to_string());
@@ -1384,10 +1314,7 @@ pub fn get_index_from_node(node: &Node, source: &str) -> Option<String> {
         if kind == "type_use" {
             let mut inner_cursor = child.walk();
             for inner_child in child.children(&mut inner_cursor) {
-                #[cfg(feature = "native")]
-                let inner_kind = inner_child.kind();
-                #[cfg(all(feature = "wasm", not(feature = "native")))]
-                let inner_kind = inner_child.kind();
+                node_kind!(inner_kind = inner_child);
 
                 if inner_kind == "index" || inner_kind == "identifier" {
                     return Some(source[inner_child.byte_range()].trim().to_string());
@@ -1397,10 +1324,7 @@ pub fn get_index_from_node(node: &Node, source: &str) -> Option<String> {
         if kind.starts_with("op_") {
             let mut inner_cursor = child.walk();
             for inner_child in child.children(&mut inner_cursor) {
-                #[cfg(feature = "native")]
-                let inner_kind = inner_child.kind();
-                #[cfg(all(feature = "wasm", not(feature = "native")))]
-                let inner_kind = inner_child.kind();
+                node_kind!(inner_kind = inner_child);
 
                 if inner_kind == "index" || inner_kind == "identifier" {
                     return Some(source[inner_child.byte_range()].trim().to_string());
@@ -1614,7 +1538,7 @@ pub fn get_local_type_from_node(
         if let Some(param_name) = &param.name {
             let param_name_stripped = param_name.strip_prefix('$').unwrap_or(param_name);
             if param_name_stripped == name_to_check || param_name == &index {
-                return Some(param.param_type.clone());
+                return Some(param.param_type);
             }
         }
     }
@@ -1623,18 +1547,18 @@ pub fn get_local_type_from_node(
         if let Some(local_name) = &local.name {
             let local_name_stripped = local_name.strip_prefix('$').unwrap_or(local_name);
             if local_name_stripped == name_to_check || local_name == &index {
-                return Some(local.var_type.clone());
+                return Some(local.var_type);
             }
         }
     }
 
     if let Ok(idx) = index.parse::<usize>() {
         if idx < func.parameters.len() {
-            return Some(func.parameters[idx].param_type.clone());
+            return Some(func.parameters[idx].param_type);
         }
         let local_idx = idx - func.parameters.len();
         if local_idx < func.locals.len() {
-            return Some(func.locals[local_idx].var_type.clone());
+            return Some(func.locals[local_idx].var_type);
         }
     }
 
@@ -1650,11 +1574,11 @@ pub fn get_global_type_from_node(
     let index = get_index_from_node(node, source)?;
 
     if let Some(global) = symbols.get_global_by_name(&index) {
-        return Some(global.var_type.clone());
+        return Some(global.var_type);
     }
     if let Ok(idx) = index.parse::<usize>() {
         if let Some(global) = symbols.get_global_by_index(idx) {
-            return Some(global.var_type.clone());
+            return Some(global.var_type);
         }
     }
     None
@@ -1678,7 +1602,7 @@ fn resolve_table<'a>(node: &Node, symbols: &'a SymbolTable, source: &str) -> Opt
 
 fn get_table_elem_type(node: &Node, symbols: &SymbolTable, source: &str) -> ValueType {
     resolve_table(node, symbols, source)
-        .map(|t| t.ref_type.clone())
+        .map(|t| t.ref_type)
         .unwrap_or(ValueType::Funcref)
 }
 
@@ -1710,11 +1634,8 @@ fn get_ref_func_result_type(node: &Node, symbols: &SymbolTable, source: &str) ->
 
         if let Some(func) = func {
             // Find a matching type definition for this function's signature
-            let func_params: Vec<ValueType> = func
-                .parameters
-                .iter()
-                .map(|p| p.param_type.clone())
-                .collect();
+            let func_params: Vec<ValueType> =
+                func.parameters.iter().map(|p| p.param_type).collect();
             for type_def in &symbols.types {
                 if let TypeKind::Func { params, results } = &type_def.kind {
                     if *params == func_params && *results == func.results {
@@ -1773,10 +1694,7 @@ fn resolve_call_indirect_type<'a>(
     let mut cursor = node.walk();
     let mut first_index: Option<String> = None;
     for child in node.children(&mut cursor) {
-        #[cfg(feature = "native")]
-        let kind = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let kind = child.kind();
+        node_kind!(kind = child);
 
         // type_use is authoritative — use it directly
         if kind == "type_use" {
@@ -1819,10 +1737,7 @@ pub fn get_call_indirect_result_types(
     let mut results = Vec::new();
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        #[cfg(feature = "native")]
-        let kind = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let kind = child.kind();
+        node_kind!(kind = child);
 
         if kind == "func_type_results" {
             results.extend(parse_func_type_results(&child, source));
@@ -1840,18 +1755,13 @@ fn resolve_call_indirect_type_implicit(
 ) -> Option<(Vec<ValueType>, Vec<ValueType>)> {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        #[cfg(feature = "native")]
-        let kind = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let kind = child.kind();
+        node_kind!(kind = child);
 
         if kind == "type_use" {
             // Extract index from type_use
             let mut inner_cursor = child.walk();
             for inner in child.children(&mut inner_cursor) {
-                let ik = inner.kind();
-                #[cfg(all(feature = "wasm", not(feature = "native")))]
-                let ik = ik.as_str();
+                node_kind!(ik = inner);
                 if ik == "index" || ik == "identifier" {
                     let idx_text = source[inner.byte_range()].trim();
                     if let Ok(idx) = idx_text.parse::<usize>() {
@@ -1869,18 +1779,12 @@ fn resolve_call_indirect_type_implicit(
 fn find_instr_plain_in_expr<'a>(expr: &'a Node) -> Option<Node<'a>> {
     let mut cursor = expr.walk();
     for child in expr.children(&mut cursor) {
-        #[cfg(feature = "native")]
-        let kind = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let kind = child.kind();
+        node_kind!(kind = child);
 
         if kind == "expr1" || kind.starts_with("expr1_") {
             let mut inner_cursor = child.walk();
             for inner in child.children(&mut inner_cursor) {
-                #[cfg(feature = "native")]
-                let ik = inner.kind();
-                #[cfg(all(feature = "wasm", not(feature = "native")))]
-                let ik = inner.kind();
+                node_kind!(ik = inner);
 
                 if ik == "instr_plain" {
                     return Some(inner);
@@ -1934,10 +1838,7 @@ fn find_instr_plain_in_expr(expr: &Node) -> Option<Node> {
 pub fn get_folded_expr_info(expr: &Node, source: &str) -> Option<(String, usize)> {
     let mut cursor = expr.walk();
     for child in expr.children(&mut cursor) {
-        #[cfg(feature = "native")]
-        let kind = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let kind = child.kind();
+        node_kind!(kind = child);
 
         if kind == "expr1" {
             return get_expr1_wrapper_info(&child, source);
@@ -1952,10 +1853,7 @@ pub fn get_folded_expr_info(expr: &Node, source: &str) -> Option<(String, usize)
 fn get_expr1_wrapper_info(expr1: &Node, source: &str) -> Option<(String, usize)> {
     let mut cursor = expr1.walk();
     for child in expr1.children(&mut cursor) {
-        #[cfg(feature = "native")]
-        let kind = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let kind = child.kind();
+        node_kind!(kind = child);
 
         if kind.starts_with("expr1_") {
             return get_expr1_info(&child, source);
@@ -1970,20 +1868,14 @@ fn get_expr1_info(expr1: &Node, source: &str) -> Option<(String, usize)> {
     let explicit_operands = expr1
         .children(&mut expr_cursor)
         .filter(|c| {
-            #[cfg(feature = "native")]
-            let kind = c.kind();
-            #[cfg(all(feature = "wasm", not(feature = "native")))]
-            let kind = c.kind();
+            node_kind!(kind = c);
             kind == "expr"
         })
         .count();
 
     let mut cursor = expr1.walk();
     for child in expr1.children(&mut cursor) {
-        #[cfg(feature = "native")]
-        let kind = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let kind = child.kind();
+        node_kind!(kind = child);
 
         if kind == "instr_plain" {
             if let Some(name) = get_instruction_name(&child, source) {
@@ -2035,18 +1927,12 @@ fn get_dynamic_operand_count_from_expr(
 ) -> usize {
     let mut cursor = expr.walk();
     for child in expr.children(&mut cursor) {
-        #[cfg(feature = "native")]
-        let kind = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let kind = child.kind();
+        node_kind!(kind = child);
 
         if kind.starts_with("expr1_") {
             let mut inner_cursor = child.walk();
             for inner_child in child.children(&mut inner_cursor) {
-                #[cfg(feature = "native")]
-                let inner_kind = inner_child.kind();
-                #[cfg(all(feature = "wasm", not(feature = "native")))]
-                let inner_kind = inner_child.kind();
+                node_kind!(inner_kind = inner_child);
 
                 if inner_kind == "instr_plain" {
                     return get_dynamic_operand_count(&inner_child, instr_name, symbols, source);
@@ -2064,10 +1950,7 @@ fn find_folded_block_child<'a>(expr: &'a Node, source: &str) -> Option<(Node<'a>
     let _ = source;
     let mut cursor = expr.walk();
     for child in expr.children(&mut cursor) {
-        #[cfg(feature = "native")]
-        let kind = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let kind = child.kind();
+        node_kind!(kind = child);
 
         match kind.as_ref() {
             "expr1_block" => return Some((child, "block")),
@@ -2078,10 +1961,7 @@ fn find_folded_block_child<'a>(expr: &'a Node, source: &str) -> Option<(Node<'a>
                 // Check inside expr1 wrapper
                 let mut inner_cursor = child.walk();
                 for inner in child.children(&mut inner_cursor) {
-                    #[cfg(feature = "native")]
-                    let ik = inner.kind();
-                    #[cfg(all(feature = "wasm", not(feature = "native")))]
-                    let ik = inner.kind();
+                    node_kind!(ik = inner);
                     match ik.as_ref() {
                         "expr1_block" => return Some((inner, "block")),
                         "expr1_loop" => return Some((inner, "loop")),
@@ -2192,10 +2072,7 @@ fn process_folded_block_body(
 ) {
     let mut cursor = block_node.walk();
     for child in block_node.children(&mut cursor) {
-        #[cfg(feature = "native")]
-        let kind = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let kind = child.kind();
+        node_kind!(kind = child);
 
         match kind.as_ref() {
             "instr_list" => {
@@ -2227,10 +2104,7 @@ fn process_folded_block_child(
     symbols: &SymbolTable,
     checker: &mut TypeChecker,
 ) {
-    #[cfg(feature = "native")]
-    let kind = child.kind();
-    #[cfg(all(feature = "wasm", not(feature = "native")))]
-    let kind = child.kind();
+    node_kind!(kind = child);
 
     match kind.as_ref() {
         "instr" => {
@@ -2269,10 +2143,7 @@ fn process_folded_if_bodies_from_if_block(
 ) {
     let mut cursor = if_block.walk();
     for child in if_block.children(&mut cursor) {
-        #[cfg(feature = "native")]
-        let kind = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let kind = child.kind();
+        node_kind!(kind = child);
 
         if kind == "instr_list" {
             let mut list_cursor = child.walk();
@@ -2294,18 +2165,12 @@ fn process_folded_if_conditions(
     // Find the if_block child of expr1_if
     let mut cursor = block_node.walk();
     for child in block_node.children(&mut cursor) {
-        #[cfg(feature = "native")]
-        let kind = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let kind = child.kind();
+        node_kind!(kind = child);
 
         if kind == "if_block" {
             let mut if_cursor = child.walk();
             for if_child in child.children(&mut if_cursor) {
-                #[cfg(feature = "native")]
-                let ik = if_child.kind();
-                #[cfg(all(feature = "wasm", not(feature = "native")))]
-                let ik = if_child.kind();
+                node_kind!(ik = if_child);
 
                 // Process condition expr children on the outer stack
                 if ik == "expr" {
@@ -2327,19 +2192,13 @@ fn process_folded_if_bodies(
     // Find the if_block child of expr1_if
     let mut cursor = block_node.walk();
     for child in block_node.children(&mut cursor) {
-        #[cfg(feature = "native")]
-        let kind = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let kind = child.kind();
+        node_kind!(kind = child);
 
         if kind == "if_block" {
             let mut found_then = false;
             let mut if_cursor = child.walk();
             for if_child in child.children(&mut if_cursor) {
-                #[cfg(feature = "native")]
-                let ik = if_child.kind();
-                #[cfg(all(feature = "wasm", not(feature = "native")))]
-                let ik = if_child.kind();
+                node_kind!(ik = if_child);
 
                 if ik == "instr_list" {
                     if !found_then {
@@ -2376,10 +2235,7 @@ fn process_folded_sub_exprs(
     let child_count = expr.child_count();
     for i in 0..child_count {
         if let Some(child) = expr.child(i) {
-            #[cfg(feature = "native")]
-            let kind = child.kind();
-            #[cfg(all(feature = "wasm", not(feature = "native")))]
-            let kind = child.kind();
+            node_kind!(kind = child);
 
             // Navigate to the expr1_* node
             let found = if kind == "expr1" {
@@ -2567,10 +2423,7 @@ fn find_expr1_call_in_expr(expr: &Node) -> Option<Node> {
 pub fn get_expr_result_types(expr: &Node, source: &str, symbols: &SymbolTable) -> Vec<ValueType> {
     let mut cursor = expr.walk();
     for child in expr.children(&mut cursor) {
-        #[cfg(feature = "native")]
-        let kind = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let kind = child.kind();
+        node_kind!(kind = child);
 
         if kind.starts_with("expr1_") {
             return get_expr1_result_types(&child, source, symbols);
@@ -2578,10 +2431,7 @@ pub fn get_expr_result_types(expr: &Node, source: &str, symbols: &SymbolTable) -
         if kind == "expr1" {
             let mut inner_cursor = child.walk();
             for inner_child in child.children(&mut inner_cursor) {
-                #[cfg(feature = "native")]
-                let inner_kind = inner_child.kind();
-                #[cfg(all(feature = "wasm", not(feature = "native")))]
-                let inner_kind = inner_child.kind();
+                node_kind!(inner_kind = inner_child);
 
                 if inner_kind.starts_with("expr1_") {
                     return get_expr1_result_types(&inner_child, source, symbols);
@@ -2594,19 +2444,13 @@ pub fn get_expr_result_types(expr: &Node, source: &str, symbols: &SymbolTable) -
 
 /// Get result types for expr1_* nodes
 fn get_expr1_result_types(expr1: &Node, source: &str, symbols: &SymbolTable) -> Vec<ValueType> {
-    #[cfg(feature = "native")]
-    let kind = expr1.kind();
-    #[cfg(all(feature = "wasm", not(feature = "native")))]
-    let kind = expr1.kind();
+    node_kind!(kind = expr1);
 
     match kind.as_ref() {
         "expr1_plain" => {
             let mut cursor = expr1.walk();
             for child in expr1.children(&mut cursor) {
-                #[cfg(feature = "native")]
-                let child_kind = child.kind();
-                #[cfg(all(feature = "wasm", not(feature = "native")))]
-                let child_kind = child.kind();
+                node_kind!(child_kind = child);
 
                 if child_kind == "instr_plain" {
                     if let Some(instr_name) = get_instruction_name(&child, source) {
@@ -2627,10 +2471,7 @@ fn get_expr1_result_types(expr1: &Node, source: &str, symbols: &SymbolTable) -> 
         "expr1_call" => {
             let mut cursor = expr1.walk();
             for child in expr1.children(&mut cursor) {
-                #[cfg(feature = "native")]
-                let child_kind = child.kind();
-                #[cfg(all(feature = "wasm", not(feature = "native")))]
-                let child_kind = child.kind();
+                node_kind!(child_kind = child);
 
                 if child_kind == "call_indirect" || child_kind == "return_call_indirect" {
                     return get_call_indirect_result_types(expr1, symbols, source);
@@ -2655,10 +2496,7 @@ fn get_expr1_result_types(expr1: &Node, source: &str, symbols: &SymbolTable) -> 
 pub fn get_index_from_expr1_call(node: &Node, source: &str) -> Option<String> {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        #[cfg(feature = "native")]
-        let kind = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let kind = child.kind();
+        node_kind!(kind = child);
 
         if kind == "index" || kind == "identifier" {
             return Some(source[child.byte_range()].trim().to_string());
@@ -2676,10 +2514,7 @@ fn resolve_block_type_use<'a>(
 ) -> Option<&'a TypeDef> {
     let mut cursor = block_node.walk();
     for child in block_node.children(&mut cursor) {
-        #[cfg(feature = "native")]
-        let kind = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let kind = child.kind();
+        node_kind!(kind = child);
 
         if kind == "type_use" {
             return resolve_type_use_node(&child, source, symbols);
@@ -2693,10 +2528,7 @@ fn resolve_block_type_use<'a>(
         {
             let mut inner_cursor = child.walk();
             for inner_child in child.children(&mut inner_cursor) {
-                #[cfg(feature = "native")]
-                let inner_kind = inner_child.kind();
-                #[cfg(all(feature = "wasm", not(feature = "native")))]
-                let inner_kind = inner_child.kind();
+                node_kind!(inner_kind = inner_child);
 
                 if inner_kind == "type_use" {
                     return resolve_type_use_node(&inner_child, source, symbols);
@@ -2715,10 +2547,7 @@ fn resolve_type_use_node<'a>(
 ) -> Option<&'a TypeDef> {
     let mut cursor = type_use_node.walk();
     for child in type_use_node.children(&mut cursor) {
-        #[cfg(feature = "native")]
-        let kind = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let kind = child.kind();
+        node_kind!(kind = child);
 
         if kind == "index" || kind == "identifier" {
             let index_text = source[child.byte_range()].trim();
@@ -2763,11 +2592,7 @@ fn resolve_type_index_to_func_sig(
         if func.has_type_use {
             continue;
         }
-        let params: Vec<ValueType> = func
-            .parameters
-            .iter()
-            .map(|p| p.param_type.clone())
-            .collect();
+        let params: Vec<ValueType> = func.parameters.iter().map(|p| p.param_type).collect();
         let sig = (params, func.results.clone());
         if !sigs.iter().any(|s| s == &sig) {
             sigs.push(sig);
@@ -2785,10 +2610,7 @@ pub fn get_block_result_types(
     let mut types = Vec::new();
     let mut cursor = block_node.walk();
     for child in block_node.children(&mut cursor) {
-        #[cfg(feature = "native")]
-        let kind = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let kind = child.kind();
+        node_kind!(kind = child);
 
         if kind == "func_type_results" {
             types.extend(parse_func_type_results(&child, source));
@@ -2805,10 +2627,7 @@ pub fn get_block_result_types(
         {
             let mut inner_cursor = child.walk();
             for inner_child in child.children(&mut inner_cursor) {
-                #[cfg(feature = "native")]
-                let inner_kind = inner_child.kind();
-                #[cfg(all(feature = "wasm", not(feature = "native")))]
-                let inner_kind = inner_child.kind();
+                node_kind!(inner_kind = inner_child);
 
                 if inner_kind == "func_type_results" {
                     types.extend(parse_func_type_results(&inner_child, source));
@@ -2838,10 +2657,7 @@ pub fn get_block_param_types(
     let mut has_explicit_params = false;
     let mut cursor = block_node.walk();
     for child in block_node.children(&mut cursor) {
-        #[cfg(feature = "native")]
-        let kind = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let kind = child.kind();
+        node_kind!(kind = child);
 
         if kind == "func_type_params_many" {
             has_explicit_params = true;
@@ -2856,10 +2672,7 @@ pub fn get_block_param_types(
         {
             let mut inner_cursor = child.walk();
             for inner_child in child.children(&mut inner_cursor) {
-                #[cfg(feature = "native")]
-                let inner_kind = inner_child.kind();
-                #[cfg(all(feature = "wasm", not(feature = "native")))]
-                let inner_kind = inner_child.kind();
+                node_kind!(inner_kind = inner_child);
 
                 if inner_kind == "func_type_params_many" {
                     has_explicit_params = true;
@@ -2884,10 +2697,7 @@ pub fn parse_func_type_results(results_node: &Node, source: &str) -> Vec<ValueTy
     let mut types = Vec::new();
     let mut cursor = results_node.walk();
     for child in results_node.children(&mut cursor) {
-        #[cfg(feature = "native")]
-        let kind = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let kind = child.kind();
+        node_kind!(kind = child);
 
         if kind == "value_type" || kind == "ref_type" {
             let type_text = &source[child.byte_range()];
@@ -2907,18 +2717,12 @@ pub fn parse_result_types(block_type: &Node, source: &str) -> Vec<ValueType> {
     let mut cursor = block_type.walk();
 
     for child in block_type.children(&mut cursor) {
-        #[cfg(feature = "native")]
-        let kind = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let kind = child.kind();
+        node_kind!(kind = child);
 
         if kind == "func_type_results" {
             let mut inner_cursor = child.walk();
             for inner_child in child.children(&mut inner_cursor) {
-                #[cfg(feature = "native")]
-                let inner_kind = inner_child.kind();
-                #[cfg(all(feature = "wasm", not(feature = "native")))]
-                let inner_kind = inner_child.kind();
+                node_kind!(inner_kind = inner_child);
 
                 if inner_kind == "value_type" || inner_kind == "ref_type" {
                     let type_text = &source[inner_child.byte_range()];
@@ -2965,10 +2769,7 @@ fn validate_tail_call_in_folded_expr(
 ) -> Option<Diagnostic> {
     let mut cursor = expr.walk();
     for child in expr.children(&mut cursor) {
-        #[cfg(feature = "native")]
-        let kind = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let kind = child.kind();
+        node_kind!(kind = child);
 
         if kind.starts_with("expr1_") {
             if kind == "expr1_call" {
@@ -2976,10 +2777,7 @@ fn validate_tail_call_in_folded_expr(
             }
             let mut inner_cursor = child.walk();
             for inner_child in child.children(&mut inner_cursor) {
-                #[cfg(feature = "native")]
-                let inner_kind = inner_child.kind();
-                #[cfg(all(feature = "wasm", not(feature = "native")))]
-                let inner_kind = inner_child.kind();
+                node_kind!(inner_kind = inner_child);
 
                 if inner_kind == "instr_plain" {
                     return validate_tail_call_return_types(
@@ -2994,10 +2792,7 @@ fn validate_tail_call_in_folded_expr(
         if kind == "expr1" {
             let mut mid_cursor = child.walk();
             for mid_child in child.children(&mut mid_cursor) {
-                #[cfg(feature = "native")]
-                let mid_kind = mid_child.kind();
-                #[cfg(all(feature = "wasm", not(feature = "native")))]
-                let mid_kind = mid_child.kind();
+                node_kind!(mid_kind = mid_child);
 
                 if mid_kind == "expr1_call" {
                     return validate_tail_call_return_types(
@@ -3007,10 +2802,7 @@ fn validate_tail_call_in_folded_expr(
                 if mid_kind.starts_with("expr1_") {
                     let mut inner_cursor = mid_child.walk();
                     for inner_child in mid_child.children(&mut inner_cursor) {
-                        #[cfg(feature = "native")]
-                        let inner_kind = inner_child.kind();
-                        #[cfg(all(feature = "wasm", not(feature = "native")))]
-                        let inner_kind = inner_child.kind();
+                        node_kind!(inner_kind = inner_child);
 
                         if inner_kind == "instr_plain" {
                             return validate_tail_call_return_types(

--- a/src/diagnostics_core/termination.rs
+++ b/src/diagnostics_core/termination.rs
@@ -21,10 +21,7 @@ use crate::ts_facade::Node;
 /// pushed onto the stack - if the block always terminates, it doesn't produce
 /// values via fall-through.
 pub fn sequence_always_terminates(node: &Node, source: &str) -> bool {
-    #[cfg(feature = "native")]
-    let kind = node.kind();
-    #[cfg(all(feature = "wasm", not(feature = "native")))]
-    let kind = node.kind();
+    node_kind!(kind = node);
 
     match kind.as_ref() {
         // An instruction list terminates if ANY child instruction terminates
@@ -94,10 +91,7 @@ pub fn sequence_always_terminates(node: &Node, source: &str) -> bool {
         "expr1_block" | "expr1_loop" => {
             let mut cursor = node.walk();
             for child in node.children(&mut cursor) {
-                #[cfg(feature = "native")]
-                let child_kind = child.kind();
-                #[cfg(all(feature = "wasm", not(feature = "native")))]
-                let child_kind = child.kind();
+                node_kind!(child_kind = child);
 
                 // Check the body expressions/instructions
                 if (child_kind == "expr" || child_kind == "instr" || child_kind == "instr_list")
@@ -126,10 +120,7 @@ pub fn sequence_always_terminates(node: &Node, source: &str) -> bool {
 
 /// Extract the instruction name from a node (handles instr, instr_plain, etc.)
 fn get_instruction_name_from_node(node: &Node, source: &str) -> Option<String> {
-    #[cfg(feature = "native")]
-    let kind = node.kind();
-    #[cfg(all(feature = "wasm", not(feature = "native")))]
-    let kind = node.kind();
+    node_kind!(kind = node);
 
     if kind == "instr" {
         // instr wraps other instruction types
@@ -145,10 +136,7 @@ fn get_instruction_name_from_node(node: &Node, source: &str) -> Option<String> {
     if kind == "instr_plain" {
         let mut cursor = node.walk();
         for child in node.children(&mut cursor) {
-            #[cfg(feature = "native")]
-            let child_kind = child.kind();
-            #[cfg(all(feature = "wasm", not(feature = "native")))]
-            let child_kind = child.kind();
+            node_kind!(child_kind = child);
 
             if child_kind.starts_with("op_") {
                 let text = &source[child.byte_range()];
@@ -167,10 +155,7 @@ fn get_instruction_name_from_node(node: &Node, source: &str) -> Option<String> {
 fn block_body_always_terminates(node: &Node, source: &str) -> bool {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        #[cfg(feature = "native")]
-        let child_kind = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let child_kind = child.kind();
+        node_kind!(child_kind = child);
 
         if child_kind == "instr_list" {
             return sequence_always_terminates(&child, source);
@@ -215,10 +200,7 @@ fn try_table_always_terminates(node: &Node, source: &str) -> bool {
     // Check if this try_table has any catch clauses
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        #[cfg(feature = "native")]
-        let child_kind = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let child_kind = child.kind();
+        node_kind!(child_kind = child);
 
         // If we find any catch clause, the try_table doesn't "always terminate"
         // because the catch can branch to an outer label
@@ -234,10 +216,7 @@ fn try_table_always_terminates(node: &Node, source: &str) -> bool {
 
 /// Check if an if/if_block always terminates (both branches must exist and terminate)
 fn if_always_terminates(node: &Node, source: &str) -> bool {
-    #[cfg(feature = "native")]
-    let kind = node.kind();
-    #[cfg(all(feature = "wasm", not(feature = "native")))]
-    let kind = node.kind();
+    node_kind!(kind = node);
 
     // For folded if (expr1_if), we need to find then and else expressions
     if kind == "expr1_if" {
@@ -247,10 +226,7 @@ fn if_always_terminates(node: &Node, source: &str) -> bool {
 
         let mut cursor = node.walk();
         for child in node.children(&mut cursor) {
-            #[cfg(feature = "native")]
-            let child_kind = child.kind();
-            #[cfg(all(feature = "wasm", not(feature = "native")))]
-            let child_kind = child.kind();
+            node_kind!(child_kind = child);
 
             // In folded if, the structure is:
             // (if (result ...) condition (then ...) (else ...))
@@ -274,10 +250,7 @@ fn if_always_terminates(node: &Node, source: &str) -> bool {
 
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        #[cfg(feature = "native")]
-        let child_kind = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let child_kind = child.kind();
+        node_kind!(child_kind = child);
 
         if child_kind == "if_block" {
             // Recurse into if_block
@@ -301,10 +274,7 @@ fn if_always_terminates(node: &Node, source: &str) -> bool {
             // Find the instr_list inside the else
             let mut else_cursor = child.walk();
             for else_child in child.children(&mut else_cursor) {
-                #[cfg(feature = "native")]
-                let else_kind = else_child.kind();
-                #[cfg(all(feature = "wasm", not(feature = "native")))]
-                let else_kind = else_child.kind();
+                node_kind!(else_kind = else_child);
 
                 if else_kind == "instr_list" {
                     else_terminates = sequence_always_terminates(&else_child, source);

--- a/src/diagnostics_core/type_check.rs
+++ b/src/diagnostics_core/type_check.rs
@@ -180,13 +180,13 @@ fn is_type_subtype(child_idx: usize, parent_idx: usize, symbols: &SymbolTable) -
         };
 
         let parent_ref = match &type_def.parent {
-            Some(p) => p.clone(),
+            Some(p) => p.as_str(),
             None => return false,
         };
 
         // Resolve parent reference to index
         let resolved_idx = if parent_ref.starts_with('$') {
-            match symbols.get_type_by_name(&parent_ref) {
+            match symbols.get_type_by_name(parent_ref) {
                 Some(td) => td.index,
                 None => return false,
             }
@@ -280,9 +280,7 @@ impl TypeChecker {
 
     /// Push multiple values onto the stack.
     pub fn push_vals(&mut self, types: &[ValueType]) {
-        for ty in types {
-            self.push_val(ty.clone());
-        }
+        self.val_stack.extend_from_slice(types);
     }
 
     /// Pop multiple values and check types (in reverse order, as per spec).
@@ -410,16 +408,16 @@ impl TypeChecker {
         label: Option<String>,
     ) {
         let height = self.val_stack.len();
+        // Push start_types onto val_stack first, then move into frame (avoids clone)
+        self.push_vals(&start_types);
         self.ctrl_stack.push(CtrlFrame {
             opcode,
-            start_types: start_types.clone(),
+            start_types,
             end_types,
             height,
             unreachable: false,
             label,
         });
-        // Push start_types onto val_stack (block params become initial stack)
-        self.push_vals(&start_types);
     }
 
     /// Exit a control frame. Validates that end_types match the stack.

--- a/src/features/document_symbols_core.rs
+++ b/src/features/document_symbols_core.rs
@@ -9,7 +9,15 @@ use crate::symbols::*;
 
 /// Produce a hierarchical outline of all symbols in the document.
 pub fn provide_document_symbols_core(symbols: &SymbolTable) -> Vec<DocumentSymbolInfo> {
-    let mut result = Vec::new();
+    let total = symbols.types.len()
+        + symbols.functions.len()
+        + symbols.globals.len()
+        + symbols.tables.len()
+        + symbols.memories.len()
+        + symbols.tags.len()
+        + symbols.data_segments.len()
+        + symbols.elem_segments.len();
+    let mut result = Vec::with_capacity(total);
 
     for type_def in &symbols.types {
         result.push(type_to_symbol(type_def));
@@ -116,7 +124,8 @@ fn function_to_symbol(func: &Function) -> DocumentSymbolInfo {
         .range
         .unwrap_or_else(|| Range::from_coords(func.line, 0, func.end_line, 0));
 
-    let mut children = Vec::new();
+    let child_count = func.parameters.len() + func.locals.len() + func.blocks.len();
+    let mut children = Vec::with_capacity(child_count);
     for param in &func.parameters {
         children.push(param_to_symbol(param));
     }

--- a/src/features/hover/mod.rs
+++ b/src/features/hover/mod.rs
@@ -565,10 +565,7 @@ fn provide_annotation_hover(
     // Walk up the tree to find if we're inside an annotation
     let mut current = node;
     loop {
-        #[cfg(feature = "native")]
-        let kind = current.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let kind = current.kind();
+        node_kind!(kind = current);
 
         if kind == "annotation" {
             // Found annotation - extract the name from identifier_pattern child
@@ -581,10 +578,7 @@ fn provide_annotation_hover(
             let children_iter = (0..current.child_count()).filter_map(|i| current.child(i));
 
             for child in children_iter {
-                #[cfg(feature = "native")]
-                let child_kind = child.kind();
-                #[cfg(all(feature = "wasm", not(feature = "native")))]
-                let child_kind = child.kind();
+                node_kind!(child_kind = child);
 
                 if child_kind == "identifier_pattern" {
                     #[cfg(feature = "native")]

--- a/src/features/symbols/mod.rs
+++ b/src/features/symbols/mod.rs
@@ -5,7 +5,7 @@ use crate::core::types::Range;
 #[cfg(test)]
 mod tests;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ValueType {
     I32,
     I64,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,26 @@
 // Library exports for testing and WASM builds
 
+// ============================================================================
+// Macros for native/WASM platform abstraction (must be before module declarations)
+// ============================================================================
+
+/// Bind `node.kind()` to a `&str` variable, handling the native (`&str`) vs
+/// WASM (`String` → `.as_str()`) difference in one line.
+///
+/// Usage: `node_kind!(ck = child);` expands to the equivalent of:
+/// ```ignore
+/// let ck = child.kind();
+/// #[cfg(all(feature = "wasm", not(feature = "native")))]
+/// let ck = ck.as_str();
+/// ```
+macro_rules! node_kind {
+    ($name:ident = $node:expr) => {
+        let $name = $node.kind();
+        #[cfg(all(feature = "wasm", not(feature = "native")))]
+        let $name = $name.as_str();
+    };
+}
+
 // Core types (protocol-independent) - must be first as other modules depend on it
 pub mod core;
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -110,9 +110,7 @@ fn process_import_field(
     symbol_table: &mut SymbolTable,
     counts: &mut ImportCounts,
 ) {
-    let kind = field_child.kind();
-    #[cfg(all(feature = "wasm", not(feature = "native")))]
-    let kind = kind.as_str();
+    node_kind!(kind = field_child);
 
     match kind {
         "module_field_import" => {
@@ -160,9 +158,7 @@ fn process_import_field(
 fn node_has_import_child(node: &Node) -> bool {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        let kind = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let kind = kind.as_str();
+        node_kind!(kind = child);
         if kind == "import" {
             return true;
         }
@@ -248,9 +244,7 @@ fn extract_single_import(
             // Look inside import_desc for the specific import type
             let mut desc_cursor = child.walk();
             for desc_child in child.children(&mut desc_cursor) {
-                let kind = desc_child.kind();
-                #[cfg(all(feature = "wasm", not(feature = "native")))]
-                let kind = kind.as_str();
+                node_kind!(kind = desc_child);
                 match kind {
                     "import_desc_func_type" | "import_desc_type_use" => {
                         // Imported function: (func $name? ...)
@@ -609,30 +603,18 @@ fn extract_imported_tag(desc_node: &Node, source: &str, index: usize) -> Option<
     })
 }
 
-/// Find identifier child node (returns the node itself, not just text)
+/// Find identifier child node (returns the node itself, not just text).
+/// Delegates to shared `find_child_by_kind` in utils.
 #[cfg(feature = "native")]
+#[inline]
 fn find_identifier_node<'a>(node: &'a Node<'a>) -> Option<Node<'a>> {
-    let mut cursor = node.walk();
-    #[allow(clippy::manual_find)]
-    for child in node.children(&mut cursor) {
-        if child.kind() == "identifier" {
-            return Some(child);
-        }
-    }
-    None
+    crate::utils::find_child_by_kind(node, "identifier")
 }
 
-/// Find identifier child node (WASM version - no lifetime parameter needed)
 #[cfg(all(feature = "wasm", not(feature = "native")))]
+#[inline]
 fn find_identifier_node(node: &Node) -> Option<Node> {
-    let mut cursor = node.walk();
-    #[allow(clippy::manual_find)]
-    for child in node.children(&mut cursor) {
-        if child.kind() == "identifier" {
-            return Some(child);
-        }
-    }
-    None
+    crate::utils::find_child_by_kind(node, "identifier")
 }
 
 /// Extract function symbols using tree-sitter AST traversal (with offset for imports)
@@ -749,9 +731,7 @@ fn extract_doc_comment(node: &Node, source: &str) -> Option<String> {
             break;
         }
 
-        let kind = sibling.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let kind = kind.as_str();
+        node_kind!(kind = sibling);
 
         if kind == "comment_line" || kind == "comment_block" {
             let comment_end_line = sibling.range().end_point.row;
@@ -988,10 +968,7 @@ fn resolve_type_use(
         if child.kind() == "type_use" {
             let mut type_cursor = child.walk();
             for type_child in child.children(&mut type_cursor) {
-                #[cfg(feature = "native")]
-                let kind = type_child.kind();
-                #[cfg(all(feature = "wasm", not(feature = "native")))]
-                let kind = type_child.kind();
+                node_kind!(kind = type_child);
 
                 if kind == "index" || kind == "identifier" {
                     let type_ref = source[type_child.byte_range()].trim();
@@ -1010,7 +987,7 @@ fn resolve_type_use(
                                 .enumerate()
                                 .map(|(i, vt)| Parameter {
                                     name: None,
-                                    param_type: vt.clone(),
+                                    param_type: *vt,
                                     index: i,
                                     range: None,
                                 })
@@ -1029,7 +1006,7 @@ fn resolve_type_use(
                                 .enumerate()
                                 .map(|(i, vt)| Parameter {
                                     name: None,
-                                    param_type: vt.clone(),
+                                    param_type: *vt,
                                     index: i,
                                     range: None,
                                 })
@@ -1053,8 +1030,10 @@ fn resolve_implicit_type(
     symbol_table: &SymbolTable,
 ) -> Option<(Vec<ValueType>, Vec<ValueType>)> {
     let mut sigs: Vec<(Vec<ValueType>, Vec<ValueType>)> = Vec::new();
+    let mut seen = std::collections::HashSet::new();
     for type_def in &symbol_table.types {
         if let TypeKind::Func { params, results } = &type_def.kind {
+            seen.insert((params.clone(), results.clone()));
             sigs.push((params.clone(), results.clone()));
         }
     }
@@ -1062,13 +1041,9 @@ fn resolve_implicit_type(
         if func.has_type_use {
             continue;
         }
-        let params: Vec<ValueType> = func
-            .parameters
-            .iter()
-            .map(|p| p.param_type.clone())
-            .collect();
+        let params: Vec<ValueType> = func.parameters.iter().map(|p| p.param_type).collect();
         let sig = (params, func.results.clone());
-        if !sigs.iter().any(|s| s == &sig) {
+        if seen.insert(sig.clone()) {
             sigs.push(sig);
         }
     }
@@ -1147,11 +1122,7 @@ fn extract_blocks(func_node: &Node, source: &str) -> Vec<BlockLabel> {
 
 /// Recursively visit nodes to find labeled blocks/loops/ifs
 fn visit_node_for_blocks(node: &Node, source: &str, blocks: &mut Vec<BlockLabel>) {
-    let kind = node.kind();
-    #[cfg(all(feature = "wasm", not(feature = "native")))]
-    let kind_str = kind.as_str();
-    #[cfg(feature = "native")]
-    let kind_str = kind;
+    node_kind!(kind_str = node);
 
     // Check both statement form (block_block) and expression form (expr1_block)
     if BLOCK_KINDS_STATEMENT.contains(&kind_str) || BLOCK_KINDS_EXPR.contains(&kind_str) {
@@ -1398,17 +1369,13 @@ fn extract_type_from_single_node(
     let mut parent_ref: Option<String> = None;
     let mut is_final = false;
 
-    let type_kind = type_node.kind();
-    #[cfg(all(feature = "wasm", not(feature = "native")))]
-    let type_kind = type_kind.as_str();
+    node_kind!(type_kind = type_node);
     match type_kind {
         "sub_type" => {
             // Process sub_type children: (sub final? index? def_type)
             let mut sub_cursor = type_node.walk();
             for sub_child in type_node.children(&mut sub_cursor) {
-                let sub_kind = sub_child.kind();
-                #[cfg(all(feature = "wasm", not(feature = "native")))]
-                let sub_kind = sub_kind.as_str();
+                node_kind!(sub_kind = sub_child);
 
                 match sub_kind {
                     "index" => {
@@ -1483,9 +1450,7 @@ fn extract_type_from_single_node(
             // type_field wraps a def_type: func_type, struct_type, array_type, or sub_type
             let mut cursor = type_node.walk();
             for child in type_node.children(&mut cursor) {
-                let child_kind = child.kind();
-                #[cfg(all(feature = "wasm", not(feature = "native")))]
-                let child_kind = child_kind.as_str();
+                node_kind!(child_kind = child);
                 match child_kind {
                     "func_type" => {
                         let mut parameters = Vec::new();
@@ -1545,9 +1510,7 @@ fn extract_field_types(field_node: &Node, source: &str) -> Vec<(Option<String>, 
 
     let mut cursor = field_node.walk();
     for child in field_node.children(&mut cursor) {
-        let ck = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let ck = ck.as_str();
+        node_kind!(ck = child);
         match ck {
             "identifier" => {
                 field_name = Some(node_text(&child, source));
@@ -1573,9 +1536,7 @@ fn extract_field_types(field_node: &Node, source: &str) -> Vec<(Option<String>, 
         let mut mutable = false;
         let mut cursor2 = field_node.walk();
         for child in field_node.children(&mut cursor2) {
-            let ck = child.kind();
-            #[cfg(all(feature = "wasm", not(feature = "native")))]
-            let ck = ck.as_str();
+            node_kind!(ck = child);
             match ck {
                 "value_type" => {
                     field_type = extract_value_type(&child, source);
@@ -1626,9 +1587,7 @@ fn extract_type(type_node: &Node, source: &str, index: usize) -> Option<TypeDef>
         if child.kind() == "sub_type" {
             let mut sub_cursor = child.walk();
             for sub_child in child.children(&mut sub_cursor) {
-                let sub_kind = sub_child.kind();
-                #[cfg(all(feature = "wasm", not(feature = "native")))]
-                let sub_kind = sub_kind.as_str();
+                node_kind!(sub_kind = sub_child);
 
                 match sub_kind {
                     "index" => {
@@ -1745,9 +1704,7 @@ fn extract_type(type_node: &Node, source: &str, index: usize) -> Option<TypeDef>
                     // Handle sub_type inside type_field: (sub final? index? def_type)
                     let mut sub_cursor = field_child.walk();
                     for sub_child in field_child.children(&mut sub_cursor) {
-                        let sub_kind = sub_child.kind();
-                        #[cfg(all(feature = "wasm", not(feature = "native")))]
-                        let sub_kind = sub_kind.as_str();
+                        node_kind!(sub_kind = sub_child);
 
                         match sub_kind {
                             "index" => {
@@ -2226,9 +2183,7 @@ fn extract_value_type(value_type_node: &Node, source: &str) -> ValueType {
 
     let mut cursor = value_type_node.walk();
     for child in value_type_node.children(&mut cursor) {
-        let child_kind = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let child_kind = child_kind.as_str();
+        node_kind!(child_kind = child);
         match child_kind {
             "value_type_num_type" => {
                 let text = node_text(&child, source);
@@ -2242,9 +2197,7 @@ fn extract_value_type(value_type_node: &Node, source: &str) -> ValueType {
 
                 let mut num_cursor = child.walk();
                 for num_child in child.children(&mut num_cursor) {
-                    let num_kind = num_child.kind();
-                    #[cfg(all(feature = "wasm", not(feature = "native")))]
-                    let num_kind = num_kind.as_str();
+                    node_kind!(num_kind = num_child);
                     match num_kind {
                         "num_type_i32" => return ValueType::I32,
                         "num_type_i64" => return ValueType::I64,
@@ -2286,9 +2239,7 @@ fn extract_value_type(value_type_node: &Node, source: &str) -> ValueType {
 fn extract_storage_type_with_mut(storage_node: &Node, source: &str) -> (ValueType, bool) {
     let mut cursor = storage_node.walk();
     for child in storage_node.children(&mut cursor) {
-        let ck = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let ck = ck.as_str();
+        node_kind!(ck = child);
         match ck {
             "value_type" => return (extract_value_type(&child, source), false),
             "packed_type" => {
@@ -2304,9 +2255,7 @@ fn extract_storage_type_with_mut(storage_node: &Node, source: &str) -> (ValueTyp
                 // Mutable wrapper — extract inner type
                 let mut inner_cursor = child.walk();
                 for inner_child in child.children(&mut inner_cursor) {
-                    let ik = inner_child.kind();
-                    #[cfg(all(feature = "wasm", not(feature = "native")))]
-                    let ik = ik.as_str();
+                    node_kind!(ik = inner_child);
                     match ik {
                         "value_type" => return (extract_value_type(&inner_child, source), true),
                         "packed_type" => {
@@ -2346,9 +2295,7 @@ fn extract_ref_type(ref_type_node: &Node, source: &str) -> ValueType {
 
     let mut cursor = ref_type_node.walk();
     for child in ref_type_node.children(&mut cursor) {
-        let child_kind = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let child_kind = child_kind.as_str();
+        node_kind!(child_kind = child);
         match child_kind {
             "ref_type_funcref" => return ValueType::Funcref,
             "ref_type_externref" => return ValueType::Externref,
@@ -2407,9 +2354,7 @@ fn extract_ref_type(ref_type_node: &Node, source: &str) -> ValueType {
                 let mut ref_kind = None;
 
                 for c in child.children(&mut concrete_cursor) {
-                    let ck = c.kind();
-                    #[cfg(all(feature = "wasm", not(feature = "native")))]
-                    let ck = ck.as_str();
+                    node_kind!(ck = c);
                     if ck == "index" {
                         let idx_text = node_text(&c, source);
                         if let Ok(idx) = idx_text.parse::<u32>() {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -761,6 +761,37 @@ pub fn format_function_signature(func: &Function) -> String {
     sig
 }
 
+// ============================================================================
+// Node child search helpers
+// ============================================================================
+
+/// Find the first child node of a given kind.
+/// Shared between parser and diagnostics modules to avoid duplication.
+#[cfg(feature = "native")]
+#[allow(clippy::manual_find)]
+pub fn find_child_by_kind<'a>(node: &'a Node<'a>, kind: &str) -> Option<Node<'a>> {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == kind {
+            return Some(child);
+        }
+    }
+    None
+}
+
+/// Find the first child node of a given kind (WASM version).
+#[cfg(all(feature = "wasm", not(feature = "native")))]
+pub fn find_child_by_kind(node: &Node, kind: &str) -> Option<Node> {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        node_kind!(ck = child);
+        if ck == kind {
+            return Some(child.clone());
+        }
+    }
+    None
+}
+
 #[cfg(test)]
 #[cfg(feature = "native")]
 mod tests {


### PR DESCRIPTION
## Summary

- Add `node_kind!` macro to eliminate 219 occurrences of 3-line kind/as_str boilerplate across the codebase
- Derive `Copy`, `Eq`, `Hash` on `ValueType` enabling `extend_from_slice` and HashSet-based dedup
- Fix O(n²) implicit type resolution in parser and module_checks (Vec.any → HashSet)
- Add shared `find_child_by_kind()` utility, consolidating duplicate implementations
- Pre-allocate Vecs with `with_capacity` in document symbols

Net: -494 lines (335 added, 829 deleted), 11 files changed, 0 clippy warnings.