### PR TITLE
defrag: consolidate duplicate functions, add TypeChecker helpers, unify native/WASM bodies

### DIFF
--- a/src/diagnostics_core/module_checks.rs
+++ b/src/diagnostics_core/module_checks.rs
@@ -74,39 +74,32 @@ pub fn validate_module_structure(
 // Helper: find the module node
 // ============================================================================
 
+macro_rules! find_module_node_body {
+    ($root:ident) => {{
+        node_kind!(rk = $root);
+        if rk == "module" {
+            return Some(node_copy!($root));
+        }
+        let mut cursor = $root.walk();
+        for child in $root.children(&mut cursor) {
+            node_kind!(ck = child);
+            if ck == "module" {
+                return Some(node_copy!(&child));
+            }
+            if ck == "module_field" {
+                return Some(node_copy!($root));
+            }
+        }
+        None
+    }};
+}
 #[cfg(feature = "native")]
 fn find_module_node<'a>(root: &Node<'a>) -> Option<Node<'a>> {
-    if root.kind() == "module" {
-        return Some(*root);
-    }
-    let mut cursor = root.walk();
-    for child in root.children(&mut cursor) {
-        if child.kind() == "module" {
-            return Some(child);
-        }
-        if child.kind() == "module_field" {
-            return Some(*root);
-        }
-    }
-    None
+    find_module_node_body!(root)
 }
-
 #[cfg(all(feature = "wasm", not(feature = "native")))]
 fn find_module_node(root: &Node) -> Option<Node> {
-    let kind = root.kind();
-    if kind == "module" {
-        return Some(root.clone());
-    }
-    let mut cursor = root.walk();
-    for child in root.children(&mut cursor) {
-        if child.kind() == "module" {
-            return Some(child);
-        }
-        if child.kind() == "module_field" {
-            return Some(root.clone());
-        }
-    }
-    None
+    find_module_node_body!(root)
 }
 
 /// Helper: iterate module_field children of a module or root node.

--- a/src/diagnostics_core/references.rs
+++ b/src/diagnostics_core/references.rs
@@ -56,61 +56,21 @@ pub fn check_catch_clause_references(
     diagnostics
 }
 
-/// Check references in a try_catch_clause node (legacy try syntax)
-/// For (catch $tag instr*): the index is a tag reference
-pub fn check_try_catch_clause_references(
+/// Check the first index child of a node against the given instruction context.
+/// Used for nodes that contain a single index reference (start, try_catch, try_delegate).
+pub fn check_first_index_reference(
     node: &Node,
     source: &str,
     symbols: &SymbolTable,
+    context: &InstructionContext,
 ) -> Vec<Diagnostic> {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         node_kind!(kind = child);
-
         if kind == "index" {
-            return find_undefined_identifiers(&child, source, symbols, &InstructionContext::Tag);
+            return find_undefined_identifiers(&child, source, symbols, context);
         }
     }
-
-    vec![]
-}
-
-/// Check references in a try_delegate_clause node (legacy try syntax)
-/// For (delegate $label): the index is a label reference
-pub fn check_try_delegate_clause_references(
-    node: &Node,
-    source: &str,
-    symbols: &SymbolTable,
-) -> Vec<Diagnostic> {
-    let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
-        node_kind!(kind = child);
-
-        if kind == "index" {
-            return find_undefined_identifiers(
-                &child,
-                source,
-                symbols,
-                &InstructionContext::Branch,
-            );
-        }
-    }
-
-    vec![]
-}
-
-/// Check the function reference in a module_field_start node.
-/// The start directive takes a single function index: (start $func) or (start 0)
-pub fn check_start_references(node: &Node, source: &str, symbols: &SymbolTable) -> Vec<Diagnostic> {
-    let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
-        node_kind!(kind = child);
-
-        if kind == "index" {
-            return find_undefined_identifiers(&child, source, symbols, &InstructionContext::Call);
-        }
-    }
-
     vec![]
 }
 

