### PR TITLE
defrag: remove duplicate wrappers, return &str from hot paths, extract shared helpers

### DIFF
--- a/src/diagnostics_core/module_checks.rs
+++ b/src/diagnostics_core/module_checks.rs
@@ -505,7 +505,7 @@ fn check_identifier_dup(
     kind_name: &str,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
-    if let Some(id_node) = find_identifier_child(node) {
+    if let Some(id_node) = crate::utils::find_child_by_kind(node, "identifier") {
         let name = node_text(&id_node, source);
         if name.starts_with('$') {
             let range = node_to_range(&id_node);
@@ -560,19 +560,6 @@ fn check_import_identifier_dup(
             }
         }
     }
-}
-
-/// Find identifier child node. Delegates to shared `find_child_by_kind`.
-#[cfg(feature = "native")]
-#[inline]
-fn find_identifier_child<'a>(node: &'a Node<'a>) -> Option<Node<'a>> {
-    crate::utils::find_child_by_kind(node, "identifier")
-}
-
-#[cfg(all(feature = "wasm", not(feature = "native")))]
-#[inline]
-fn find_identifier_child(node: &Node) -> Option<Node> {
-    crate::utils::find_child_by_kind(node, "identifier")
 }
 
 // ============================================================================

--- a/src/diagnostics_core/semantic.rs
+++ b/src/diagnostics_core/semantic.rs
@@ -46,15 +46,15 @@ pub fn track_stack_in_instr_list(
     // Get function result types for the control frame
     let func_line = instr_list.start_position().row as u32;
     let result_types = if let Some(func) = symbols.find_function_containing_line(func_line) {
-        expected_results.unwrap_or(&func.results).to_vec()
+        expected_results.unwrap_or(&func.results)
     } else {
-        expected_results.unwrap_or(&[]).to_vec()
+        expected_results.unwrap_or(&[])
     };
 
     // Push function-level control frame
     // Note: function parameters are local variables, NOT on the value stack.
     // The value stack starts empty; start_types is empty for functions.
-    checker.push_ctrl(CtrlOpcode::Function, vec![], result_types.clone());
+    checker.push_ctrl(CtrlOpcode::Function, vec![], result_types.to_vec());
 
     // Process all children
     let mut cursor = instr_list.walk();
@@ -67,7 +67,7 @@ pub fn track_stack_in_instr_list(
             }
             "instr_plain" => {
                 if let Some(instr_name) = get_instruction_name(&child, source) {
-                    process_instruction(&child, &instr_name, &mut checker, symbols, source);
+                    process_instruction(&child, instr_name, &mut checker, symbols, source);
                 }
             }
             "expr" => {
@@ -109,7 +109,7 @@ fn process_instr_node(
         match kind.as_ref() {
             "instr_plain" => {
                 if let Some(instr_name) = get_instruction_name(&child, source) {
-                    process_instruction(&child, &instr_name, checker, symbols, source);
+                    process_instruction(&child, instr_name, checker, symbols, source);
                 }
             }
             "expr" => {
@@ -219,7 +219,7 @@ fn process_block_body(node: &Node, source: &str, symbols: &SymbolTable, checker:
                             if let Some(instr_name) = get_instruction_name(&list_child, source) {
                                 process_instruction(
                                     &list_child,
-                                    &instr_name,
+                                    instr_name,
                                     checker,
                                     symbols,
                                     source,
@@ -272,7 +272,7 @@ fn process_block_body(node: &Node, source: &str, symbols: &SymbolTable, checker:
             }
             "instr_plain" => {
                 if let Some(instr_name) = get_instruction_name(&child, source) {
-                    process_instruction(&child, &instr_name, checker, symbols, source);
+                    process_instruction(&child, instr_name, checker, symbols, source);
                 }
             }
             "expr" => {
@@ -371,8 +371,9 @@ fn is_try_table_node(node: &Node) -> bool {
     false
 }
 
-/// Get the instruction name from an instr_plain node
-pub fn get_instruction_name(instr_node: &Node, source: &str) -> Option<String> {
+/// Get the instruction name from an instr_plain node.
+/// Returns a borrowed slice from `source`, avoiding allocation.
+pub fn get_instruction_name<'a>(instr_node: &Node, source: &'a str) -> Option<&'a str> {
     let mut cursor = instr_node.walk();
     for child in instr_node.children(&mut cursor) {
         node_kind!(kind = child);
@@ -387,22 +388,22 @@ pub fn get_instruction_name(instr_node: &Node, source: &str) -> Option<String> {
 
                     // pat01 contains "i32.const", "i64.const", etc.
                     if inner_kind == "pat01" || inner_kind.contains("const") {
-                        return Some(source[inner_child.byte_range()].trim().to_string());
+                        return Some(source[inner_child.byte_range()].trim());
                     }
                 }
                 // Fallback: extract first token from the whole op_const text
                 let text = &source[child.byte_range()];
-                return text.split_whitespace().next().map(|s| s.to_string());
+                return text.split_whitespace().next();
             }
             // For other op_ nodes (like op_nullary, op_index, op_table_copy),
             // extract just the instruction name (first token)
             let text = &source[child.byte_range()];
-            return text.split_whitespace().next().map(|s| s.to_string());
+            return text.split_whitespace().next();
         }
     }
     // Fallback: get the text of the first token
     let text = &source[instr_node.byte_range()];
-    text.split_whitespace().next().map(|s| s.to_string())
+    text.split_whitespace().next()
 }
 
 /// Process a linear call_indirect/return_call_indirect node (instr_list_call)
@@ -1835,7 +1836,7 @@ fn find_instr_plain_in_expr(expr: &Node) -> Option<Node> {
 
 /// Get instruction info from a folded expression
 /// Returns (instruction_name, explicit_operand_count)
-pub fn get_folded_expr_info(expr: &Node, source: &str) -> Option<(String, usize)> {
+pub fn get_folded_expr_info<'a>(expr: &Node, source: &'a str) -> Option<(&'a str, usize)> {
     let mut cursor = expr.walk();
     for child in expr.children(&mut cursor) {
         node_kind!(kind = child);
@@ -1850,7 +1851,7 @@ pub fn get_folded_expr_info(expr: &Node, source: &str) -> Option<(String, usize)
 }
 
 /// Get instruction info from an expr1 wrapper node
-fn get_expr1_wrapper_info(expr1: &Node, source: &str) -> Option<(String, usize)> {
+fn get_expr1_wrapper_info<'a>(expr1: &Node, source: &'a str) -> Option<(&'a str, usize)> {
     let mut cursor = expr1.walk();
     for child in expr1.children(&mut cursor) {
         node_kind!(kind = child);
@@ -1863,7 +1864,7 @@ fn get_expr1_wrapper_info(expr1: &Node, source: &str) -> Option<(String, usize)>
 }
 
 /// Get instruction info from an expr1_* node
-fn get_expr1_info(expr1: &Node, source: &str) -> Option<(String, usize)> {
+fn get_expr1_info<'a>(expr1: &Node, source: &'a str) -> Option<(&'a str, usize)> {
     let mut expr_cursor = expr1.walk();
     let explicit_operands = expr1
         .children(&mut expr_cursor)
@@ -1883,16 +1884,16 @@ fn get_expr1_info(expr1: &Node, source: &str) -> Option<(String, usize)> {
             }
         }
         if kind == "call_indirect" {
-            return Some(("call_indirect".to_string(), explicit_operands));
+            return Some(("call_indirect", explicit_operands));
         }
         if kind == "return_call_indirect" {
-            return Some(("return_call_indirect".to_string(), explicit_operands));
+            return Some(("return_call_indirect", explicit_operands));
         }
         if kind == "instr_call" {
             let text = &source[child.byte_range()];
             let first_token = text.split_whitespace().next().unwrap_or("");
             if !first_token.is_empty() {
-                return Some((first_token.to_string(), explicit_operands));
+                return Some((first_token, explicit_operands));
             }
         }
     }
@@ -2112,7 +2113,7 @@ fn process_folded_block_child(
         }
         "instr_plain" => {
             if let Some(instr_name) = get_instruction_name(child, source) {
-                process_instruction(child, &instr_name, checker, symbols, source);
+                process_instruction(child, instr_name, checker, symbols, source);
             }
         }
         "expr" => {
@@ -2314,7 +2315,7 @@ fn process_folded_expr(
     // process_instruction handles all cases: branches, terminators, regular instructions.
     if let Some(instr_node) = find_instr_plain_in_expr(expr) {
         if let Some(instr_name) = get_instruction_name(&instr_node, source) {
-            process_instruction(&instr_node, &instr_name, checker, symbols, source);
+            process_instruction(&instr_node, instr_name, checker, symbols, source);
             return;
         }
     }
@@ -2323,24 +2324,17 @@ fn process_folded_expr(
     // The grammar uses string literals for "call_indirect", so there's no named
     // call_indirect child — the expr1_call node itself holds type_use/index.
     if let Some((instr_name, _)) = get_folded_expr_info(expr, source) {
-        if matches!(
-            instr_name.as_str(),
-            "call_indirect" | "return_call_indirect"
-        ) {
+        if matches!(instr_name, "call_indirect" | "return_call_indirect") {
             if let Some(expr1_call_node) = find_expr1_call_in_expr(expr) {
-                let consumed = get_call_indirect_consumed_types(
-                    &expr1_call_node,
-                    &instr_name,
-                    symbols,
-                    source,
-                );
+                let consumed =
+                    get_call_indirect_consumed_types(&expr1_call_node, instr_name, symbols, source);
                 if !consumed.is_empty() {
-                    checker.pop_vals_for_instr(&consumed, expr, &instr_name);
+                    checker.pop_vals_for_instr(&consumed, expr, instr_name);
                 }
 
-                if is_terminating_instruction(&instr_name) {
+                if is_terminating_instruction(instr_name) {
                     if let Some(diag) =
-                        validate_tail_call_in_folded_expr(expr, &instr_name, symbols, source)
+                        validate_tail_call_in_folded_expr(expr, instr_name, symbols, source)
                     {
                         checker.diagnostics.push(diag);
                     }
@@ -2454,12 +2448,7 @@ fn get_expr1_result_types(expr1: &Node, source: &str, symbols: &SymbolTable) -> 
 
                 if child_kind == "instr_plain" {
                     if let Some(instr_name) = get_instruction_name(&child, source) {
-                        return infer_instruction_result_types(
-                            &instr_name,
-                            &child,
-                            symbols,
-                            source,
-                        );
+                        return infer_instruction_result_types(instr_name, &child, symbols, source);
                     }
                 }
             }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -543,24 +543,10 @@ fn extract_imported_tag(desc_node: &Node, source: &str, index: usize) -> Option<
     })
 }
 
-/// Find identifier child node (returns the node itself, not just text).
-/// Delegates to shared `find_child_by_kind` in utils.
-#[cfg(feature = "native")]
-#[inline]
-fn find_identifier_node<'a>(node: &'a Node<'a>) -> Option<Node<'a>> {
-    crate::utils::find_child_by_kind(node, "identifier")
-}
-
-#[cfg(all(feature = "wasm", not(feature = "native")))]
-#[inline]
-fn find_identifier_node(node: &Node) -> Option<Node> {
-    crate::utils::find_child_by_kind(node, "identifier")
-}
-
 /// Extract name and name_range from a node's identifier child.
 /// This pattern is used across all symbol extraction functions.
 fn extract_identifier_info(node: &Node, source: &str) -> (Option<String>, Option<Range>) {
-    if let Some(id_node) = find_identifier_node(node) {
+    if let Some(id_node) = crate::utils::find_child_by_kind(node, "identifier") {
         (
             Some(node_text(&id_node, source)),
             Some(node_to_range(&id_node)),
@@ -586,70 +572,57 @@ fn extract_functions_with_offset(
     let mut seen_ranges: std::collections::HashSet<(usize, usize)> =
         std::collections::HashSet::new();
 
+    let mut try_add_func =
+        |field_child: &Node,
+         func_index: &mut usize,
+         seen_names: &mut std::collections::HashSet<String>,
+         seen_ranges: &mut std::collections::HashSet<(usize, usize)>| {
+            if field_child.kind() == "module_field_func" && !node_has_import_child(field_child) {
+                if let Some(func) = extract_function(field_child, source, *func_index, symbol_table)
+                {
+                    let is_duplicate = func.name.as_ref().map_or(
+                        seen_ranges.contains(&(func.start_byte, func.end_byte)),
+                        |n| seen_names.contains(n),
+                    );
+                    if !is_duplicate {
+                        if let Some(ref name) = func.name {
+                            seen_names.insert(name.clone());
+                        } else {
+                            seen_ranges.insert((func.start_byte, func.end_byte));
+                        }
+                        symbol_table.add_function(func);
+                        *func_index += 1;
+                    }
+                }
+            }
+        };
+
     // Walk through all children of root (could be module or direct module_field)
     for child in root.children(&mut cursor) {
         if child.kind() == "module" {
-            // Inside module, look for module_field children
             let mut module_cursor = child.walk();
             for module_child in child.children(&mut module_cursor) {
                 if module_child.kind() == "module_field" {
                     let mut field_cursor = module_child.walk();
                     for field_child in module_child.children(&mut field_cursor) {
-                        if field_child.kind() == "module_field_func"
-                            && !node_has_import_child(&field_child)
-                        {
-                            if let Some(func) =
-                                extract_function(&field_child, source, func_index, symbol_table)
-                            {
-                                // Skip duplicates from error recovery
-                                let is_duplicate = if let Some(ref name) = func.name {
-                                    seen_names.contains(name)
-                                } else {
-                                    let range = (func.start_byte, func.end_byte);
-                                    seen_ranges.contains(&range)
-                                };
-
-                                if !is_duplicate {
-                                    if let Some(ref name) = func.name {
-                                        seen_names.insert(name.clone());
-                                    } else {
-                                        seen_ranges.insert((func.start_byte, func.end_byte));
-                                    }
-                                    symbol_table.add_function(func);
-                                    func_index += 1;
-                                }
-                            }
-                        }
+                        try_add_func(
+                            &field_child,
+                            &mut func_index,
+                            &mut seen_names,
+                            &mut seen_ranges,
+                        );
                     }
                 }
             }
         } else if child.kind() == "module_field" {
-            // Direct module_field (for standalone functions)
             let mut field_cursor = child.walk();
             for field_child in child.children(&mut field_cursor) {
-                if field_child.kind() == "module_field_func" && !node_has_import_child(&field_child)
-                {
-                    if let Some(func) =
-                        extract_function(&field_child, source, func_index, symbol_table)
-                    {
-                        let is_duplicate = if let Some(ref name) = func.name {
-                            seen_names.contains(name)
-                        } else {
-                            let range = (func.start_byte, func.end_byte);
-                            seen_ranges.contains(&range)
-                        };
-
-                        if !is_duplicate {
-                            if let Some(ref name) = func.name {
-                                seen_names.insert(name.clone());
-                            } else {
-                                seen_ranges.insert((func.start_byte, func.end_byte));
-                            }
-                            symbol_table.add_function(func);
-                            func_index += 1;
-                        }
-                    }
-                }
+                try_add_func(
+                    &field_child,
+                    &mut func_index,
+                    &mut seen_names,
+                    &mut seen_ranges,
+                );
             }
         }
     }
@@ -1074,7 +1047,7 @@ fn visit_node_for_blocks(node: &Node, source: &str, blocks: &mut Vec<BlockLabel>
     // Check both statement form (block_block) and expression form (expr1_block)
     if BLOCK_KINDS_STATEMENT.contains(&kind_str) || BLOCK_KINDS_EXPR.contains(&kind_str) {
         // Check if it has a label
-        if let Some(id_node) = find_identifier_node(node) {
+        if let Some(id_node) = crate::utils::find_child_by_kind(node, "identifier") {
             let label = node_text(&id_node, source);
             let block_type = block_type_from_kind(kind_str).to_string();
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -141,36 +141,8 @@ pub fn determine_instruction_context(node: Node, document: &str) -> InstructionC
             || kind == "instr_call"
             || kind == "expr1_call"
         {
-            let instr_text = &document[current.byte_range()];
-
-            if instr_text.contains("call") {
-                return InstructionContext::Call;
-            } else if instr_text.contains("local.") {
-                return InstructionContext::Local;
-            } else if instr_text.contains("global.") {
-                return InstructionContext::Global;
-            } else if instr_text.starts_with("br") || instr_text.contains(" br") {
-                return InstructionContext::Branch;
-            // Check data/elem segment operations BEFORE general table/memory
-            } else if instr_text.contains("memory.init") || instr_text.contains("data.drop") {
-                return InstructionContext::Data;
-            } else if instr_text.contains("table.init") || instr_text.contains("elem.drop") {
-                return InstructionContext::Elem;
-            } else if instr_text.contains("table.") {
-                return InstructionContext::Table;
-            } else if instr_text.contains("memory.")
-                || instr_text.contains(".load")
-                || instr_text.contains(".store")
-            {
-                return InstructionContext::Memory;
-            } else if instr_text.contains("struct.")
-                || instr_text.contains("array.")
-                || instr_text.contains("ref.cast")
-                || instr_text.contains("ref.test")
-            {
-                return InstructionContext::Type;
-            } else if instr_text.contains("throw") || instr_text.contains("rethrow") {
-                return InstructionContext::Tag;
+            if let Some(ctx) = context_from_instruction_text(&document[current.byte_range()]) {
+                return ctx;
             }
         }
 
@@ -227,44 +199,8 @@ pub fn determine_instruction_context_at_node(node: &Node, document: &str) -> Ins
 
     // Only check instr_plain nodes for instruction context
     if kind == "instr_plain" || kind == "expr1_plain" {
-        let instr_text = &document[node.byte_range()];
-        // Extract just the first token (instruction name) to avoid matching nested instructions
-        let first_token = instr_text.split_whitespace().next().unwrap_or("");
-
-        // Check data/elem segment operations BEFORE general memory/table
-        if first_token == "memory.init" || first_token == "data.drop" {
-            return InstructionContext::Data;
-        } else if first_token == "table.init" || first_token == "elem.drop" {
-            return InstructionContext::Elem;
-        // Check GC/struct/array instructions first (they take type indices)
-        // Also includes call_ref and return_call_ref which take type indices
-        } else if first_token.starts_with("struct.")
-            || first_token.starts_with("array.")
-            || first_token == "ref.cast"
-            || first_token == "ref.test"
-            || first_token == "call_ref"
-            || first_token == "return_call_ref"
-        {
-            return InstructionContext::Type;
-        } else if first_token == "ref.func" || first_token == "return_call" {
-            return InstructionContext::Call;
-        } else if first_token.starts_with("br") {
-            return InstructionContext::Branch;
-        } else if first_token.starts_with("call") && first_token != "call_indirect" {
-            return InstructionContext::Call;
-        } else if first_token.starts_with("local.") {
-            return InstructionContext::Local;
-        } else if first_token.starts_with("global.") {
-            return InstructionContext::Global;
-        } else if first_token.starts_with("table.") {
-            return InstructionContext::Table;
-        } else if first_token.starts_with("memory.")
-            || first_token.contains(".load")
-            || first_token.contains(".store")
-        {
-            return InstructionContext::Memory;
-        } else if first_token == "throw" || first_token == "rethrow" {
-            return InstructionContext::Tag;
+        if let Some(ctx) = context_from_instruction_text(&document[node.byte_range()]) {
+            return ctx;
         }
     }
 
@@ -285,6 +221,49 @@ pub fn determine_instruction_context_at_node(node: &Node, document: &str) -> Ins
     }
 
     InstructionContext::General
+}
+
+/// Classify instruction text into an InstructionContext using first-word matching.
+/// Avoids repeated `.contains()` scans over the full text.
+fn context_from_instruction_text(instr_text: &str) -> Option<InstructionContext> {
+    let first_token = instr_text.split_whitespace().next().unwrap_or("");
+
+    // Check data/elem segment operations BEFORE general memory/table
+    if first_token == "memory.init" || first_token == "data.drop" {
+        Some(InstructionContext::Data)
+    } else if first_token == "table.init" || first_token == "elem.drop" {
+        Some(InstructionContext::Elem)
+    // Check GC/struct/array instructions (they take type indices)
+    } else if first_token.starts_with("struct.")
+        || first_token.starts_with("array.")
+        || first_token == "ref.cast"
+        || first_token == "ref.test"
+        || first_token == "call_ref"
+        || first_token == "return_call_ref"
+    {
+        Some(InstructionContext::Type)
+    } else if first_token == "ref.func" || first_token == "return_call" {
+        Some(InstructionContext::Call)
+    } else if first_token.starts_with("br") {
+        Some(InstructionContext::Branch)
+    } else if first_token.starts_with("call") && first_token != "call_indirect" {
+        Some(InstructionContext::Call)
+    } else if first_token.starts_with("local.") {
+        Some(InstructionContext::Local)
+    } else if first_token.starts_with("global.") {
+        Some(InstructionContext::Global)
+    } else if first_token.starts_with("table.") {
+        Some(InstructionContext::Table)
+    } else if first_token.starts_with("memory.")
+        || first_token.contains(".load")
+        || first_token.contains(".store")
+    {
+        Some(InstructionContext::Memory)
+    } else if first_token == "throw" || first_token == "rethrow" {
+        Some(InstructionContext::Tag)
+    } else {
+        None
+    }
 }
 
 /// Determine the context for a node inside a catch_clause.


### PR DESCRIPTION
## Summary
- Remove `find_identifier_child` and `find_identifier_node` wrapper functions (4 cfg-gated variants), replaced with direct `find_child_by_kind` calls
- Change `get_instruction_name`, `get_folded_expr_info`, and helpers to return `&str` instead of `String`, eliminating per-instruction allocations in the hot path
- Extract `try_add_func` closure in `extract_functions_with_offset` to eliminate ~50 lines of copy-pasted dedup logic
- Extract shared `context_from_instruction_text()` helper using first-word matching, replacing duplicate instruction context logic and chain of `.contains()` scans
- Remove double allocation in `track_stack_in_instr_list` (`.to_vec()` + `.clone()` → single `.to_vec()`)