### PR TITLE
feat: detect uninitialized non-nullable locals and validate elem type nullability

### DIFF
--- a/src/diagnostics_core/local_init.rs
+++ b/src/diagnostics_core/local_init.rs
@@ -1,0 +1,638 @@
+//! Uninitialized local detection for non-nullable reference types.
+//!
+//! Per the Wasm spec (GC proposal), locals with non-nullable reference types
+//! (e.g., `ref $t`, `ref func`, `ref extern`) must be explicitly initialized
+//! via `local.set` or `local.tee` before being read with `local.get`.
+//!
+//! Initialization tracking rules:
+//! - Parameters are always initialized
+//! - Locals with defaultable types (numeric, nullable ref) are always initialized
+//! - After a block/loop, initialization state reverts to before the block
+//! - After an if/else, only locals initialized in BOTH branches are considered initialized
+
+use std::collections::HashSet;
+
+use crate::core::types::Diagnostic;
+use crate::symbols::{Function, SymbolTable};
+use crate::utils::node_to_range;
+
+#[cfg(feature = "native")]
+use tree_sitter::Node;
+
+#[cfg(all(feature = "wasm", not(feature = "native")))]
+use crate::ts_facade::Node;
+
+/// Check for uses of uninitialized locals with non-defaultable types.
+pub(crate) fn check_uninitialized_locals(
+    func_node: &Node,
+    source: &str,
+    symbols: &SymbolTable,
+) -> Vec<Diagnostic> {
+    let func_line = func_node.start_position().row as u32;
+    let func = match symbols.find_function_containing_line(func_line) {
+        Some(f) => f,
+        None => return vec![],
+    };
+
+    // Scan the AST to find which locals have non-defaultable (non-nullable ref) types
+    let non_defaultable = find_non_defaultable_locals(func_node, source, func);
+    if non_defaultable.is_empty() {
+        return vec![];
+    }
+
+    // Initialize tracking: params are always initialized, defaultable locals are initialized
+    let num_params = func.parameters.len();
+    let total = num_params + func.locals.len();
+    let mut initialized: HashSet<usize> = (0..total)
+        .filter(|i| !non_defaultable.contains(i))
+        .collect();
+
+    let mut diagnostics = Vec::new();
+
+    // Find and walk the instr_list
+    let mut cursor = func_node.walk();
+    for child in func_node.children(&mut cursor) {
+        let kind = child.kind();
+        #[cfg(all(feature = "wasm", not(feature = "native")))]
+        let kind = &*kind;
+        if kind == "instr_list" {
+            walk_body(
+                &child,
+                source,
+                func,
+                &non_defaultable,
+                &mut initialized,
+                &mut diagnostics,
+            );
+            break;
+        }
+    }
+
+    diagnostics
+}
+
+/// Scan function AST for local declarations with non-nullable reference types.
+/// Returns the set of absolute local indices (params.len() + local_index) that are non-defaultable.
+fn find_non_defaultable_locals(func_node: &Node, source: &str, func: &Function) -> HashSet<usize> {
+    let mut result = HashSet::new();
+    let num_params = func.parameters.len();
+    let mut local_counter = 0;
+
+    let mut cursor = func_node.walk();
+    for child in func_node.children(&mut cursor) {
+        let kind = child.kind();
+        #[cfg(all(feature = "wasm", not(feature = "native")))]
+        let kind = &*kind;
+
+        if kind == "func_locals" || kind == "func_locals_one" || kind == "func_locals_many" {
+            scan_locals_node(&child, source, num_params, &mut local_counter, &mut result);
+        }
+    }
+
+    result
+}
+
+/// Recursively scan a locals node (func_locals, func_locals_one, func_locals_many)
+/// for value_type children and check if they are non-nullable ref types.
+fn scan_locals_node(
+    node: &Node,
+    source: &str,
+    num_params: usize,
+    local_counter: &mut usize,
+    result: &mut HashSet<usize>,
+) {
+    let kind = node.kind();
+    #[cfg(all(feature = "wasm", not(feature = "native")))]
+    let kind = &*kind;
+
+    match kind {
+        "value_type" | "value_type_ref_type" | "value_type_num_type" => {
+            if is_non_nullable_ref_in_ast(node, source) {
+                result.insert(num_params + *local_counter);
+            }
+            *local_counter += 1;
+        }
+        _ => {
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                scan_locals_node(&child, source, num_params, local_counter, result);
+            }
+        }
+    }
+}
+
+/// Check if a `value_type` AST node represents a non-nullable reference type.
+/// Walks down through `value_type → value_type_ref_type → ref_type → ref_type_ref/ref_type_concrete`
+/// and checks for the absence of `null`.
+fn is_non_nullable_ref_in_ast(node: &Node, source: &str) -> bool {
+    let kind = node.kind();
+    #[cfg(all(feature = "wasm", not(feature = "native")))]
+    let kind = &*kind;
+
+    match kind {
+        "ref_type_ref" | "ref_type_concrete" => {
+            // (ref null? ...) — non-nullable if no "null" child
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                if &source[child.byte_range()] == "null" {
+                    return false;
+                }
+            }
+            true
+        }
+        // Shorthand types are always nullable
+        "ref_type_funcref" | "ref_type_externref" => false,
+        _ => {
+            let text = source[node.byte_range()].trim();
+            if matches!(
+                text,
+                "funcref"
+                    | "externref"
+                    | "anyref"
+                    | "eqref"
+                    | "i31ref"
+                    | "structref"
+                    | "arrayref"
+                    | "nullref"
+                    | "nullfuncref"
+                    | "nullexternref"
+                    | "exnref"
+                    | "nullexnref"
+            ) {
+                return false;
+            }
+            // Recurse into children
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                if is_non_nullable_ref_in_ast(&child, source) {
+                    return true;
+                }
+            }
+            false
+        }
+    }
+}
+
+/// Walk a block body (instr_list, block_block, etc.) tracking local initialization.
+fn walk_body(
+    node: &Node,
+    source: &str,
+    func: &Function,
+    non_defaultable: &HashSet<usize>,
+    initialized: &mut HashSet<usize>,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        walk_node(
+            &child,
+            source,
+            func,
+            non_defaultable,
+            initialized,
+            diagnostics,
+        );
+    }
+}
+
+/// Process a single AST node for local initialization tracking.
+fn walk_node(
+    node: &Node,
+    source: &str,
+    func: &Function,
+    non_defaultable: &HashSet<usize>,
+    initialized: &mut HashSet<usize>,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let kind = node.kind();
+    #[cfg(all(feature = "wasm", not(feature = "native")))]
+    let kind = &*kind;
+
+    match kind {
+        "instr_plain" => {
+            check_local_instruction(
+                node,
+                source,
+                func,
+                non_defaultable,
+                initialized,
+                diagnostics,
+            );
+        }
+
+        // Folded expression: process operand sub-exprs first, then the instruction
+        "expr1_plain" => {
+            let mut cursor = node.walk();
+            let mut instr_plain = None;
+            for child in node.children(&mut cursor) {
+                let ck = child.kind();
+                #[cfg(all(feature = "wasm", not(feature = "native")))]
+                let ck = &*ck;
+                if ck == "expr" {
+                    walk_node(
+                        &child,
+                        source,
+                        func,
+                        non_defaultable,
+                        initialized,
+                        diagnostics,
+                    );
+                } else if ck == "instr_plain" {
+                    // Save for processing after operands
+                    instr_plain = Some(child);
+                }
+            }
+            if let Some(ref ip) = instr_plain {
+                check_local_instruction(
+                    ip,
+                    source,
+                    func,
+                    non_defaultable,
+                    initialized,
+                    diagnostics,
+                );
+            }
+        }
+
+        // Block/loop: save state, walk body, restore state
+        "instr_block" | "instr_loop" => {
+            let saved = initialized.clone();
+            if is_block_if(node) {
+                walk_if_body(
+                    node,
+                    source,
+                    func,
+                    non_defaultable,
+                    initialized,
+                    diagnostics,
+                    &saved,
+                );
+            } else {
+                walk_body(
+                    node,
+                    source,
+                    func,
+                    non_defaultable,
+                    initialized,
+                    diagnostics,
+                );
+            }
+            *initialized = saved;
+        }
+        "block_block" | "loop_block" | "block_try_table" | "block_try" => {
+            let saved = initialized.clone();
+            walk_body(
+                node,
+                source,
+                func,
+                non_defaultable,
+                initialized,
+                diagnostics,
+            );
+            *initialized = saved;
+        }
+
+        // Folded block/loop
+        "expr1_block" | "expr1_loop" | "expr1_try_table" => {
+            let saved = initialized.clone();
+            walk_body(
+                node,
+                source,
+                func,
+                non_defaultable,
+                initialized,
+                diagnostics,
+            );
+            *initialized = saved;
+        }
+
+        // If: save/restore same as block (control flow doesn't contribute to init)
+        "instr_if" | "expr1_if" => {
+            let saved = initialized.clone();
+            walk_if_body(
+                node,
+                source,
+                func,
+                non_defaultable,
+                initialized,
+                diagnostics,
+                &saved,
+            );
+            *initialized = saved;
+        }
+        "block_if" | "if_block" => {
+            let saved = initialized.clone();
+            walk_if_body(
+                node,
+                source,
+                func,
+                non_defaultable,
+                initialized,
+                diagnostics,
+                &saved,
+            );
+            *initialized = saved;
+        }
+
+        // Default: recurse into children in order
+        _ => {
+            walk_body(
+                node,
+                source,
+                func,
+                non_defaultable,
+                initialized,
+                diagnostics,
+            );
+        }
+    }
+}
+
+/// Walk if body, resetting init state at the else boundary.
+/// Each branch sees the pre-if initialization state.
+fn walk_if_body(
+    node: &Node,
+    source: &str,
+    func: &Function,
+    non_defaultable: &HashSet<usize>,
+    initialized: &mut HashSet<usize>,
+    diagnostics: &mut Vec<Diagnostic>,
+    saved: &HashSet<usize>,
+) {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        let ck = child.kind();
+        #[cfg(all(feature = "wasm", not(feature = "native")))]
+        let ck = &*ck;
+
+        match ck {
+            // Linear format: else branch is in a separate node
+            "instr_else" => {
+                *initialized = saved.clone();
+                walk_body(
+                    &child,
+                    source,
+                    func,
+                    non_defaultable,
+                    initialized,
+                    diagnostics,
+                );
+            }
+            // Folded format: "else" keyword resets state
+            "else" => {
+                *initialized = saved.clone();
+            }
+            // if_block / block_if contain the then/else structure — recurse
+            "if_block" | "block_if" => {
+                walk_if_body(
+                    &child,
+                    source,
+                    func,
+                    non_defaultable,
+                    initialized,
+                    diagnostics,
+                    saved,
+                );
+            }
+            _ => {
+                walk_node(
+                    &child,
+                    source,
+                    func,
+                    non_defaultable,
+                    initialized,
+                    diagnostics,
+                );
+            }
+        }
+    }
+}
+
+/// Check if a block node is actually a linear-format if (contains block_if child).
+fn is_block_if(node: &Node) -> bool {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        let ck = child.kind();
+        #[cfg(all(feature = "wasm", not(feature = "native")))]
+        let ck = &*ck;
+        if ck == "block_if" {
+            return true;
+        }
+    }
+    false
+}
+
+/// Check if an instr_plain is a local.get/set/tee and update initialization tracking.
+fn check_local_instruction(
+    node: &Node,
+    source: &str,
+    func: &Function,
+    non_defaultable: &HashSet<usize>,
+    initialized: &mut HashSet<usize>,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let text = &source[node.byte_range()];
+    let first_token = text.split_whitespace().next().unwrap_or("");
+
+    match first_token {
+        "local.get" => {
+            if let Some(idx) = resolve_local_index_from_node(node, source, func) {
+                if non_defaultable.contains(&idx) && !initialized.contains(&idx) {
+                    diagnostics.push(Diagnostic::error(
+                        node_to_range(node),
+                        "uninitialized local".to_string(),
+                    ));
+                }
+            }
+        }
+        "local.set" | "local.tee" => {
+            if let Some(idx) = resolve_local_index_from_node(node, source, func) {
+                initialized.insert(idx);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Resolve the local index referenced by a local.get/set/tee instruction node.
+fn resolve_local_index_from_node(node: &Node, source: &str, func: &Function) -> Option<usize> {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        let ck = child.kind();
+        #[cfg(all(feature = "wasm", not(feature = "native")))]
+        let ck = &*ck;
+
+        if ck == "index" || ck == "identifier" || ck == "nat" {
+            let text = source[child.byte_range()].trim();
+            if let Some(idx) = resolve_local_text(text, func) {
+                return Some(idx);
+            }
+            // Check inside index node for identifier/nat children
+            let mut ic = child.walk();
+            for idx_child in child.children(&mut ic) {
+                let ik = idx_child.kind();
+                #[cfg(all(feature = "wasm", not(feature = "native")))]
+                let ik = &*ik;
+                if ik == "identifier" || ik == "nat" {
+                    let id_text = source[idx_child.byte_range()].trim();
+                    if let Some(idx) = resolve_local_text(id_text, func) {
+                        return Some(idx);
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Resolve a text reference (name or numeric index) to an absolute local index.
+fn resolve_local_text(text: &str, func: &Function) -> Option<usize> {
+    if text.starts_with('$') {
+        for param in &func.parameters {
+            if param.name.as_deref() == Some(text) {
+                return Some(param.index);
+            }
+        }
+        for local in &func.locals {
+            if local.name.as_deref() == Some(text) {
+                return Some(func.parameters.len() + local.index);
+            }
+        }
+    } else if let Ok(idx) = text.parse::<usize>() {
+        return Some(idx);
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn get_diagnostics(source: &str) -> Vec<String> {
+        let mut parser = crate::tree_sitter_bindings::create_parser();
+        let tree = parser.parse(source, None).unwrap();
+        let symbols = crate::parser::parse_document(source).expect("Failed to extract symbols");
+        let root = tree.root_node();
+
+        let mut diagnostics = Vec::new();
+        collect_local_init_diags(root, source, &symbols, &mut diagnostics);
+        diagnostics.into_iter().map(|d| d.message).collect()
+    }
+
+    fn collect_local_init_diags(
+        node: tree_sitter::Node,
+        source: &str,
+        symbols: &SymbolTable,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) {
+        if node.kind() == "module_field_func" {
+            diagnostics.extend(check_uninitialized_locals(&node, source, symbols));
+        }
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            collect_local_init_diags(child, source, symbols, diagnostics);
+        }
+    }
+
+    #[test]
+    fn test_simple_uninit() {
+        let src = r#"(module
+            (type $t (func))
+            (func (local $x (ref $t)) (drop (local.get $x)))
+        )"#;
+        let diags = get_diagnostics(src);
+        assert!(
+            diags.iter().any(|d| d.contains("uninitialized local")),
+            "Expected uninitialized local error, got: {:?}",
+            diags
+        );
+    }
+
+    #[test]
+    fn test_init_before_get() {
+        let src = r#"(module
+            (type $t (func))
+            (func (param $p (ref $t)) (local $x (ref $t))
+                (local.set $x (local.get $p))
+                (drop (local.get $x))
+            )
+        )"#;
+        let diags = get_diagnostics(src);
+        assert!(diags.is_empty(), "Expected no errors, got: {:?}", diags);
+    }
+
+    #[test]
+    fn test_uninit_after_block() {
+        let src = r#"(module
+            (func (param $p (ref extern)) (local $x (ref extern))
+                (block (local.set $x (local.get $p)) (drop (local.tee $x (local.get $p))))
+                (drop (local.get $x))
+            )
+        )"#;
+        let diags = get_diagnostics(src);
+        assert!(
+            diags.iter().any(|d| d.contains("uninitialized local")),
+            "Expected uninitialized local error after block, got: {:?}",
+            diags
+        );
+    }
+
+    #[test]
+    fn test_uninit_in_else() {
+        let src = r#"(module
+            (func (param $p (ref extern)) (local $x (ref extern))
+                (if (i32.const 0)
+                    (then (local.set $x (local.get $p)))
+                    (else (drop (local.get $x)))
+                )
+            )
+        )"#;
+        let diags = get_diagnostics(src);
+        assert!(
+            diags.iter().any(|d| d.contains("uninitialized local")),
+            "Expected uninitialized local error in else, got: {:?}",
+            diags
+        );
+    }
+
+    #[test]
+    fn test_defaultable_local_ok() {
+        // Nullable ref types are defaultable — no error expected
+        let src = r#"(module
+            (func (local $x funcref) (drop (local.get $x)))
+        )"#;
+        let diags = get_diagnostics(src);
+        assert!(
+            diags.is_empty(),
+            "Expected no errors for funcref local, got: {:?}",
+            diags
+        );
+    }
+
+    #[test]
+    fn test_numeric_local_ok() {
+        let src = r#"(module
+            (func (local $x i32) (drop (local.get $x)))
+        )"#;
+        let diags = get_diagnostics(src);
+        assert!(
+            diags.is_empty(),
+            "Expected no errors for i32 local, got: {:?}",
+            diags
+        );
+    }
+
+    #[test]
+    fn test_param_always_init() {
+        let src = r#"(module
+            (type $t (func))
+            (func (param $p (ref $t)) (drop (local.get $p)))
+        )"#;
+        let diags = get_diagnostics(src);
+        assert!(
+            diags.is_empty(),
+            "Expected no errors for param, got: {:?}",
+            diags
+        );
+    }
+}

--- a/src/diagnostics_core/mod.rs
+++ b/src/diagnostics_core/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod alignment_checks;
 pub(crate) mod arity;
 pub(crate) mod folded_checks;
 pub(crate) mod gc_checks;
+pub(crate) mod local_init;
 pub(crate) mod memory_checks;
 pub(crate) mod module_checks;
 pub(crate) mod references;

--- a/src/diagnostics_core/module_checks.rs
+++ b/src/diagnostics_core/module_checks.rs
@@ -1117,6 +1117,7 @@ fn check_elem_segment_types(
 
         // Extract declared elem type from elem_list (e.g. funcref, externref)
         let mut elem_type: Option<ValueType> = None;
+        let mut elem_type_nullable = true; // nullable until proven otherwise
         let mut table_idx: Option<usize> = None;
         let mut has_offset = false;
 
@@ -1151,6 +1152,10 @@ fn check_elem_segment_types(
                     if ek == "ref_type" || ek == "value_type" {
                         let text = node_text(&ec_child, source);
                         elem_type = ValueType::try_parse(text.trim());
+                        // Check if the ref_type AST node is non-nullable
+                        if is_non_nullable_ref_type_node(&ec_child, source) {
+                            elem_type_nullable = false;
+                        }
                     }
                 }
             }
@@ -1158,17 +1163,29 @@ fn check_elem_segment_types(
             if ck == "ref_type" && elem_type.is_none() {
                 let text = node_text(&child, source);
                 elem_type = ValueType::try_parse(text.trim());
+                if is_non_nullable_ref_type_node(&child, source) {
+                    elem_type_nullable = false;
+                }
             }
         }
 
-        // Old-style elem segments without explicit type default to funcref
+        // Old-style elem segments without explicit type:
+        // "func" keyword or bare indices = non-nullable func references
         let elem_type = elem_type.unwrap_or(ValueType::Funcref);
+        if elem_type == ValueType::Funcref && !has_explicit_nullable_type(field, source) {
+            elem_type_nullable = false;
+        }
 
         // Check 1: elem type vs target table type (for active segments)
         if has_offset {
             let tbl_idx = table_idx.unwrap_or(0);
             if let Some(table) = symbols.tables.get(tbl_idx) {
-                if !elem_ref_compatible(&elem_type, &table.ref_type) {
+                if !elem_ref_compatible(
+                    &elem_type,
+                    &table.ref_type,
+                    table.ref_type_non_nullable,
+                    elem_type_nullable,
+                ) {
                     diagnostics.push(
                         Diagnostic::error(node_to_range(field), "type mismatch")
                             .with_code("type-mismatch"),
@@ -1189,9 +1206,89 @@ fn check_elem_segment_types(
     });
 }
 
+/// Check if an elem segment has an explicitly nullable type keyword (`funcref` or `externref`).
+/// Returns false for old-style segments (bare indices, `func` keyword), `(ref func)`, etc.
+fn has_explicit_nullable_type(elem_node: &Node, source: &str) -> bool {
+    let mut cursor = elem_node.walk();
+    for child in elem_node.children(&mut cursor) {
+        node_kind!(ck = child);
+        if ck == "elem_list" || ck == "ref_type" || ck == "value_type" {
+            let text = node_text(&child, source).trim().to_string();
+            if text == "funcref" || text == "externref" {
+                return true;
+            }
+            // Check for nested ref_type children
+            let mut ec = child.walk();
+            for gc in child.children(&mut ec) {
+                node_kind!(gk = gc);
+                if gk == "ref_type" || gk == "ref_type_funcref" || gk == "ref_type_externref" {
+                    let gtext = node_text(&gc, source).trim().to_string();
+                    if gtext == "funcref" || gtext == "externref" {
+                        return true;
+                    }
+                }
+            }
+        }
+    }
+    false
+}
+
+/// Check if a ref_type AST node is a non-nullable reference type.
+fn is_non_nullable_ref_type_node(node: &Node, source: &str) -> bool {
+    node_kind!(kind = node);
+    match kind {
+        "ref_type_ref" | "ref_type_concrete" => {
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                if &source[child.byte_range()] == "null" {
+                    return false;
+                }
+            }
+            true
+        }
+        "ref_type_funcref" | "ref_type_externref" => false,
+        _ => {
+            let text = source[node.byte_range()].trim();
+            if matches!(
+                text,
+                "funcref"
+                    | "externref"
+                    | "anyref"
+                    | "eqref"
+                    | "i31ref"
+                    | "structref"
+                    | "arrayref"
+                    | "nullref"
+                    | "nullfuncref"
+                    | "nullexternref"
+            ) {
+                return false;
+            }
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                if is_non_nullable_ref_type_node(&child, source) {
+                    return true;
+                }
+            }
+            false
+        }
+    }
+}
+
 /// Check if elem ref type is compatible with table element type.
-fn elem_ref_compatible(elem_type: &ValueType, table_type: &ValueType) -> bool {
+fn elem_ref_compatible(
+    elem_type: &ValueType,
+    table_type: &ValueType,
+    table_non_nullable: bool,
+    elem_nullable: bool,
+) -> bool {
     use ValueType::*;
+
+    // If the table type is non-nullable, nullable elem types are incompatible
+    if table_non_nullable && elem_nullable {
+        return false;
+    }
+
     if elem_type == table_type {
         return true;
     }

--- a/src/diagnostics_core/tree_walk.rs
+++ b/src/diagnostics_core/tree_walk.rs
@@ -108,6 +108,15 @@ pub fn walk_tree_for_diagnostics(
             ));
         }
 
+        // Check for uninitialized non-nullable ref locals
+        if !has_inline_import(&node) {
+            diagnostics.extend(
+                crate::diagnostics_core::local_init::check_uninitialized_locals(
+                    &node, source, symbols,
+                ),
+            );
+        }
+
         // Check for unused locals and parameters
         if !has_inline_import(&node) {
             check_unused_locals(&node, source, symbols, diagnostics);

--- a/src/features/symbols/mod.rs
+++ b/src/features/symbols/mod.rs
@@ -184,6 +184,8 @@ pub struct Table {
     pub name: Option<String>,
     pub index: usize,
     pub ref_type: ValueType,
+    /// Whether the table's element type is non-nullable (e.g. `(ref func)` vs `funcref`).
+    pub ref_type_non_nullable: bool,
     pub limits: (u64, Option<u64>),
     pub is_table64: bool,
     pub line: u32,

--- a/src/features/symbols/tests.rs
+++ b/src/features/symbols/tests.rs
@@ -71,6 +71,7 @@ fn test_add_table() {
         name: Some("$funcs".to_string()),
         index: 0,
         ref_type: ValueType::Funcref,
+        ref_type_non_nullable: false,
         limits: (10, Some(100)),
         is_table64: false,
         line: 0,

--- a/src/features/test_utils.rs
+++ b/src/features/test_utils.rs
@@ -88,6 +88,7 @@ pub fn create_test_symbols() -> SymbolTable {
         name: Some("$funcs".to_string()),
         index: 0,
         ref_type: ValueType::Funcref,
+        ref_type_non_nullable: false,
         limits: (10, None),
         is_table64: false,
         line: 0,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -407,6 +407,7 @@ fn extract_imported_table(desc_node: &Node, source: &str, index: usize) -> Optio
     let (name, name_range) = extract_identifier_info(desc_node, source);
 
     let mut ref_type = ValueType::Funcref;
+    let mut ref_type_non_nullable = false;
     let mut min_limit: u64 = 0;
     let mut max_limit: Option<u64> = None;
     let mut is_table64 = false;
@@ -434,6 +435,7 @@ fn extract_imported_table(desc_node: &Node, source: &str, index: usize) -> Optio
                     }
                 } else if type_child.kind() == "ref_type" {
                     ref_type = extract_ref_type(&type_child, source);
+                    ref_type_non_nullable = is_ref_type_non_nullable(&type_child, source);
                 } else if type_child.kind() == "table64_type" {
                     is_table64 = true;
                 }
@@ -445,6 +447,7 @@ fn extract_imported_table(desc_node: &Node, source: &str, index: usize) -> Optio
         name,
         index,
         ref_type,
+        ref_type_non_nullable,
         limits: (min_limit, max_limit),
         is_table64,
         line: desc_node.range().start_point.row as u32,
@@ -1753,6 +1756,7 @@ fn extract_table(table_node: &Node, source: &str, index: usize) -> Option<Table>
     let (name, name_range) = extract_identifier_info(table_node, source);
 
     let mut ref_type = ValueType::Funcref;
+    let mut ref_type_non_nullable = false;
     let mut min_limit: u64 = 0;
     let mut max_limit: Option<u64> = None;
     let mut is_table64 = false;
@@ -1783,8 +1787,8 @@ fn extract_table(table_node: &Node, source: &str, index: usize) -> Option<Table>
                                 }
                             }
                         } else if type_child.kind() == "ref_type" {
-                            // Extract ref type from nested structure
                             ref_type = extract_ref_type(&type_child, source);
+                            ref_type_non_nullable = is_ref_type_non_nullable(&type_child, source);
                         } else if type_child.kind() == "table64_type" {
                             is_table64 = true;
                         }
@@ -1813,6 +1817,7 @@ fn extract_table(table_node: &Node, source: &str, index: usize) -> Option<Table>
                     }
                 } else if type_child.kind() == "ref_type" {
                     ref_type = extract_ref_type(&type_child, source);
+                    ref_type_non_nullable = is_ref_type_non_nullable(&type_child, source);
                 } else if type_child.kind() == "table64_type" {
                     is_table64 = true;
                 }