--- a/src/diagnostics_core/semantic.rs
+++ b/src/diagnostics_core/semantic.rs
@@ -483,10 +483,7 @@ fn process_instruction(
     if instr_name == "br" {
         // Pop label types then mark unreachable
         if let Some(depth) = get_branch_depth(node, source, checker) {
-            if let Some(label_types) = checker.label_types(depth) {
-                let label_types = label_types.to_vec();
-                checker.pop_vals_for_instr(&label_types, node, instr_name);
-            }
+            checker.pop_label_types_for_instr(depth, node, instr_name);
         }
         checker.mark_unreachable();
         return;
@@ -496,9 +493,7 @@ fn process_instruction(
         // Pop i32 condition first, then pop+push label types
         checker.pop_expect(&ValueType::I32, node);
         if let Some(depth) = get_branch_depth(node, source, checker) {
-            if let Some(label_types) = checker.label_types(depth) {
-                let label_types = label_types.to_vec();
-                checker.pop_vals_for_instr(&label_types, node, instr_name);
+            if let Some(label_types) = checker.pop_label_types_for_instr(depth, node, instr_name) {
                 checker.push_vals(&label_types);
             }
         }
@@ -512,15 +507,11 @@ fn process_instruction(
         let depths = get_all_branch_depths(node, source, checker);
         if let Some(&default_depth) = depths.last() {
             // Type-check using the default (last) label
-            if let Some(label_types) = checker.label_types(default_depth) {
-                let label_types = label_types.to_vec();
-                checker.pop_vals_for_instr(&label_types, node, instr_name);
-            }
+            checker.pop_label_types_for_instr(default_depth, node, instr_name);
             // Validate all non-default labels have consistent arity with default.
             // Arity must always match. Type compatibility is only checked when reachable
             // (after unreachable, the polymorphic stack bottom satisfies any type).
-            if let Some(default_types) = checker.label_types(default_depth) {
-                let default_types = default_types.to_vec();
+            if let Some(default_types) = checker.label_types_vec(default_depth) {
                 let default_arity = default_types.len();
                 let mut reported = false;
                 for &depth in depths.iter().take(depths.len().saturating_sub(1)) {
@@ -528,7 +519,6 @@ fn process_instruction(
                         break;
                     }
                     if let Some(target_types) = checker.label_types(depth) {
-                        let target_types = target_types.to_vec();
                         if target_types.len() != default_arity {
                             checker.diagnostics.push(
                                 Diagnostic::error(
@@ -567,10 +557,7 @@ fn process_instruction(
     if is_terminating_instruction(instr_name) {
         // For 'return', pop function result types
         if instr_name == "return" {
-            if let Some(frame) = checker.function_frame() {
-                let end_types = frame.end_types.clone();
-                checker.pop_vals_for_instr(&end_types, node, instr_name);
-            }
+            checker.pop_function_return_types(node, instr_name);
         }
         // For 'throw', pop tag parameter types
         if instr_name == "throw" {
@@ -1776,62 +1763,41 @@ fn resolve_call_indirect_type_implicit(
 }
 
 /// Find the instr_plain node inside a folded expression (for branch depth resolution).
+/// Note: separate native/WASM signatures required due to Node<'a> lifetime differences.
+macro_rules! find_instr_plain_in_expr_body {
+    ($expr:ident) => {{
+        let mut cursor = $expr.walk();
+        for child in $expr.children(&mut cursor) {
+            node_kind!(kind = child);
+            if kind == "expr1" || kind.starts_with("expr1_") {
+                let mut inner_cursor = child.walk();
+                for inner in child.children(&mut inner_cursor) {
+                    node_kind!(ik = inner);
+                    if ik == "instr_plain" {
+                        return Some(node_copy!(&inner));
+                    }
+                    if ik.starts_with("expr1_") {
+                        let mut deep_cursor = inner.walk();
+                        for deep in inner.children(&mut deep_cursor) {
+                            node_kind!(dk = deep);
+                            if dk == "instr_plain" {
+                                return Some(node_copy!(&deep));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        None
+    }};
+}
 #[cfg(feature = "native")]
 fn find_instr_plain_in_expr<'a>(expr: &'a Node) -> Option<Node<'a>> {
-    let mut cursor = expr.walk();
-    for child in expr.children(&mut cursor) {
-        node_kind!(kind = child);
-
-        if kind == "expr1" || kind.starts_with("expr1_") {
-            let mut inner_cursor = child.walk();
-            for inner in child.children(&mut inner_cursor) {
-                node_kind!(ik = inner);
-
-                if ik == "instr_plain" {
-                    return Some(inner);
-                }
-                // Check inside nested expr1 wrapper
-                if ik.starts_with("expr1_") {
-                    let mut deep_cursor = inner.walk();
-                    for deep in inner.children(&mut deep_cursor) {
-                        if deep.kind() == "instr_plain" {
-                            return Some(deep);
-                        }
-                    }
-                }
-            }
-        }
-    }
-    None
+    find_instr_plain_in_expr_body!(expr)
 }
-
-/// Find the instr_plain node inside a folded expression (for branch depth resolution).
 #[cfg(all(feature = "wasm", not(feature = "native")))]
 fn find_instr_plain_in_expr(expr: &Node) -> Option<Node> {
-    let mut cursor = expr.walk();
-    for child in expr.children(&mut cursor) {
-        let kind = child.kind();
-
-        if kind == "expr1" || kind.starts_with("expr1_") {
-            let mut inner_cursor = child.walk();
-            for inner in child.children(&mut inner_cursor) {
-                let ik = inner.kind();
-
-                if ik == "instr_plain" {
-                    return Some(inner);
-                }
-                if ik.starts_with("expr1_") {
-                    let mut deep_cursor = inner.walk();
-                    for deep in inner.children(&mut deep_cursor) {
-                        if deep.kind() == "instr_plain" {
-                            return Some(deep);
-                        }
-                    }
-                }
-            }
-        }
-    }
-    None
+    find_instr_plain_in_expr_body!(expr)
 }
 
 /// Get instruction info from a folded expression
@@ -1945,70 +1911,51 @@ fn get_dynamic_operand_count_from_expr(
 }
 
 /// Check if a folded expression is a block-type (block, loop, if, try_table).
-/// Returns the expr1_* node if found.
-#[cfg(feature = "native")]
-fn find_folded_block_child<'a>(expr: &'a Node, source: &str) -> Option<(Node<'a>, &'static str)> {
-    let _ = source;
-    let mut cursor = expr.walk();
-    for child in expr.children(&mut cursor) {
-        node_kind!(kind = child);
-
-        match kind.as_ref() {
-            "expr1_block" => return Some((child, "block")),
-            "expr1_loop" => return Some((child, "loop")),
-            "expr1_if" => return Some((child, "if")),
-            "expr1_try_table" => return Some((child, "try_table")),
-            "expr1" => {
-                // Check inside expr1 wrapper
+/// Returns the expr1_* node and its block kind if found.
+macro_rules! find_folded_block_child_body {
+    ($expr:ident) => {{
+        let mut cursor = $expr.walk();
+        for child in $expr.children(&mut cursor) {
+            node_kind!(kind = child);
+            let block_kind = match kind.as_ref() {
+                "expr1_block" => Some("block"),
+                "expr1_loop" => Some("loop"),
+                "expr1_if" => Some("if"),
+                "expr1_try_table" => Some("try_table"),
+                _ => None,
+            };
+            if let Some(bk) = block_kind {
+                return Some((node_copy!(&child), bk));
+            }
+            if kind == "expr1" {
                 let mut inner_cursor = child.walk();
                 for inner in child.children(&mut inner_cursor) {
                     node_kind!(ik = inner);
-                    match ik.as_ref() {
-                        "expr1_block" => return Some((inner, "block")),
-                        "expr1_loop" => return Some((inner, "loop")),
-                        "expr1_if" => return Some((inner, "if")),
-                        "expr1_try_table" => return Some((inner, "try_table")),
-                        _ => {}
+                    let inner_block_kind = match ik.as_ref() {
+                        "expr1_block" => Some("block"),
+                        "expr1_loop" => Some("loop"),
+                        "expr1_if" => Some("if"),
+                        "expr1_try_table" => Some("try_table"),
+                        _ => None,
+                    };
+                    if let Some(bk) = inner_block_kind {
+                        return Some((node_copy!(&inner), bk));
                     }
                 }
             }
-            _ => {}
         }
-    }
-    None
+        None
+    }};
 }
-
-/// Check if a folded expression is a block-type (block, loop, if, try_table).
-/// Returns the expr1_* node if found.
+#[cfg(feature = "native")]
+fn find_folded_block_child<'a>(expr: &'a Node, source: &str) -> Option<(Node<'a>, &'static str)> {
+    let _ = source;
+    find_folded_block_child_body!(expr)
+}
 #[cfg(all(feature = "wasm", not(feature = "native")))]
 fn find_folded_block_child(expr: &Node, source: &str) -> Option<(Node, &'static str)> {
     let _ = source;
-    let mut cursor = expr.walk();
-    for child in expr.children(&mut cursor) {
-        let kind = child.kind();
-
-        match kind.as_ref() {
-            "expr1_block" => return Some((child, "block")),
-            "expr1_loop" => return Some((child, "loop")),
-            "expr1_if" => return Some((child, "if")),
-            "expr1_try_table" => return Some((child, "try_table")),
-            "expr1" => {
-                let mut inner_cursor = child.walk();
-                for inner in child.children(&mut inner_cursor) {
-                    let ik = inner.kind();
-                    match ik.as_ref() {
-                        "expr1_block" => return Some((inner, "block")),
-                        "expr1_loop" => return Some((inner, "loop")),
-                        "expr1_if" => return Some((inner, "if")),
-                        "expr1_try_table" => return Some((inner, "try_table")),
-                        _ => {}
-                    }
-                }
-            }
-            _ => {}
-        }
-    }
-    None
+    find_folded_block_child_body!(expr)
 }
 
 /// Process a folded block expression (block, loop, if, try_table) with control frames.
@@ -2364,53 +2311,34 @@ fn process_folded_expr(
 /// Find the expr1_call node inside a folded expression.
 /// The grammar uses string literals for "call_indirect", so the expr1_call node
 /// itself holds type_use/index children needed for type resolution.
+macro_rules! find_expr1_call_in_expr_body {
+    ($expr:ident) => {{
+        let mut cursor = $expr.walk();
+        for child in $expr.children(&mut cursor) {
+            node_kind!(kind = child);
+            if kind == "expr1_call" {
+                return Some(node_copy!(&child));
+            }
+            if kind == "expr1" {
+                let mut inner_cursor = child.walk();
+                for inner in child.children(&mut inner_cursor) {
+                    node_kind!(ik = inner);
+                    if ik == "expr1_call" {
+                        return Some(node_copy!(&inner));
+                    }
+                }
+            }
+        }
+        None
+    }};
+}
 #[cfg(feature = "native")]
 fn find_expr1_call_in_expr<'a>(expr: &'a Node) -> Option<Node<'a>> {
-    let child_count = expr.child_count();
-    for i in 0..child_count {
-        if let Some(child) = expr.child(i) {
-            let kind = child.kind();
-            if kind == "expr1_call" {
-                return Some(child);
-            }
-            if kind == "expr1" {
-                let inner_count = child.child_count();
-                for j in 0..inner_count {
-                    if let Some(inner) = child.child(j) {
-                        if inner.kind() == "expr1_call" {
-                            return Some(inner);
-                        }
-                    }
-                }
-            }
-        }
-    }
-    None
+    find_expr1_call_in_expr_body!(expr)
 }
-
-/// Find the expr1_call node inside a folded expression.
 #[cfg(all(feature = "wasm", not(feature = "native")))]
 fn find_expr1_call_in_expr(expr: &Node) -> Option<Node> {
-    let child_count = expr.child_count();
-    for i in 0..child_count {
-        if let Some(child) = expr.child(i) {
-            let kind = child.kind();
-            if kind == "expr1_call" {
-                return Some(child);
-            }
-            if kind == "expr1" {
-                let inner_count = child.child_count();
-                for j in 0..inner_count {
-                    if let Some(inner) = child.child(j) {
-                        if inner.kind() == "expr1_call" {
-                            return Some(inner);
-                        }
-                    }
-                }
-            }
-        }
-    }
-    None
+    find_expr1_call_in_expr_body!(expr)
 }
 
 /// Get result types from a folded expression

--- a/src/diagnostics_core/tree_walk.rs
+++ b/src/diagnostics_core/tree_walk.rs
@@ -127,8 +127,11 @@ pub fn walk_tree_for_diagnostics(
     // Special handling for legacy try catch clause
     if kind_str == "try_catch_clause" {
         diagnostics.extend(
-            crate::diagnostics_core::references::check_try_catch_clause_references(
-                &node, source, symbols,
+            crate::diagnostics_core::references::check_first_index_reference(
+                &node,
+                source,
+                symbols,
+                &InstructionContext::Tag,
             ),
         );
         // Continue recursing to check nested instructions
@@ -136,9 +139,14 @@ pub fn walk_tree_for_diagnostics(
 
     // Special handling for start directive
     if kind_str == "module_field_start" {
-        diagnostics.extend(crate::diagnostics_core::references::check_start_references(
-            &node, source, symbols,
-        ));
+        diagnostics.extend(
+            crate::diagnostics_core::references::check_first_index_reference(
+                &node,
+                source,
+                symbols,
+                &InstructionContext::Call,
+            ),
+        );
         return;
     }
 
@@ -158,8 +166,11 @@ pub fn walk_tree_for_diagnostics(
     // Special handling for try_delegate_clause (legacy try): index is a label reference
     if kind_str == "try_delegate_clause" {
         diagnostics.extend(
-            crate::diagnostics_core::references::check_try_delegate_clause_references(
-                &node, source, symbols,
+            crate::diagnostics_core::references::check_first_index_reference(
+                &node,
+                source,
+                symbols,
+                &InstructionContext::Branch,
             ),
         );
         return;
@@ -406,6 +417,25 @@ fn collect_local_uses(
     }
 }
 
+/// Resolve a text reference (name or numeric index) to a local index.
+fn resolve_local_text(text: &str, func: &crate::symbols::Function) -> Option<usize> {
+    if text.starts_with('$') {
+        for param in &func.parameters {
+            if param.name.as_deref() == Some(text) {
+                return Some(param.index);
+            }
+        }
+        for local in &func.locals {
+            if local.name.as_deref() == Some(text) {
+                return Some(func.parameters.len() + local.index);
+            }
+        }
+    } else if let Ok(idx) = text.parse::<usize>() {
+        return Some(idx);
+    }
+    None
+}
+
 /// Resolve the local index referenced by a local.get/set/tee instruction.
 fn resolve_local_index(
     node: &Node,
@@ -420,19 +450,7 @@ fn resolve_local_index(
 
         if ck == "index" || ck == "identifier" || ck == "nat" {
             let text = source[child.byte_range()].trim();
-            if text.starts_with('$') {
-                // Named reference — find the param or local
-                for param in &func.parameters {
-                    if param.name.as_deref() == Some(text) {
-                        return Some(param.index);
-                    }
-                }
-                for local in &func.locals {
-                    if local.name.as_deref() == Some(text) {
-                        return Some(func.parameters.len() + local.index);
-                    }
-                }
-            } else if let Ok(idx) = text.parse::<usize>() {
+            if let Some(idx) = resolve_local_text(text, func) {
                 return Some(idx);
             }
             // Check inside index node for identifier/nat children
@@ -441,20 +459,9 @@ fn resolve_local_index(
                 let ik = idx_child.kind();
                 #[cfg(all(feature = "wasm", not(feature = "native")))]
                 let ik = &*ik;
-                if ik == "identifier" {
+                if ik == "identifier" || ik == "nat" {
                     let id_text = source[idx_child.byte_range()].trim();
-                    for param in &func.parameters {
-                        if param.name.as_deref() == Some(id_text) {
-                            return Some(param.index);
-                        }
-                    }
-                    for local in &func.locals {
-                        if local.name.as_deref() == Some(id_text) {
-                            return Some(func.parameters.len() + local.index);
-                        }
-                    }
-                } else if ik == "nat" {
-                    if let Ok(idx) = source[idx_child.byte_range()].trim().parse::<usize>() {
+                    if let Some(idx) = resolve_local_text(id_text, func) {
                         return Some(idx);
                     }
                 }

--- a/src/diagnostics_core/type_check.rs
+++ b/src/diagnostics_core/type_check.rs
@@ -530,6 +530,25 @@ impl TypeChecker {
         })
     }
 
+    /// Look up label types at depth, copy them, and pop them for the given instruction.
+    /// Returns the label types if found (owned, for callers that need to push them back).
+    pub fn pop_label_types_for_instr(
+        &mut self,
+        depth: usize,
+        node: &Node,
+        instr_name: &str,
+    ) -> Option<Vec<ValueType>> {
+        let label_types = self.label_types(depth)?.to_vec();
+        self.pop_vals_for_instr(&label_types, node, instr_name);
+        Some(label_types)
+    }
+
+    /// Get an owned copy of label types at the given depth.
+    /// Useful when the caller needs both the types and a mutable borrow on self.
+    pub fn label_types_vec(&self, depth: usize) -> Option<Vec<ValueType>> {
+        self.label_types(depth).map(|t| t.to_vec())
+    }
+
     /// Get the current control frame's height.
     fn current_frame_height(&self) -> usize {
         self.ctrl_stack.last().map(|f| f.height).unwrap_or(0)
@@ -589,6 +608,14 @@ impl TypeChecker {
     /// Get the function-level frame (bottom of control stack).
     pub fn function_frame(&self) -> Option<&CtrlFrame> {
         self.ctrl_stack.first()
+    }
+
+    /// Pop the function's return types for a `return` instruction.
+    /// Copies end_types from the function frame and pops them from the stack.
+    pub fn pop_function_return_types(&mut self, node: &Node, instr_name: &str) {
+        if let Some(end_types) = self.ctrl_stack.first().map(|f| f.end_types.clone()) {
+            self.pop_vals_for_instr(&end_types, node, instr_name);
+        }
     }
 
     /// Take all collected diagnostics out of the checker.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,34 @@ macro_rules! node_kind {
     };
 }
 
+/// Copy a node value: native Node is Copy (`*node`), WASM Node requires `.clone()`.
+macro_rules! node_copy {
+    ($node:expr) => {{
+        #[cfg(feature = "native")]
+        {
+            *$node
+        }
+        #[cfg(all(feature = "wasm", not(feature = "native")))]
+        {
+            $node.clone()
+        }
+    }};
+}
+
+/// Clone a node for storage: native Node is Copy (no-op), WASM Node requires `.clone()`.
+macro_rules! node_clone {
+    ($node:expr) => {{
+        #[cfg(feature = "native")]
+        {
+            $node
+        }
+        #[cfg(all(feature = "wasm", not(feature = "native")))]
+        {
+            $node.clone()
+        }
+    }};
+}
+
 // Core types (protocol-independent) - must be first as other modules depend on it
 pub mod core;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -12,38 +12,6 @@ use crate::ts_facade::{Node, Tree};
 use tower_lsp::lsp_types::Range as LspRange;
 
 // ============================================================================
-// Macros to eliminate native/wasm code duplication
-// ============================================================================
-
-/// Macro to copy a node (handles Copy vs Clone difference between native and wasm)
-macro_rules! node_copy {
-    ($node:expr) => {{
-        #[cfg(feature = "native")]
-        {
-            *$node
-        }
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        {
-            $node.clone()
-        }
-    }};
-}
-
-/// Macro to clone a node for storage
-macro_rules! node_clone {
-    ($node:expr) => {{
-        #[cfg(feature = "native")]
-        {
-            $node
-        }
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        {
-            $node.clone()
-        }
-    }};
-}
-
-// ============================================================================
 // Block type constants - centralized to prevent sync issues
 // ============================================================================
 
@@ -746,29 +714,26 @@ pub fn format_function_signature(func: &Function) -> String {
 
 /// Find the first child node of a given kind.
 /// Shared between parser and diagnostics modules to avoid duplication.
+macro_rules! find_child_by_kind_body {
+    ($node:ident, $kind:ident) => {{
+        let mut cursor = $node.walk();
+        for child in $node.children(&mut cursor) {
+            node_kind!(ck = child);
+            if ck == $kind {
+                return Some(node_copy!(&child));
+            }
+        }
+        None
+    }};
+}
 #[cfg(feature = "native")]
 #[allow(clippy::manual_find)]
 pub fn find_child_by_kind<'a>(node: &'a Node<'a>, kind: &str) -> Option<Node<'a>> {
-    let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
-        if child.kind() == kind {
-            return Some(child);
-        }
-    }
-    None
+    find_child_by_kind_body!(node, kind)
 }
-
-/// Find the first child node of a given kind (WASM version).
 #[cfg(all(feature = "wasm", not(feature = "native")))]
 pub fn find_child_by_kind(node: &Node, kind: &str) -> Option<Node> {
-    let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
-        node_kind!(ck = child);
-        if ck == kind {
-            return Some(child.clone());
-        }
-    }
-    None
+    find_child_by_kind_body!(node, kind)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Merge 3 reference check functions into single `check_first_index_reference`
- Add `pop_label_types_for_instr`, `label_types_vec`, `pop_function_return_types` helpers to TypeChecker
- Unify 5 duplicate native/WASM function pairs via body macros
- Move `node_copy!`/`node_clone!` macros to lib.rs for crate-wide visibility
- Extract `resolve_local_text` helper in tree_walk.rs

Net: -92 lines (241 added, 333 removed). All 475+ tests pass, clippy clean.