### PR TITLE
defrag: reduce allocations, deduplicate helpers, consolidate parse_nat

### DIFF
--- a/src/diagnostics_core/folded_checks.rs
+++ b/src/diagnostics_core/folded_checks.rs
@@ -32,37 +32,36 @@ pub fn check_folded_operand_count(
     let mut diagnostics = Vec::new();
 
     let mut cursor = node.walk();
-    let children: Vec<_> = node.children(&mut cursor).collect();
 
     // First child should be instr_plain
-    let first_child = match children.first() {
+    let first_child = match node.children(&mut cursor).next() {
         Some(c) if c.kind() == "instr_plain" => c,
         _ => return diagnostics,
     };
 
     // Get the instruction name from instr_plain
     let mut instr_cursor = first_child.walk();
-    let instr_children: Vec<_> = first_child.children(&mut instr_cursor).collect();
-    if instr_children.is_empty() {
-        return diagnostics;
-    }
+    let first_instr_child = match first_child.children(&mut instr_cursor).next() {
+        Some(c) => c,
+        None => return diagnostics,
+    };
 
-    let instr_kind = instr_children[0].kind();
+    let instr_kind = first_instr_child.kind();
     let instr_name = match instr_kind.as_ref() {
         "op_const" => {
-            let mut const_cursor = instr_children[0].walk();
-            let const_children: Vec<_> = instr_children[0].children(&mut const_cursor).collect();
-            if const_children.is_empty() {
-                return diagnostics;
+            let mut const_cursor = first_instr_child.walk();
+            let result = first_instr_child.children(&mut const_cursor).next();
+            match result {
+                Some(c) => source[c.byte_range()].trim().to_string(),
+                None => return diagnostics,
             }
-            source[const_children[0].byte_range()].trim().to_string()
         }
-        _ => source[instr_children[0].byte_range()].trim().to_string(),
+        _ => source[first_instr_child.byte_range()].trim().to_string(),
     };
 
     // Count expr children (these are the operands)
-    let operand_count = children
-        .iter()
+    let operand_count = node
+        .children(&mut cursor)
         .skip(1)
         .filter(|c| c.kind() == "expr")
         .count();

--- a/src/diagnostics_core/module_checks.rs
+++ b/src/diagnostics_core/module_checks.rs
@@ -404,7 +404,7 @@ fn check_import_ordering(module: &Node, source: &str, diagnostics: &mut Vec<Diag
     });
 }
 
-fn has_inline_import(node: &Node) -> bool {
+pub(super) fn has_inline_import(node: &Node) -> bool {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         node_kind!(ck = child);
@@ -2170,12 +2170,9 @@ fn check_type_use_index(
 
 /// Parse a nat (natural number) from text, handling hex prefix.
 fn parse_nat(text: &str) -> Result<usize, ()> {
-    let text = text.trim().replace('_', "");
-    if text.starts_with("0x") || text.starts_with("0X") {
-        usize::from_str_radix(&text[2..], 16).map_err(|_| ())
-    } else {
-        text.parse::<usize>().map_err(|_| ())
-    }
+    crate::parser::parse_wat_nat(text)
+        .map(|v| v as usize)
+        .ok_or(())
 }
 
 // ============================================================================

--- a/src/diagnostics_core/references.rs
+++ b/src/diagnostics_core/references.rs
@@ -130,8 +130,10 @@ pub fn find_undefined_identifiers(
                 // Check if label exists in containing function
                 if let Some(func) = find_containing_function(symbols, position) {
                     func.blocks.iter().any(|block| {
-                        format!("${}", block.label) == identifier_name
-                            || block.label == identifier_name
+                        block.label == identifier_name
+                            || identifier_name
+                                .strip_prefix('$')
+                                .is_some_and(|s| s == block.label)
                     })
                 } else {
                     false

--- a/src/diagnostics_core/semantic.rs
+++ b/src/diagnostics_core/semantic.rs
@@ -30,6 +30,28 @@ use tree_sitter::Node;
 #[cfg(all(feature = "wasm", not(feature = "native")))]
 use crate::ts_facade::Node;
 
+/// Get the ValueType corresponding to an instruction's prefix (i32., i64., f32., f64., v128.).
+fn type_from_prefix(name: &str) -> Option<ValueType> {
+    if name.starts_with("i32.") {
+        Some(ValueType::I32)
+    } else if name.starts_with("i64.") {
+        Some(ValueType::I64)
+    } else if name.starts_with("f32.") {
+        Some(ValueType::F32)
+    } else if name.starts_with("f64.") {
+        Some(ValueType::F64)
+    } else if name.starts_with("v128.") {
+        Some(ValueType::V128)
+    } else {
+        None
+    }
+}
+
+/// Check if an instruction name refers to a SIMD lane operation (contains x2./x4./x8./x16.).
+fn is_simd_instruction(name: &str) -> bool {
+    name.contains("x2.") || name.contains("x4.") || name.contains("x8.") || name.contains("x16.")
+}
+
 /// Track stack state through an instruction list and report underflow/type errors.
 /// If expected_results is None, skip return type validation (e.g., when function uses type reference).
 /// Returns diagnostics as core::types::Diagnostic.
@@ -657,7 +679,7 @@ fn process_instruction(
     // Check global.set targets a mutable global
     if instr_name == "global.set" {
         if let Some(index) = get_index_from_node(node, source) {
-            let is_immutable = if let Some(global) = symbols.get_global_by_name(&index) {
+            let is_immutable = if let Some(global) = symbols.get_global_by_name(index) {
                 !global.is_mutable
             } else if let Ok(idx) = index.parse::<usize>() {
                 symbols
@@ -732,33 +754,9 @@ fn derive_consumed_types_from_name(
     symbols: &SymbolTable,
     source: &str,
 ) -> Option<Vec<ValueType>> {
-    // Helper to get type from instruction prefix
-    let type_from_prefix = |name: &str| -> Option<ValueType> {
-        if name.starts_with("i32.") {
-            return Some(ValueType::I32);
-        }
-        if name.starts_with("i64.") {
-            return Some(ValueType::I64);
-        }
-        if name.starts_with("f32.") {
-            return Some(ValueType::F32);
-        }
-        if name.starts_with("f64.") {
-            return Some(ValueType::F64);
-        }
-        if name.starts_with("v128.") {
-            return Some(ValueType::V128);
-        }
-        None
-    };
-
     // Helper to check if an instruction is a scalar binary op (2 operands of prefix type)
     let is_binary_scalar = |name: &str| -> bool {
-        let is_simd = name.contains("x2.")
-            || name.contains("x4.")
-            || name.contains("x8.")
-            || name.contains("x16.");
-        if is_simd {
+        if is_simd_instruction(name) {
             return false;
         }
         // Arithmetic: add, sub, mul, div, rem, and, or, xor, shl, shr, rot, copysign, min, max
@@ -782,11 +780,7 @@ fn derive_consumed_types_from_name(
 
     // Helper to check if an instruction is a scalar unary op
     let is_unary_scalar = |name: &str| -> bool {
-        let is_simd = name.contains("x2.")
-            || name.contains("x4.")
-            || name.contains("x8.")
-            || name.contains("x16.");
-        if is_simd {
+        if is_simd_instruction(name) {
             return false;
         }
         name.ends_with(".eqz")
@@ -846,7 +840,7 @@ fn derive_consumed_types_from_name(
         // Call — consume parameter types
         "call" | "return_call" => {
             if let Some(func_ref) = get_index_from_node(node, source) {
-                if let Some(func) = symbols.get_function_by_name(&func_ref) {
+                if let Some(func) = symbols.get_function_by_name(func_ref) {
                     return Some(func.parameters.iter().map(|p| p.param_type).collect());
                 } else if let Ok(idx) = func_ref.parse::<usize>() {
                     if let Some(func) = symbols.get_function_by_index(idx) {
@@ -860,13 +854,13 @@ fn derive_consumed_types_from_name(
         // Call_ref — consume param types + typed funcref (ref null $type)
         "call_ref" | "return_call_ref" => {
             if let Some(type_ref) = get_index_from_node(node, source) {
-                if let Some(type_def) = symbols.get_type_by_name(&type_ref) {
+                if let Some(type_def) = symbols.get_type_by_name(type_ref) {
                     if let TypeKind::Func { params, .. } = &type_def.kind {
                         let mut types: Vec<ValueType> = params.clone();
                         types.push(ValueType::RefNull(type_def.index as u32));
                         return Some(types);
                     }
-                } else if let Some(idx) = parse_wat_nat(&type_ref) {
+                } else if let Some(idx) = parse_wat_nat(type_ref) {
                     if let Some(type_def) = symbols.get_type_by_index(idx as usize) {
                         if let TypeKind::Func { params, .. } = &type_def.kind {
                             let mut types: Vec<ValueType> = params.clone();
@@ -1096,7 +1090,7 @@ fn get_branch_depth(node: &Node, source: &str, checker: &mut TypeChecker) -> Opt
     let index = get_index_from_node(node, source)?;
     // Try as numeric index first (supports hex like 0x10000001 and underscore separators)
     if !index.starts_with('$') {
-        if let Some(depth) = parse_wat_nat(&index) {
+        if let Some(depth) = parse_wat_nat(index) {
             let depth = depth as usize;
             if depth < checker.ctrl_depth() {
                 return Some(depth);
@@ -1111,7 +1105,7 @@ fn get_branch_depth(node: &Node, source: &str, checker: &mut TypeChecker) -> Opt
     }
     // Try named label resolution
     if index.starts_with('$') {
-        return checker.resolve_label_depth(&index);
+        return checker.resolve_label_depth(index);
     }
     None
 }
@@ -1209,7 +1203,7 @@ pub fn get_dynamic_operand_count(
     match instr_name {
         "call" | "return_call" => {
             if let Some(func_ref) = get_index_from_node(node, source) {
-                if let Some(func) = symbols.get_function_by_name(&func_ref) {
+                if let Some(func) = symbols.get_function_by_name(func_ref) {
                     return func.parameters.len();
                 } else if let Ok(idx) = func_ref.parse::<usize>() {
                     if let Some(func) = symbols.get_function_by_index(idx) {
@@ -1221,7 +1215,7 @@ pub fn get_dynamic_operand_count(
         }
         "call_ref" | "return_call_ref" => {
             if let Some(type_ref) = get_index_from_node(node, source) {
-                if let Some(type_def) = symbols.get_type_by_name(&type_ref) {
+                if let Some(type_def) = symbols.get_type_by_name(type_ref) {
                     if let TypeKind::Func { params, .. } = &type_def.kind {
                         return params.len() + 1;
                     }
@@ -1237,7 +1231,7 @@ pub fn get_dynamic_operand_count(
         }
         "call_indirect" | "return_call_indirect" => {
             if let Some(type_ref) = get_index_from_node(node, source) {
-                if let Some(type_def) = symbols.get_type_by_name(&type_ref) {
+                if let Some(type_def) = symbols.get_type_by_name(type_ref) {
                     if let TypeKind::Func { params, .. } = &type_def.kind {
                         return params.len() + 1;
                     }
@@ -1253,7 +1247,7 @@ pub fn get_dynamic_operand_count(
         }
         "struct.new" => {
             if let Some(type_ref) = get_index_from_node(node, source) {
-                if let Some(type_def) = symbols.get_type_by_name(&type_ref) {
+                if let Some(type_def) = symbols.get_type_by_name(type_ref) {
                     if let TypeKind::Struct { fields } = &type_def.kind {
                         return fields.len();
                     }
@@ -1269,7 +1263,7 @@ pub fn get_dynamic_operand_count(
         }
         "throw" => {
             if let Some(tag_ref) = get_index_from_node(node, source) {
-                if let Some(tag) = symbols.get_tag_by_name(&tag_ref) {
+                if let Some(tag) = symbols.get_tag_by_name(tag_ref) {
                     return tag.params.len();
                 } else if let Ok(idx) = tag_ref.parse::<usize>() {
                     if let Some(tag) = symbols.get_tag_by_index(idx) {
@@ -1291,13 +1285,13 @@ pub fn get_dynamic_operand_count(
 }
 
 /// Get the index/identifier from an instruction node
-pub fn get_index_from_node(node: &Node, source: &str) -> Option<String> {
+pub fn get_index_from_node<'a>(node: &Node, source: &'a str) -> Option<&'a str> {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         node_kind!(kind = child);
 
         if kind == "index" || kind == "identifier" {
-            return Some(source[child.byte_range()].trim().to_string());
+            return Some(source[child.byte_range()].trim());
         }
         if kind == "type_use" {
             let mut inner_cursor = child.walk();
@@ -1305,7 +1299,7 @@ pub fn get_index_from_node(node: &Node, source: &str) -> Option<String> {
                 node_kind!(inner_kind = inner_child);
 
                 if inner_kind == "index" || inner_kind == "identifier" {
-                    return Some(source[inner_child.byte_range()].trim().to_string());
+                    return Some(source[inner_child.byte_range()].trim());
                 }
             }
         }
@@ -1315,7 +1309,7 @@ pub fn get_index_from_node(node: &Node, source: &str) -> Option<String> {
                 node_kind!(inner_kind = inner_child);
 
                 if inner_kind == "index" || inner_kind == "identifier" {
-                    return Some(source[inner_child.byte_range()].trim().to_string());
+                    return Some(source[inner_child.byte_range()].trim());
                 }
             }
         }
@@ -1347,31 +1341,8 @@ pub fn infer_instruction_result_types(
         }
     }
 
-    let type_from_prefix = |name: &str| -> Option<ValueType> {
-        if name.starts_with("i32.") {
-            return Some(ValueType::I32);
-        }
-        if name.starts_with("i64.") {
-            return Some(ValueType::I64);
-        }
-        if name.starts_with("f32.") {
-            return Some(ValueType::F32);
-        }
-        if name.starts_with("f64.") {
-            return Some(ValueType::F64);
-        }
-        if name.starts_with("v128.") {
-            return Some(ValueType::V128);
-        }
-        None
-    };
-
     let is_scalar_comparison = |name: &str| -> bool {
-        let is_simd = name.contains("x2.")
-            || name.contains("x4.")
-            || name.contains("x8.")
-            || name.contains("x16.");
-        if is_simd {
+        if is_simd_instruction(name) {
             return false;
         }
         name.ends_with(".eq")
@@ -1520,12 +1491,12 @@ pub fn get_local_type_from_node(
     let func_line = node.start_position().row as u32;
     let func = symbols.find_function_containing_line(func_line)?;
 
-    let name_to_check = index.strip_prefix('$').unwrap_or(&index);
+    let name_to_check = index.strip_prefix('$').unwrap_or(index);
 
     for param in &func.parameters {
         if let Some(param_name) = &param.name {
             let param_name_stripped = param_name.strip_prefix('$').unwrap_or(param_name);
-            if param_name_stripped == name_to_check || param_name == &index {
+            if param_name_stripped == name_to_check || param_name == index {
                 return Some(param.param_type);
             }
         }
@@ -1534,7 +1505,7 @@ pub fn get_local_type_from_node(
     for local in &func.locals {
         if let Some(local_name) = &local.name {
             let local_name_stripped = local_name.strip_prefix('$').unwrap_or(local_name);
-            if local_name_stripped == name_to_check || local_name == &index {
+            if local_name_stripped == name_to_check || local_name == index {
                 return Some(local.var_type);
             }
         }
@@ -1561,7 +1532,7 @@ pub fn get_global_type_from_node(
 ) -> Option<ValueType> {
     let index = get_index_from_node(node, source)?;
 
-    if let Some(global) = symbols.get_global_by_name(&index) {
+    if let Some(global) = symbols.get_global_by_name(index) {
         return Some(global.var_type);
     }
     if let Ok(idx) = index.parse::<usize>() {
@@ -1576,10 +1547,10 @@ pub fn get_global_type_from_node(
 /// Falls back to table 0 if no explicit index.
 fn resolve_table<'a>(node: &Node, symbols: &'a SymbolTable, source: &str) -> Option<&'a Table> {
     if let Some(index) = get_index_from_node(node, source) {
-        if let Some(table) = symbols.get_table_by_name(&index) {
+        if let Some(table) = symbols.get_table_by_name(index) {
             return Some(table);
         }
-        if let Some(idx) = parse_wat_nat(&index) {
+        if let Some(idx) = parse_wat_nat(index) {
             if let Some(table) = symbols.tables.get(idx as usize) {
                 return Some(table);
             }
@@ -1612,7 +1583,7 @@ fn get_table_index_type(node: &Node, symbols: &SymbolTable, source: &str) -> Val
 fn get_ref_func_result_type(node: &Node, symbols: &SymbolTable, source: &str) -> Vec<ValueType> {
     if let Some(func_ref) = get_index_from_node(node, source) {
         // Look up the function to find its type
-        let func = if let Some(f) = symbols.get_function_by_name(&func_ref) {
+        let func = if let Some(f) = symbols.get_function_by_name(func_ref) {
             Some(f)
         } else if let Ok(idx) = func_ref.parse::<usize>() {
             symbols.get_function_by_index(idx)
@@ -1639,7 +1610,7 @@ fn get_ref_func_result_type(node: &Node, symbols: &SymbolTable, source: &str) ->
 /// Get result types for a call instruction
 pub fn get_call_result_types(node: &Node, symbols: &SymbolTable, source: &str) -> Vec<ValueType> {
     if let Some(func_ref) = get_index_from_node(node, source) {
-        if let Some(func) = symbols.get_function_by_name(&func_ref) {
+        if let Some(func) = symbols.get_function_by_name(func_ref) {
             return func.results.clone();
         } else if let Ok(idx) = func_ref.parse::<usize>() {
             if let Some(func) = symbols.get_function_by_index(idx) {
@@ -1657,7 +1628,7 @@ pub fn get_call_ref_result_types(
     source: &str,
 ) -> Vec<ValueType> {
     if let Some(type_ref) = get_index_from_node(node, source) {
-        if let Some(type_def) = symbols.get_type_by_name(&type_ref) {
+        if let Some(type_def) = symbols.get_type_by_name(type_ref) {
             if let TypeKind::Func { results, .. } = &type_def.kind {
                 return results.clone();
             }
@@ -2395,7 +2366,7 @@ fn get_expr1_result_types(expr1: &Node, source: &str, symbols: &SymbolTable) -> 
                 }
             }
             if let Some(func_ref) = get_index_from_expr1_call(expr1, source) {
-                if let Some(func) = symbols.get_function_by_name(&func_ref) {
+                if let Some(func) = symbols.get_function_by_name(func_ref) {
                     return func.results.clone();
                 } else if let Ok(idx) = func_ref.parse::<usize>() {
                     if let Some(func) = symbols.get_function_by_index(idx) {
@@ -2410,13 +2381,13 @@ fn get_expr1_result_types(expr1: &Node, source: &str, symbols: &SymbolTable) -> 
 }
 
 /// Get function reference from expr1_call node
-pub fn get_index_from_expr1_call(node: &Node, source: &str) -> Option<String> {
+pub fn get_index_from_expr1_call<'a>(node: &Node, source: &'a str) -> Option<&'a str> {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         node_kind!(kind = child);
 
         if kind == "index" || kind == "identifier" {
-            return Some(source[child.byte_range()].trim().to_string());
+            return Some(source[child.byte_range()].trim());
         }
     }
     None

--- a/src/diagnostics_core/tree_walk.rs
+++ b/src/diagnostics_core/tree_walk.rs
@@ -318,19 +318,7 @@ fn is_value_type_context(node: &Node) -> bool {
     }
 }
 
-/// Check if a function node has an inline import
-fn has_inline_import(node: &Node) -> bool {
-    let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
-        let ck = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let ck = &*ck;
-        if ck == "import" {
-            return true;
-        }
-    }
-    false
-}
+use super::module_checks::has_inline_import;
 
 /// Check for unused locals and parameters in a function.
 fn check_unused_locals(

--- a/src/features/references_core.rs
+++ b/src/features/references_core.rs
@@ -636,7 +636,7 @@ fn find_reference_identifiers(
     if matches!(&*kind, "nat" | "dec_nat" | "hex_nat" | "index") {
         let text = &ctx.document[node.byte_range()];
         if !text.trim().starts_with('$') {
-            if let Ok(index) = parse_nat(text.trim()) {
+            if let Some(index) = crate::parser::parse_wat_nat(text).map(|v| v as usize) {
                 if matches_target_index(
                     index,
                     target,
@@ -1030,13 +1030,4 @@ fn is_in_same_function_by_line(
     symbols
         .find_function_containing_line(line)
         .is_some_and(|func| func.start_byte == target_function_start_byte)
-}
-
-/// Parse a natural number (decimal or hex)
-fn parse_nat(text: &str) -> Result<usize, std::num::ParseIntError> {
-    if text.starts_with("0x") || text.starts_with("0X") {
-        usize::from_str_radix(&text[2..], 16)
-    } else {
-        text.parse::<usize>()
-    }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -420,7 +420,7 @@ fn extract_imported_table(desc_node: &Node, source: &str, index: usize) -> Optio
                     for limit_child in type_child.children(&mut limits_cursor) {
                         if limit_child.kind() == "nat" {
                             let text = node_text(&limit_child, source);
-                            if let Some(num) = parse_wat_nat(&text) {
+                            if let Some(num) = parse_wat_nat(text) {
                                 if nat_index == 0 {
                                     min_limit = num;
                                 } else {
@@ -548,7 +548,7 @@ fn extract_imported_tag(desc_node: &Node, source: &str, index: usize) -> Option<
 fn extract_identifier_info(node: &Node, source: &str) -> (Option<String>, Option<Range>) {
     if let Some(id_node) = crate::utils::find_child_by_kind(node, "identifier") {
         (
-            Some(node_text(&id_node, source)),
+            Some(node_text(&id_node, source).to_string()),
             Some(node_to_range(&id_node)),
         )
     } else {
@@ -806,7 +806,7 @@ fn extract_parameters(func_node: &Node, source: &str) -> Vec<Parameter> {
                     let mut one_cursor = param_child.walk();
                     for one_child in param_child.children(&mut one_cursor) {
                         if one_child.kind() == "identifier" {
-                            name_opt = Some(node_text(&one_child, source));
+                            name_opt = Some(node_text(&one_child, source).to_string());
                             range_opt = Some(node_to_range(&one_child));
                         } else if one_child.kind() == "value_type" {
                             type_opt = Some(extract_value_type(&one_child, source));
@@ -990,7 +990,7 @@ fn extract_locals(func_node: &Node, source: &str) -> Vec<Variable> {
                     let mut one_cursor = locals_child.walk();
                     for one_child in locals_child.children(&mut one_cursor) {
                         if one_child.kind() == "identifier" {
-                            name_opt = Some(node_text(&one_child, source));
+                            name_opt = Some(node_text(&one_child, source).to_string());
                             range_opt = Some(node_to_range(&one_child));
                         } else if one_child.kind() == "value_type" {
                             type_opt = Some(extract_value_type(&one_child, source));
@@ -1048,7 +1048,7 @@ fn visit_node_for_blocks(node: &Node, source: &str, blocks: &mut Vec<BlockLabel>
     if BLOCK_KINDS_STATEMENT.contains(&kind_str) || BLOCK_KINDS_EXPR.contains(&kind_str) {
         // Check if it has a label
         if let Some(id_node) = crate::utils::find_child_by_kind(node, "identifier") {
-            let label = node_text(&id_node, source);
+            let label = node_text(&id_node, source).to_string();
             let block_type = block_type_from_kind(kind_str).to_string();
 
             blocks.push(BlockLabel {
@@ -1226,7 +1226,7 @@ fn extract_rec_types(
                     let id_node = &children_vec[i];
                     i += 1;
                     (
-                        Some(node_text(id_node, source)),
+                        Some(node_text(id_node, source).to_string()),
                         Some(node_to_range(id_node)),
                     )
                 } else {
@@ -1292,7 +1292,7 @@ fn extract_type_from_single_node(
 
                 match sub_kind {
                     "index" => {
-                        parent_ref = Some(node_text(&sub_child, source));
+                        parent_ref = Some(node_text(&sub_child, source).to_string());
                     }
                     "def_type" => {
                         let mut def_cursor = sub_child.walk();
@@ -1426,7 +1426,7 @@ fn extract_field_types(field_node: &Node, source: &str) -> Vec<(Option<String>, 
         node_kind!(ck = child);
         match ck {
             "identifier" => {
-                field_name = Some(node_text(&child, source));
+                field_name = Some(node_text(&child, source).to_string());
             }
             "storage_type" => {
                 let (ft, mutable) = extract_storage_type_with_mut(&child, source);
@@ -1456,7 +1456,7 @@ fn extract_field_types(field_node: &Node, source: &str) -> Vec<(Option<String>, 
                 }
                 "packed_type" => {
                     let text = node_text(&child, source);
-                    field_type = match text.as_str() {
+                    field_type = match text {
                         "i8" => ValueType::I8,
                         "i16" => ValueType::I16,
                         _ => ValueType::Unknown,
@@ -1497,7 +1497,7 @@ fn extract_type(type_node: &Node, source: &str, index: usize) -> Option<TypeDef>
 
                 match sub_kind {
                     "index" => {
-                        parent_ref = Some(node_text(&sub_child, source));
+                        parent_ref = Some(node_text(&sub_child, source).to_string());
                     }
                     "def_type" => {
                         // Process the inner type definition
@@ -1614,7 +1614,7 @@ fn extract_type(type_node: &Node, source: &str, index: usize) -> Option<TypeDef>
 
                         match sub_kind {
                             "index" => {
-                                parent_ref = Some(node_text(&sub_child, source));
+                                parent_ref = Some(node_text(&sub_child, source).to_string());
                             }
                             "def_type" => {
                                 let mut def_cursor = sub_child.walk();
@@ -1770,7 +1770,7 @@ fn extract_table(table_node: &Node, source: &str, index: usize) -> Option<Table>
                             for limit_child in type_child.children(&mut limits_cursor) {
                                 if limit_child.kind() == "nat" {
                                     let text = node_text(&limit_child, source);
-                                    if let Some(num) = parse_wat_nat(&text) {
+                                    if let Some(num) = parse_wat_nat(text) {
                                         if nat_index == 0 {
                                             min_limit = num;
                                         } else {
@@ -1799,7 +1799,7 @@ fn extract_table(table_node: &Node, source: &str, index: usize) -> Option<Table>
                     for limit_child in type_child.children(&mut limits_cursor) {
                         if limit_child.kind() == "nat" {
                             let text = node_text(&limit_child, source);
-                            if let Some(num) = parse_wat_nat(&text) {
+                            if let Some(num) = parse_wat_nat(text) {
                                 if nat_index == 0 {
                                     min_limit = num;
                                 } else {
@@ -1891,7 +1891,7 @@ fn extract_memory(memory_node: &Node, source: &str, index: usize) -> Option<Memo
             for limit_child in limits_node.children(&mut limits_cursor) {
                 if limit_child.kind() == "nat" {
                     let text = node_text(&limit_child, source);
-                    if let Some(num) = parse_wat_nat(&text) {
+                    if let Some(num) = parse_wat_nat(text) {
                         if nat_index == 0 {
                             *min = num;
                         } else {
@@ -2044,8 +2044,8 @@ fn extract_tag(tag_node: &Node, source: &str, index: usize) -> Option<Tag> {
 }
 
 /// Helper: Extract text from a node
-fn node_text(node: &Node, source: &str) -> String {
-    source[node.byte_range()].to_string()
+fn node_text<'a>(node: &Node, source: &'a str) -> &'a str {
+    &source[node.byte_range()]
 }
 
 /// Parse a WAT natural number, handling hex (0x...) and underscore separators.
@@ -2062,7 +2062,7 @@ pub(crate) fn parse_wat_nat(text: &str) -> Option<u64> {
 fn extract_value_type(value_type_node: &Node, source: &str) -> ValueType {
     // Check strict match first (for direct children like "i32" in some contexts)
     let text = node_text(value_type_node, source);
-    if let Some(vt) = ValueType::try_parse(&text) {
+    if let Some(vt) = ValueType::try_parse(text) {
         return vt;
     }
 
@@ -2109,7 +2109,7 @@ fn extract_value_type(value_type_node: &Node, source: &str) -> ValueType {
             _ => {
                 // Check if child itself is a type keyword
                 let text = node_text(&child, source);
-                if let Some(vt) = simple_type_from_str(&text) {
+                if let Some(vt) = simple_type_from_str(text) {
                     return vt;
                 }
             }
@@ -2129,7 +2129,7 @@ fn extract_storage_type_with_mut(storage_node: &Node, source: &str) -> (ValueTyp
             "value_type" => return (extract_value_type(&child, source), false),
             "packed_type" => {
                 let text = node_text(&child, source);
-                let vt = match text.as_str() {
+                let vt = match text {
                     "i8" => ValueType::I8,
                     "i16" => ValueType::I16,
                     _ => ValueType::Unknown,
@@ -2145,7 +2145,7 @@ fn extract_storage_type_with_mut(storage_node: &Node, source: &str) -> (ValueTyp
                         "value_type" => return (extract_value_type(&inner_child, source), true),
                         "packed_type" => {
                             let text = node_text(&inner_child, source);
-                            let vt = match text.as_str() {
+                            let vt = match text {
                                 "i8" => ValueType::I8,
                                 "i16" => ValueType::I16,
                                 _ => ValueType::Unknown,
@@ -2174,7 +2174,7 @@ fn simple_type_from_str(s: &str) -> Option<ValueType> {
 fn extract_ref_type(ref_type_node: &Node, source: &str) -> ValueType {
     // Check strict match first
     let text = node_text(ref_type_node, source);
-    if let Some(vt) = simple_type_from_str(&text) {
+    if let Some(vt) = simple_type_from_str(text) {
         return vt;
     }
 
@@ -2255,7 +2255,7 @@ fn extract_ref_type(ref_type_node: &Node, source: &str) -> ValueType {
 
                 // If it's a ref_kind like (ref func), (ref extern), etc.
                 if let Some(kind) = ref_kind {
-                    return match kind.as_str() {
+                    return match kind {
                         "func" => ValueType::Funcref,
                         "extern" => ValueType::Externref,
                         "any" => ValueType::Anyref,
@@ -2283,7 +2283,7 @@ fn extract_ref_type(ref_type_node: &Node, source: &str) -> ValueType {
             "ref_type" => return extract_ref_type(&child, source),
             _ => {
                 let text = node_text(&child, source);
-                if let Some(vt) = simple_type_from_str(&text) {
+                if let Some(vt) = simple_type_from_str(text) {
                     return vt;
                 }
             }
@@ -2293,7 +2293,7 @@ fn extract_ref_type(ref_type_node: &Node, source: &str) -> ValueType {
     // Check for direct string matches in children (e.g. "anyref")
     for child in ref_type_node.children(&mut cursor) {
         let text = node_text(&child, source);
-        if let Some(vt) = simple_type_from_str(&text) {
+        if let Some(vt) = simple_type_from_str(text) {
             return vt;
         }
     }
@@ -2458,7 +2458,10 @@ fn find_identifier_in_data_or_elem(node: &Node, source: &str) -> (Option<String>
     for child in node.children(&mut cursor) {
         // Direct identifier (shouldn't happen, but handle it)
         if child.kind() == "identifier" {
-            return (Some(node_text(&child, source)), Some(node_to_range(&child)));
+            return (
+                Some(node_text(&child, source).to_string()),
+                Some(node_to_range(&child)),
+            );
         }
         // Index node that contains the identifier
         if child.kind() == "index" {
@@ -2466,7 +2469,7 @@ fn find_identifier_in_data_or_elem(node: &Node, source: &str) -> (Option<String>
             for index_child in child.children(&mut index_cursor) {
                 if index_child.kind() == "identifier" {
                     return (
-                        Some(node_text(&index_child, source)),
+                        Some(node_text(&index_child, source).to_string()),
                         Some(node_to_range(&index_child)),
                     );
                 }


### PR DESCRIPTION
## Summary

- Extract `type_from_prefix()` and `is_simd_instruction()` as standalone functions, replacing 3 duplicate closures in semantic.rs
- Change `node_text()`, `get_index_from_node()`, and `get_index_from_expr1_call()` to return `&str` instead of `String`, eliminating per-instruction heap allocations
- Consolidate `parse_nat` duplicates in module_checks.rs and references_core.rs to delegate to `parser::parse_wat_nat()`
- Remove allocation in label comparison loop (references.rs) using `strip_prefix`
- Replace unnecessary `Vec::collect()` calls with iterators in folded_checks.rs
- Consolidate duplicate `has_inline_import` in tree_walk.rs
- Net: -48 lines, clippy warnings reduced from 30 to 9