@@ -1824,6 +1829,7 @@ fn extract_table(table_node: &Node, source: &str, index: usize) -> Option<Table>
         name,
         index,
         ref_type,
+        ref_type_non_nullable,
         limits: (min_limit, max_limit),
         is_table64,
         line: table_node.range().start_point.row as u32,
@@ -2165,6 +2171,50 @@ fn extract_storage_type_with_mut(storage_node: &Node, source: &str) -> (ValueTyp
 #[inline]
 fn simple_type_from_str(s: &str) -> Option<ValueType> {
     ValueType::try_parse(s)
+}
+
+/// Check if a ref_type AST node represents a non-nullable reference type.
+/// Returns true for `(ref func)`, `(ref $t)`, etc. (without `null`).
+/// Returns false for `funcref`, `externref`, `(ref null func)`, etc.
+fn is_ref_type_non_nullable(node: &Node, source: &str) -> bool {
+    node_kind!(kind = node);
+    match kind {
+        "ref_type_ref" | "ref_type_concrete" => {
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                if &source[child.byte_range()] == "null" {
+                    return false;
+                }
+            }
+            true
+        }
+        "ref_type_funcref" | "ref_type_externref" => false,
+        _ => {
+            let text = source[node.byte_range()].trim();
+            if matches!(
+                text,
+                "funcref"
+                    | "externref"
+                    | "anyref"
+                    | "eqref"
+                    | "i31ref"
+                    | "structref"
+                    | "arrayref"
+                    | "nullref"
+                    | "nullfuncref"
+                    | "nullexternref"
+            ) {
+                return false;
+            }
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                if is_ref_type_non_nullable(&child, source) {
+                    return true;
+                }
+            }
+            false
+        }
+    }
 }
 
 /// Extract reference type from a ref_type node (handles nested structure)


### PR DESCRIPTION
## Summary

- Add `local_init.rs`: detect uses of uninitialized locals with non-defaultable types (non-nullable ref types like `ref $t`, `ref func`, `ref extern`)
- Track initialization state through control flow (block/loop revert, if/else intersection)
- Add `ref_type_non_nullable` field to Table struct for elem type nullability validation
- Validate elem segment reference types are compatible with table nullability constraints