### PR TITLE
feat: memory64/table64 address types, GC subtype variance, SIMD type signatures, and misc spec compliance

### DIFF
--- a/grammars/tree-sitter-wat/grammar.js
+++ b/grammars/tree-sitter-wat/grammar.js
@@ -745,7 +745,7 @@ module.exports = grammar({
         optional($.share),
       ),
 
-    memory_fields_data: $ => seq("(", "data", repeat($.string), ")"),
+    memory_fields_data: $ => seq(optional($.memory64_type), "(", "data", repeat($.string), ")"),
 
     memory_fields_type: $ => seq(optional($.import), $.memory_type),
 
@@ -975,7 +975,7 @@ module.exports = grammar({
 
     array_type: $ => seq("(", "array", $.storage_type, ")"),
 
-    field_type: $ => seq("(", "field", optional(field("identifier", $.identifier)), repeat1($.storage_type), ")"),
+    field_type: $ => seq("(", "field", optional(field("identifier", $.identifier)), repeat($.storage_type), ")"),
 
     // Packed types (i8/i16) are only valid as storage types in struct/array fields
     packed_type: $ => choice("i8", "i16"),

--- a/src/diagnostics_core/alignment_checks.rs
+++ b/src/diagnostics_core/alignment_checks.rs
@@ -4,6 +4,7 @@
 //! and that alignment values are powers of 2.
 
 use crate::core::types::Diagnostic;
+use crate::symbols::SymbolTable;
 use crate::utils::node_to_range;
 
 #[cfg(feature = "native")]
@@ -17,7 +18,8 @@ use crate::ts_facade::Node;
 /// Returns diagnostics if:
 /// - `align=N` where N is not a power of 2
 /// - `align=N` where N exceeds the instruction's natural alignment
-pub fn check_alignment(node: &Node, source: &str) -> Vec<Diagnostic> {
+/// - `offset=N` where N exceeds u32::MAX for memory32 targets
+pub fn check_alignment(node: &Node, source: &str, symbols: &SymbolTable) -> Vec<Diagnostic> {
     let mut diagnostics = Vec::new();
     let mut instr_name = None;
     let mut align_node = None;
@@ -47,14 +49,17 @@ pub fn check_alignment(node: &Node, source: &str) -> Vec<Diagnostic> {
         }
     }
 
-    // Check offset range (must fit in u32 for memory32)
-    if let Some(ref offset_nd) = offset_node {
-        if let Some(offset) = parse_offset_value(offset_nd, source) {
-            if offset > u32::MAX as u64 {
-                diagnostics.push(Diagnostic::error(
-                    node_to_range(offset_nd),
-                    "offset out of range".to_string(),
-                ));
+    // Check offset range (must fit in u32 for memory32, u64 for memory64)
+    let is_memory64 = symbols.memories.first().is_some_and(|m| m.is_memory64);
+    if !is_memory64 {
+        if let Some(ref offset_nd) = offset_node {
+            if let Some(offset) = parse_offset_value(offset_nd, source) {
+                if offset > u32::MAX as u64 {
+                    diagnostics.push(Diagnostic::error(
+                        node_to_range(offset_nd),
+                        "offset out of range".to_string(),
+                    ));
+                }
             }
         }
     }

--- a/src/diagnostics_core/module_checks.rs
+++ b/src/diagnostics_core/module_checks.rs
@@ -453,6 +453,7 @@ fn check_duplicate_identifiers(module: &Node, source: &str, diagnostics: &mut Ve
             }
             "module_field_tag" => {
                 check_identifier_dup(field, source, &mut seen_tag, "tag", diagnostics);
+                check_tag_no_results(field, source, diagnostics);
             }
             "module_field_rec" => {
                 // Types inside rec groups share the type index space
@@ -542,12 +543,36 @@ fn check_import_identifier_dup(
                     }
                     "import_desc_tag_type" => {
                         check_identifier_dup(&desc, source, seen_tag, "tag", diagnostics);
+                        check_tag_no_results(&desc, source, diagnostics);
                     }
                     _ => {}
                 }
             }
         }
     }
+}
+
+/// Check that a tag (or imported tag) has no result types.
+fn check_tag_no_results(node: &Node, _source: &str, diagnostics: &mut Vec<Diagnostic>) {
+    // Recursively search for func_type_results nodes
+    fn has_results(node: &Node, diagnostics: &mut Vec<Diagnostic>) -> bool {
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            node_kind!(ck = child);
+            if ck == "func_type_results" {
+                diagnostics.push(Diagnostic::error(
+                    node_to_range(&child),
+                    "non-empty tag result type".to_string(),
+                ));
+                return true;
+            }
+            if has_results(&child, diagnostics) {
+                return true;
+            }
+        }
+        false
+    }
+    has_results(node, diagnostics);
 }
 
 // ============================================================================
@@ -2734,6 +2759,53 @@ fn check_const_expr_type_for_global(
     }
 }
 
+/// Resolve the expected offset type for a data segment's target memory.
+/// Checks for `memory_use` child (explicit memory ref) or defaults to memory 0.
+fn resolve_data_offset_type(node: &Node, source: &str, symbols: &SymbolTable) -> ValueType {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        node_kind!(ck = child);
+        if ck == "memory_use" {
+            // Explicit (memory $idx) — resolve against symbol table
+            let mut inner = child.walk();
+            for gc in child.children(&mut inner) {
+                node_kind!(gk = gc);
+                if gk == "index" || gk == "identifier" {
+                    let idx_text = node_text(&gc, source);
+                    if let Some(mem) = symbols.get_memory_by_name(idx_text) {
+                        return if mem.is_memory64 {
+                            ValueType::I64
+                        } else {
+                            ValueType::I32
+                        };
+                    }
+                    if let Some(n) = crate::parser::parse_wat_nat(idx_text) {
+                        if let Some(mem) = symbols.memories.get(n as usize) {
+                            return if mem.is_memory64 {
+                                ValueType::I64
+                            } else {
+                                ValueType::I32
+                            };
+                        }
+                    }
+                }
+            }
+        }
+    }
+    // Default to memory 0
+    symbols
+        .memories
+        .first()
+        .map(|m| {
+            if m.is_memory64 {
+                ValueType::I64
+            } else {
+                ValueType::I32
+            }
+        })
+        .unwrap_or(ValueType::I32)
+}
+
 /// Check data segment offset expression type.
 fn check_data_offset_type(
     node: &Node,
@@ -2741,13 +2813,12 @@ fn check_data_offset_type(
     symbols: &SymbolTable,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
+    let expected = resolve_data_offset_type(node, source, symbols);
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         node_kind!(ck = child);
         if ck == "offset" {
             let (count, ty) = count_const_instrs_deep(&child, source, symbols);
-            // Expected: i32 for memory32, i64 for memory64
-            let expected = ValueType::I32; // default to i32
             if count != 1 {
                 diagnostics.push(
                     Diagnostic::error(node_to_range(node), "type mismatch")
@@ -2765,6 +2836,52 @@ fn check_data_offset_type(
     }
 }
 
+/// Resolve the expected offset type for an elem segment's target table.
+/// Checks for `table_use` child (explicit table ref) or defaults to table 0.
+fn resolve_elem_offset_type(node: &Node, source: &str, symbols: &SymbolTable) -> ValueType {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        node_kind!(ck = child);
+        if ck == "table_use" {
+            let mut inner = child.walk();
+            for gc in child.children(&mut inner) {
+                node_kind!(gk = gc);
+                if gk == "index" || gk == "identifier" {
+                    let idx_text = node_text(&gc, source);
+                    if let Some(table) = symbols.get_table_by_name(idx_text) {
+                        return if table.is_table64 {
+                            ValueType::I64
+                        } else {
+                            ValueType::I32
+                        };
+                    }
+                    if let Some(n) = crate::parser::parse_wat_nat(idx_text) {
+                        if let Some(table) = symbols.tables.get(n as usize) {
+                            return if table.is_table64 {
+                                ValueType::I64
+                            } else {
+                                ValueType::I32
+                            };
+                        }
+                    }
+                }
+            }
+        }
+    }
+    // Default to table 0
+    symbols
+        .tables
+        .first()
+        .map(|t| {
+            if t.is_table64 {
+                ValueType::I64
+            } else {
+                ValueType::I32
+            }
+        })
+        .unwrap_or(ValueType::I32)
+}
+
 /// Check elem segment offset expression type.
 fn check_elem_offset_type(
     node: &Node,
@@ -2772,12 +2889,12 @@ fn check_elem_offset_type(
     symbols: &SymbolTable,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
+    let expected = resolve_elem_offset_type(node, source, symbols);
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         node_kind!(ck = child);
         if ck == "offset" {
             let (count, ty) = count_const_instrs_deep(&child, source, symbols);
-            let expected = ValueType::I32;
             if count != 1 {
                 diagnostics.push(
                     Diagnostic::error(node_to_range(node), "type mismatch")

--- a/src/diagnostics_core/references.rs
+++ b/src/diagnostics_core/references.rs
@@ -296,16 +296,17 @@ pub fn check_references(
         return find_first_index_identifier(node, source, symbols, context);
     }
 
-    // Multi-index instructions: table.init takes (elem_idx, table_idx),
-    // memory.init takes (data_idx, memory_idx). The context from
-    // determine_instruction_context_at_node applies only to the first index.
+    // Multi-index instructions: table.init / memory.init
+    // WAT text format: (table.init $table $elem) or (table.init $elem) — abbreviated
+    // With 1 index: it's elem/data (table/memory defaults to 0)
+    // With 2 indices: first is table/memory, second is elem/data
     if first_token == "table.init" || first_token == "memory.init" {
-        let second_context = if first_token == "table.init" {
+        let secondary = if first_token == "table.init" {
             InstructionContext::Table
         } else {
             InstructionContext::Memory
         };
-        return check_multi_index_instruction(node, source, symbols, context, &second_context);
+        return check_init_instruction(node, source, symbols, context, &secondary);
     }
 
     // memory.copy and table.copy take two indices of the same context (dest, src)
@@ -313,11 +314,73 @@ pub fn check_references(
         return check_multi_index_instruction(node, source, symbols, context, context);
     }
 
+    // array.new_data / array.init_data: first index is Type, second is Data
+    if first_token == "array.new_data" || first_token == "array.init_data" {
+        return check_multi_index_instruction(
+            node,
+            source,
+            symbols,
+            &InstructionContext::Type,
+            &InstructionContext::Data,
+        );
+    }
+
+    // array.new_elem / array.init_elem: first index is Type, second is Elem
+    if first_token == "array.new_elem" || first_token == "array.init_elem" {
+        return check_multi_index_instruction(
+            node,
+            source,
+            symbols,
+            &InstructionContext::Type,
+            &InstructionContext::Elem,
+        );
+    }
+
+    // br_on_cast / br_on_cast_fail: first index is Branch, rest are heap types (not validated)
+    if first_token == "br_on_cast" || first_token == "br_on_cast_fail" {
+        return check_first_index_reference(node, source, symbols, &InstructionContext::Branch);
+    }
+
     find_undefined_identifiers(node, source, symbols, context)
 }
 
+/// Check table.init / memory.init where the index order depends on count:
+/// - 1 index: elem/data (table/memory defaults to 0)
+/// - 2 indices: first is table/memory, second is elem/data
+fn check_init_instruction(
+    node: &Node,
+    source: &str,
+    symbols: &SymbolTable,
+    primary_context: &InstructionContext,   // Elem or Data
+    secondary_context: &InstructionContext, // Table or Memory
+) -> Vec<Diagnostic> {
+    // Count indices first
+    let mut total_indices = 0usize;
+    find_indices_recursive(node, &mut |_| {
+        total_indices += 1;
+    });
+
+    let mut diagnostics = Vec::new();
+    let mut index_count = 0usize;
+    find_indices_recursive(node, &mut |index_node| {
+        let ctx = if total_indices == 1 {
+            // Abbreviated: single index is primary (elem/data)
+            primary_context
+        } else if index_count == 0 {
+            // Full form: first is secondary (table/memory)
+            secondary_context
+        } else {
+            // Full form: second is primary (elem/data)
+            primary_context
+        };
+        diagnostics.extend(find_undefined_identifiers(index_node, source, symbols, ctx));
+        index_count += 1;
+    });
+
+    diagnostics
+}
+
 /// Check a multi-index instruction where the first and second index have different contexts.
-/// E.g. `table.init $elem $table` or `memory.init $data $memory`.
 fn check_multi_index_instruction(
     node: &Node,
     source: &str,

--- a/src/diagnostics_core/semantic.rs
+++ b/src/diagnostics_core/semantic.rs
@@ -16,7 +16,7 @@ use crate::core::types::Diagnostic;
 use crate::instruction_metadata::{
     infer_simd_instruction_arity, is_terminating_instruction, lookup_instruction_arity, OperandMode,
 };
-use crate::symbols::{SymbolTable, Table, TypeDef, TypeKind, ValueType};
+use crate::symbols::{Memory, SymbolTable, Table, TypeDef, TypeKind, ValueType};
 use crate::utils::node_to_range;
 
 use super::sequence_always_terminates;
@@ -50,6 +50,112 @@ fn type_from_prefix(name: &str) -> Option<ValueType> {
 /// Check if an instruction name refers to a SIMD lane operation (contains x2./x4./x8./x16.).
 fn is_simd_instruction(name: &str) -> bool {
     name.contains("x2.") || name.contains("x4.") || name.contains("x8.") || name.contains("x16.")
+}
+
+/// Derive the splat input type from an instruction prefix (e.g. "i8x16" -> I32, "f32x4" -> F32).
+fn simd_splat_input_type(name: &str) -> ValueType {
+    if name.starts_with("i8x16.") || name.starts_with("i16x8.") || name.starts_with("i32x4.") {
+        ValueType::I32
+    } else if name.starts_with("i64x2.") {
+        ValueType::I64
+    } else if name.starts_with("f32x4.") {
+        ValueType::F32
+    } else if name.starts_with("f64x2.") {
+        ValueType::F64
+    } else {
+        ValueType::I32
+    }
+}
+
+/// Derive consumed types for SIMD lane instructions (i8x16.*, i16x8.*, i32x4.*, i64x2.*, f32x4.*, f64x2.*).
+fn derive_simd_consumed_types(name: &str) -> Option<Vec<ValueType>> {
+    // Splat: scalar -> v128
+    if name.ends_with(".splat") {
+        return Some(vec![simd_splat_input_type(name)]);
+    }
+
+    // Extract lane: v128 -> scalar (lane index is immediate, not stack operand)
+    if name.contains(".extract_lane") {
+        return Some(vec![ValueType::V128]);
+    }
+
+    // Replace lane: v128 + scalar -> v128
+    if name.contains(".replace_lane") {
+        return Some(vec![ValueType::V128, simd_splat_input_type(name)]);
+    }
+
+    // Reductions: v128 -> i32
+    if name.ends_with(".all_true") || name.ends_with(".bitmask") {
+        return Some(vec![ValueType::V128]);
+    }
+
+    // Shift operations: v128 + i32 -> v128
+    if name.ends_with(".shl") || name.ends_with(".shr_s") || name.ends_with(".shr_u") {
+        return Some(vec![ValueType::V128, ValueType::I32]);
+    }
+
+    // Unary ops: v128 -> v128
+    if name.ends_with(".neg")
+        || name.ends_with(".abs")
+        || name.ends_with(".not")
+        || name.ends_with(".popcnt")
+        || name.ends_with(".ceil")
+        || name.ends_with(".floor")
+        || name.ends_with(".trunc")
+        || name.ends_with(".nearest")
+        || name.ends_with(".sqrt")
+        || name.contains(".trunc_sat_")
+        || name.contains(".extend_low_")
+        || name.contains(".extend_high_")
+        || name.contains(".convert_")
+        || name.contains(".promote_low_")
+        || name.contains(".demote_")
+        || name.contains(".extadd_pairwise_")
+    {
+        return Some(vec![ValueType::V128]);
+    }
+
+    // Ternary relaxed SIMD ops: (v128, v128, v128) -> v128
+    if name.contains(".relaxed_madd")
+        || name.contains(".relaxed_nmadd")
+        || name.contains(".relaxed_laneselect")
+        || name.contains(".relaxed_dot_i8x16_i7x16_add")
+    {
+        return Some(vec![ValueType::V128, ValueType::V128, ValueType::V128]);
+    }
+
+    // Unary relaxed SIMD ops
+    if name.contains(".relaxed_trunc") {
+        return Some(vec![ValueType::V128]);
+    }
+
+    // i8x16.shuffle: (v128, v128) -> v128 (lane indices are immediates)
+    if name == "i8x16.shuffle" {
+        return Some(vec![ValueType::V128, ValueType::V128]);
+    }
+
+    // Narrow operations: (v128, v128) -> v128
+    if name.contains(".narrow_") {
+        return Some(vec![ValueType::V128, ValueType::V128]);
+    }
+
+    // Swizzle: (v128, v128) -> v128
+    if name.ends_with(".swizzle") || name.contains(".relaxed_swizzle") {
+        return Some(vec![ValueType::V128, ValueType::V128]);
+    }
+
+    // Dot product: (v128, v128) -> v128
+    if name.contains(".dot_") {
+        return Some(vec![ValueType::V128, ValueType::V128]);
+    }
+
+    // Extmul: (v128, v128) -> v128
+    if name.contains(".extmul_") {
+        return Some(vec![ValueType::V128, ValueType::V128]);
+    }
+
+    // Default: binary ops (v128, v128) -> v128 (add, sub, mul, min, max, eq, ne, lt, gt, le, ge, etc.)
+    Some(vec![ValueType::V128, ValueType::V128])
 }
 
 /// Track stack state through an instruction list and report underflow/type errors.
@@ -697,6 +803,16 @@ fn process_instruction(
         }
     }
 
+    // Check table.init/table.copy type compatibility
+    if instr_name == "table.init" {
+        check_table_init_types(node, symbols, source, checker);
+    } else if instr_name == "table.copy" {
+        check_table_copy_types(node, symbols, source, checker);
+    }
+
+    // Check immutable array for array mutation instructions
+    check_immutable_array(instr_name, node, symbols, source, checker);
+
     let produced = infer_instruction_result_types(instr_name, node, symbols, source);
     // If we know the instruction produces N values but couldn't infer types, pad with Unknown
     let produces_count = get_instruction_produces_count(instr_name);
@@ -899,27 +1015,51 @@ fn derive_consumed_types_from_name(
         "f32.reinterpret_i32" => Some(vec![ValueType::I32]),
         "f64.reinterpret_i64" => Some(vec![ValueType::I64]),
 
-        // SIMD lane load/store — consume address (i32) + v128 vector
+        // ---- SIMD instruction type signatures ----
+        // v128 bitwise: (v128, v128) -> v128
+        "v128.and" | "v128.or" | "v128.xor" | "v128.andnot" => {
+            Some(vec![ValueType::V128, ValueType::V128])
+        }
+        // v128 bitselect: (v128, v128, v128) -> v128
+        "v128.bitselect" => Some(vec![ValueType::V128, ValueType::V128, ValueType::V128]),
+        // v128 not: (v128) -> v128
+        "v128.not" => Some(vec![ValueType::V128]),
+        // v128.any_true: (v128) -> i32
+        "v128.any_true" => Some(vec![ValueType::V128]),
+
+        // SIMD lane instructions
+        name if is_simd_instruction(name) => derive_simd_consumed_types(name),
+
+        // SIMD lane load/store — consume address + v128 vector
         name if name.contains("_lane") && name.starts_with("v128.load") => {
-            Some(vec![ValueType::I32, ValueType::V128])
+            let addr_type = get_memory_address_type(node, symbols, source);
+            Some(vec![addr_type, ValueType::V128])
         }
         name if name.contains("_lane") && name.starts_with("v128.store") => {
-            Some(vec![ValueType::I32, ValueType::V128])
+            let addr_type = get_memory_address_type(node, symbols, source);
+            Some(vec![addr_type, ValueType::V128])
         }
 
-        // Memory load — consume address (i32 for memory32)
-        name if name.contains(".load") => Some(vec![ValueType::I32]),
+        // Memory load — consume address (i32 for memory32, i64 for memory64)
+        name if name.contains(".load") => {
+            let addr_type = get_memory_address_type(node, symbols, source);
+            Some(vec![addr_type])
+        }
 
         // Memory store — consume address + value
         name if name.contains(".store") => {
+            let addr_type = get_memory_address_type(node, symbols, source);
             let value_type = type_from_prefix(name).unwrap_or(ValueType::Unknown);
-            Some(vec![ValueType::I32, value_type])
+            Some(vec![addr_type, value_type])
         }
 
         // Memory size — no operands
         "memory.size" => Some(vec![]),
-        // Memory grow — consume delta (i32)
-        "memory.grow" => Some(vec![ValueType::I32]),
+        // Memory grow — consume delta (i32 for memory32, i64 for memory64)
+        "memory.grow" => {
+            let addr_type = get_memory_address_type(node, symbols, source);
+            Some(vec![addr_type])
+        }
 
         // Reference instructions
         "ref.null" => Some(vec![]),
@@ -973,12 +1113,33 @@ fn derive_consumed_types_from_name(
         "br_on_cast" | "br_on_cast_fail" => Some(vec![ValueType::Unknown]),
 
         // Exceptions
+        "throw" => {
+            // throw $tag: consumes tag's param types
+            if let Some(tag_ref) = get_index_from_node(node, source) {
+                let tag = symbols
+                    .get_tag_by_name(tag_ref)
+                    .or_else(|| parse_wat_nat(tag_ref).and_then(|i| symbols.tags.get(i as usize)));
+                if let Some(tag) = tag {
+                    return Some(tag.params.clone());
+                }
+            }
+            Some(vec![])
+        }
         "throw_ref" => Some(vec![ValueType::Unknown]), // exnref
 
-        // Bulk memory
-        "memory.copy" => Some(vec![ValueType::I32, ValueType::I32, ValueType::I32]),
-        "memory.fill" => Some(vec![ValueType::I32, ValueType::I32, ValueType::I32]),
-        "memory.init" => Some(vec![ValueType::I32, ValueType::I32, ValueType::I32]),
+        // Bulk memory — addresses are i32/i64 depending on memory type
+        "memory.copy" => {
+            let addr_type = get_memory_address_type(node, symbols, source);
+            Some(vec![addr_type, addr_type, addr_type])
+        }
+        "memory.fill" => {
+            let addr_type = get_memory_address_type(node, symbols, source);
+            Some(vec![addr_type, ValueType::I32, addr_type])
+        }
+        "memory.init" => {
+            let addr_type = get_memory_address_type(node, symbols, source);
+            Some(vec![addr_type, ValueType::I32, ValueType::I32])
+        }
         "data.drop" | "elem.drop" => Some(vec![]),
 
         // Table operations — resolve element type and index type from symbol table
@@ -1002,16 +1163,31 @@ fn derive_consumed_types_from_name(
             let elem_type = get_table_elem_type(node, symbols, source);
             Some(vec![idx_type, elem_type, idx_type])
         }
-        "table.copy" => Some(vec![
-            ValueType::Unknown,
-            ValueType::Unknown,
-            ValueType::Unknown,
-        ]),
-        "table.init" => Some(vec![
-            ValueType::Unknown,
-            ValueType::Unknown,
-            ValueType::Unknown,
-        ]),
+        "table.copy" => {
+            // table.copy $dst $src: (d:dst_addr, s:src_addr, n:min(dst_addr, src_addr))
+            let (dst_type, src_type) = resolve_table_copy_addr_types(node, symbols, source);
+            // n uses i32 unless both tables are i64
+            let n_type = if dst_type == ValueType::I64 && src_type == ValueType::I64 {
+                ValueType::I64
+            } else {
+                ValueType::I32
+            };
+            Some(vec![dst_type, src_type, n_type])
+        }
+        "table.init" => {
+            // table.init $table $elem: (d:table_addr, s:i32, n:i32)
+            let table = resolve_table_for_table_init(node, symbols, source);
+            let addr_type = table
+                .map(|t| {
+                    if t.is_table64 {
+                        ValueType::I64
+                    } else {
+                        ValueType::I32
+                    }
+                })
+                .unwrap_or(ValueType::I32);
+            Some(vec![addr_type, ValueType::I32, ValueType::I32])
+        }
 
         // Atomic fence — no operands
         "atomic.fence" => Some(vec![]),
@@ -1422,7 +1598,9 @@ fn infer_instruction_result_types(
         }
         name if name.contains(".store") => vec![],
 
-        "memory.size" | "memory.grow" => vec![ValueType::I32],
+        "memory.size" | "memory.grow" => {
+            vec![get_memory_address_type(node, symbols, source)]
+        }
 
         "local.get" | "local.tee" => get_local_type_from_node(node, symbols, source)
             .map(|t| vec![t])
@@ -1566,6 +1744,35 @@ fn get_table_index_type(node: &Node, symbols: &SymbolTable, source: &str) -> Val
     resolve_table(node, symbols, source)
         .map(|t| {
             if t.is_table64 {
+                ValueType::I64
+            } else {
+                ValueType::I32
+            }
+        })
+        .unwrap_or(ValueType::I32)
+}
+
+/// Resolve the memory referenced by a memory instruction node.
+/// Checks for a memory index/identifier in the instruction, falls back to memory 0.
+fn resolve_memory<'a>(node: &Node, symbols: &'a SymbolTable, source: &str) -> Option<&'a Memory> {
+    if let Some(index) = get_index_from_node(node, source) {
+        if let Some(mem) = symbols.get_memory_by_name(index) {
+            return Some(mem);
+        }
+        if let Some(idx) = parse_wat_nat(index) {
+            if let Some(mem) = symbols.memories.get(idx as usize) {
+                return Some(mem);
+            }
+        }
+    }
+    symbols.memories.first()
+}
+
+/// Get the address type for memory operations (i32 for memory32, i64 for memory64)
+fn get_memory_address_type(node: &Node, symbols: &SymbolTable, source: &str) -> ValueType {
+    resolve_memory(node, symbols, source)
+        .map(|m| {
+            if m.is_memory64 {
                 ValueType::I64
             } else {
                 ValueType::I32
@@ -2715,4 +2922,204 @@ fn validate_tail_call_return_types(
     }
 
     None
+}
+
+/// Resolve elem segment from an instruction's indices.
+/// For table.init with 1 index: it's the elem idx. With 2 indices: second is elem idx.
+fn resolve_elem_for_table_init<'a>(
+    node: &Node,
+    symbols: &'a SymbolTable,
+    source: &str,
+) -> Option<&'a crate::symbols::ElemSegment> {
+    let mut indices = Vec::new();
+    collect_instruction_indices(node, source, &mut indices);
+
+    let elem_ref = if indices.len() == 1 {
+        indices[0]
+    } else if indices.len() >= 2 {
+        indices[1]
+    } else {
+        return symbols.elem_segments.first();
+    };
+
+    if let Some(elem) = symbols.get_elem_by_name(elem_ref) {
+        return Some(elem);
+    }
+    if let Some(idx) = parse_wat_nat(elem_ref) {
+        return symbols.elem_segments.get(idx as usize);
+    }
+    None
+}
+
+/// Resolve table from table.init's indices.
+/// With 1 index: table defaults to 0. With 2 indices: first is table idx.
+fn resolve_table_for_table_init<'a>(
+    node: &Node,
+    symbols: &'a SymbolTable,
+    source: &str,
+) -> Option<&'a Table> {
+    let mut indices = Vec::new();
+    collect_instruction_indices(node, source, &mut indices);
+
+    if indices.len() >= 2 {
+        let table_ref = indices[0];
+        if let Some(table) = symbols.get_table_by_name(table_ref) {
+            return Some(table);
+        }
+        if let Some(idx) = parse_wat_nat(table_ref) {
+            return symbols.tables.get(idx as usize);
+        }
+    }
+    symbols.tables.first()
+}
+
+/// Collect index/identifier text values from instruction node children.
+fn collect_instruction_indices<'a>(node: &Node, source: &'a str, out: &mut Vec<&'a str>) {
+    let mut c = node.walk();
+    for child in node.children(&mut c) {
+        let kind = child.kind();
+        if kind == "index" || kind == "identifier" {
+            out.push(source[child.byte_range()].trim());
+        } else if kind.starts_with("op_") {
+            collect_instruction_indices(&child, source, out);
+        }
+    }
+}
+
+/// Check table.init type compatibility between table and elem segment ref types.
+fn check_table_init_types(
+    node: &Node,
+    symbols: &SymbolTable,
+    source: &str,
+    checker: &mut TypeChecker,
+) {
+    let table = resolve_table_for_table_init(node, symbols, source);
+    let elem = resolve_elem_for_table_init(node, symbols, source);
+    if let (Some(table), Some(elem)) = (table, elem) {
+        if !ref_types_compatible(elem.ref_type, table.ref_type) {
+            checker.diagnostics.push(
+                Diagnostic::error(node_to_range(node), "type mismatch".to_string())
+                    .with_code("type-mismatch"),
+            );
+        }
+    }
+}
+
+/// Check table.copy type compatibility between destination and source tables.
+fn check_table_copy_types(
+    node: &Node,
+    symbols: &SymbolTable,
+    source: &str,
+    checker: &mut TypeChecker,
+) {
+    let mut indices = Vec::new();
+    collect_instruction_indices(node, source, &mut indices);
+
+    let (dst, src) = if indices.len() >= 2 {
+        let dst = symbols
+            .get_table_by_name(indices[0])
+            .or_else(|| parse_wat_nat(indices[0]).and_then(|i| symbols.tables.get(i as usize)));
+        let src = symbols
+            .get_table_by_name(indices[1])
+            .or_else(|| parse_wat_nat(indices[1]).and_then(|i| symbols.tables.get(i as usize)));
+        (dst, src)
+    } else {
+        (symbols.tables.first(), symbols.tables.first())
+    };
+
+    if let (Some(dst), Some(src)) = (dst, src) {
+        if !ref_types_compatible(src.ref_type, dst.ref_type) {
+            checker.diagnostics.push(
+                Diagnostic::error(node_to_range(node), "type mismatch".to_string())
+                    .with_code("type-mismatch"),
+            );
+        }
+    }
+}
+
+/// Resolve address types for table.copy $dst $src.
+fn resolve_table_copy_addr_types(
+    node: &Node,
+    symbols: &SymbolTable,
+    source: &str,
+) -> (ValueType, ValueType) {
+    let mut indices = Vec::new();
+    collect_instruction_indices(node, source, &mut indices);
+
+    let addr = |t: Option<&Table>| -> ValueType {
+        t.map(|t| {
+            if t.is_table64 {
+                ValueType::I64
+            } else {
+                ValueType::I32
+            }
+        })
+        .unwrap_or(ValueType::I32)
+    };
+
+    if indices.len() >= 2 {
+        let dst = symbols
+            .get_table_by_name(indices[0])
+            .or_else(|| parse_wat_nat(indices[0]).and_then(|i| symbols.tables.get(i as usize)));
+        let src = symbols
+            .get_table_by_name(indices[1])
+            .or_else(|| parse_wat_nat(indices[1]).and_then(|i| symbols.tables.get(i as usize)));
+        (addr(dst), addr(src))
+    } else {
+        let t = symbols.tables.first();
+        (addr(t), addr(t))
+    }
+}
+
+/// Check if an array mutation instruction targets an immutable array type.
+fn check_immutable_array(
+    instr_name: &str,
+    node: &Node,
+    symbols: &SymbolTable,
+    source: &str,
+    checker: &mut TypeChecker,
+) {
+    // Only check mutation instructions
+    if !matches!(
+        instr_name,
+        "array.set" | "array.fill" | "array.copy" | "array.init_data" | "array.init_elem"
+    ) {
+        return;
+    }
+
+    // Resolve the first type index to a TypeDef
+    if let Some(type_def) = resolve_first_type_index(node, symbols, source) {
+        if let TypeKind::Array { mutable, .. } = &type_def.kind {
+            if !mutable {
+                checker.diagnostics.push(
+                    Diagnostic::error(node_to_range(node), "immutable array".to_string())
+                        .with_code("immutable-array"),
+                );
+            }
+        }
+    }
+}
+
+/// Resolve the first type index in an instruction to a TypeDef.
+fn resolve_first_type_index<'a>(
+    node: &Node,
+    symbols: &'a SymbolTable,
+    source: &str,
+) -> Option<&'a TypeDef> {
+    let index = get_index_from_node(node, source)?;
+    if let Some(t) = symbols.get_type_by_name(index) {
+        return Some(t);
+    }
+    if let Some(idx) = parse_wat_nat(index) {
+        return symbols.types.get(idx as usize);
+    }
+    None
+}
+
+/// Check if source ref type is compatible with destination ref type.
+fn ref_types_compatible(src: ValueType, dst: ValueType) -> bool {
+    if src == dst {
+        return true;
+    }
+    super::type_check::types_compatible(&src, &dst)
 }

--- a/src/diagnostics_core/subtype.rs
+++ b/src/diagnostics_core/subtype.rs
@@ -6,6 +6,8 @@
 use crate::core::types::Diagnostic;
 use crate::symbols::{SymbolTable, TypeDef, TypeKind};
 
+use super::type_check::types_compatible_with_symbols;
+
 /// Validate subtype hierarchy in the symbol table.
 /// Returns diagnostics for invalid parent references, final type violations,
 /// and structural incompatibilities.
@@ -47,7 +49,7 @@ pub fn validate_subtype_hierarchy(symbols: &SymbolTable) -> Vec<Diagnostic> {
         }
 
         // Check structural compatibility
-        check_structural_compatibility(type_def, parent, &mut diagnostics);
+        check_structural_compatibility(type_def, parent, symbols, &mut diagnostics);
     }
 
     diagnostics
@@ -69,6 +71,7 @@ fn resolve_parent<'a>(symbols: &'a SymbolTable, parent_ref: &str) -> Option<&'a 
 fn check_structural_compatibility(
     child: &TypeDef,
     parent: &TypeDef,
+    symbols: &SymbolTable,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
     let range = match child.range {
@@ -97,38 +100,79 @@ fn check_structural_compatibility(
                 ));
                 return;
             }
-            // First N fields must match parent's types
-            for (i, (_, parent_type, _parent_mut)) in parent_fields.iter().enumerate() {
-                let (_, child_type, _child_mut) = &child_fields[i];
-                if child_type != parent_type {
-                    diagnostics.push(Diagnostic::error(
-                        range,
-                        format!(
-                            "Struct field {} type mismatch: expected {:?}, got {:?}",
-                            i, parent_type, child_type
-                        ),
-                    ));
+            // First N fields must match parent's types with proper variance
+            for (i, (_, parent_type, parent_mut)) in parent_fields.iter().enumerate() {
+                let (_, child_type, child_mut) = &child_fields[i];
+                if *parent_mut {
+                    // Mutable fields: invariant (must be exact match both ways)
+                    if child_type != parent_type {
+                        diagnostics.push(Diagnostic::error(
+                            range,
+                            format!(
+                                "Struct field {} type mismatch: expected {:?}, got {:?}",
+                                i, parent_type, child_type
+                            ),
+                        ));
+                    }
+                    // Mutable fields must both be mutable
+                    if child_mut != parent_mut {
+                        diagnostics.push(Diagnostic::error(
+                            range,
+                            format!("Struct field {} mutability mismatch", i),
+                        ));
+                    }
+                } else {
+                    // Immutable fields: covariant (child must be subtype of parent)
+                    if !types_compatible_with_symbols(child_type, parent_type, symbols) {
+                        diagnostics.push(Diagnostic::error(
+                            range,
+                            format!(
+                                "Struct field {} type mismatch: expected {:?}, got {:?}",
+                                i, parent_type, child_type
+                            ),
+                        ));
+                    }
                 }
             }
         }
         (
             TypeKind::Array {
                 element_type: child_elem,
-                ..
+                mutable: child_mut,
             },
             TypeKind::Array {
                 element_type: parent_elem,
-                ..
+                mutable: parent_mut,
             },
         ) => {
-            if child_elem != parent_elem {
-                diagnostics.push(Diagnostic::error(
-                    range,
-                    format!(
-                        "Array element type mismatch: expected {:?}, got {:?}",
-                        parent_elem, child_elem
-                    ),
-                ));
+            if *parent_mut {
+                // Mutable array: invariant
+                if child_elem != parent_elem {
+                    diagnostics.push(Diagnostic::error(
+                        range,
+                        format!(
+                            "Array element type mismatch: expected {:?}, got {:?}",
+                            parent_elem, child_elem
+                        ),
+                    ));
+                }
+                if child_mut != parent_mut {
+                    diagnostics.push(Diagnostic::error(
+                        range,
+                        "Array mutability mismatch".to_string(),
+                    ));
+                }
+            } else {
+                // Immutable array: covariant
+                if !types_compatible_with_symbols(child_elem, parent_elem, symbols) {
+                    diagnostics.push(Diagnostic::error(
+                        range,
+                        format!(
+                            "Array element type mismatch: expected {:?}, got {:?}",
+                            parent_elem, child_elem
+                        ),
+                    ));
+                }
             }
         }
         (
@@ -141,7 +185,21 @@ fn check_structural_compatibility(
                 results: parent_results,
             },
         ) => {
-            if child_params != parent_params || child_results != parent_results {
+            // Function subtyping: params are contravariant, results are covariant
+            let params_ok = child_params.len() == parent_params.len()
+                && child_params.iter().zip(parent_params.iter()).all(|(c, p)| {
+                    // Contravariant: parent param must be subtype of child param
+                    types_compatible_with_symbols(p, c, symbols)
+                });
+            let results_ok = child_results.len() == parent_results.len()
+                && child_results
+                    .iter()
+                    .zip(parent_results.iter())
+                    .all(|(c, p)| {
+                        // Covariant: child result must be subtype of parent result
+                        types_compatible_with_symbols(c, p, symbols)
+                    });
+            if !params_ok || !results_ok {
                 diagnostics.push(Diagnostic::error(
                     range,
                     "Function subtype signature must match parent exactly".to_string(),

--- a/src/diagnostics_core/tree_walk.rs
+++ b/src/diagnostics_core/tree_walk.rs
@@ -219,7 +219,7 @@ pub fn walk_tree_for_diagnostics(
             &node, source,
         ));
         diagnostics.extend(crate::diagnostics_core::alignment_checks::check_alignment(
-            &node, source,
+            &node, source, symbols,
         ));
         diagnostics.extend(
             crate::diagnostics_core::gc_checks::check_struct_field_access(&node, source, symbols),
@@ -233,7 +233,7 @@ pub fn walk_tree_for_diagnostics(
                     &child, source,
                 ));
                 diagnostics.extend(crate::diagnostics_core::alignment_checks::check_alignment(
-                    &child, source,
+                    &child, source, symbols,
                 ));
                 diagnostics.extend(
                     crate::diagnostics_core::gc_checks::check_struct_field_access(

--- a/src/features/symbols/mod.rs
+++ b/src/features/symbols/mod.rs
@@ -252,6 +252,7 @@ pub struct DataSegment {
 pub struct ElemSegment {
     pub name: Option<String>,
     pub index: usize,
+    pub ref_type: ValueType,
     pub func_names: Vec<String>,
     pub line: u32,
     pub range: Option<Range>,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1346,23 +1346,7 @@ fn extract_type_from_single_node(
             kind = TypeKind::Struct { fields };
         }
         "array_type" => {
-            // Extract array field
-            let mut element_type = ValueType::Unknown;
-            let mut mutable = false;
-            let mut cursor = type_node.walk();
-            for child in type_node.children(&mut cursor) {
-                if child.kind() == "field_type" {
-                    let extracted = extract_field_types(&child, source);
-                    if let Some((_, ft, m)) = extracted.into_iter().next() {
-                        element_type = ft;
-                        mutable = m;
-                    }
-                }
-            }
-            kind = TypeKind::Array {
-                element_type,
-                mutable,
-            };
+            kind = extract_array_kind(type_node, source);
         }
         "type_field" => {
             // type_field wraps a def_type: func_type, struct_type, array_type, or sub_type
@@ -1551,24 +1535,7 @@ fn extract_type(type_node: &Node, source: &str, index: usize) -> Option<TypeDef>
             }
             kind = TypeKind::Struct { fields };
         } else if child.kind() == "array_type" {
-            // Extract array field directly
-            let mut element_type = ValueType::Unknown;
-            let mut mutable = false;
-
-            let mut array_cursor = child.walk();
-            for array_child in child.children(&mut array_cursor) {
-                if array_child.kind() == "field_type" {
-                    let extracted = extract_field_types(&array_child, source);
-                    if let Some((_, ft, m)) = extracted.into_iter().next() {
-                        element_type = ft;
-                        mutable = m;
-                    }
-                }
-            }
-            kind = TypeKind::Array {
-                element_type,
-                mutable,
-            };
+            kind = extract_array_kind(&child, source);
         } else if child.kind() == "type_field" {
             let mut field_cursor = child.walk();
             for field_child in child.children(&mut field_cursor) {
@@ -1592,25 +1559,7 @@ fn extract_type(type_node: &Node, source: &str, index: usize) -> Option<TypeDef>
                     }
                     kind = TypeKind::Struct { fields };
                 } else if field_child.kind() == "array_type" {
-                    // Extract array field
-                    // array_type: (array field_type)
-                    let mut element_type = ValueType::Unknown;
-                    let mut mutable = false;
-
-                    let mut array_cursor = field_child.walk();
-                    for array_child in field_child.children(&mut array_cursor) {
-                        if array_child.kind() == "field_type" {
-                            let extracted = extract_field_types(&array_child, source);
-                            if let Some((_, ft, m)) = extracted.into_iter().next() {
-                                element_type = ft;
-                                mutable = m;
-                            }
-                        }
-                    }
-                    kind = TypeKind::Array {
-                        element_type,
-                        mutable,
-                    };
+                    kind = extract_array_kind(&field_child, source);
                 } else if field_child.kind() == "sub_type" {
                     // Handle sub_type inside type_field: (sub final? index? def_type)
                     let mut sub_cursor = field_child.walk();
@@ -1686,19 +1635,18 @@ fn extract_struct_kind(struct_node: &Node, source: &str) -> TypeKind {
     TypeKind::Struct { fields }
 }
 
-/// Helper to extract array kind from an array_type node
+/// Helper to extract array kind from an array_type node.
+/// Grammar: `array_type: (array storage_type)` — storage_type is a direct child.
 fn extract_array_kind(array_node: &Node, source: &str) -> TypeKind {
     let mut element_type = ValueType::Unknown;
     let mut mutable = false;
 
     let mut array_cursor = array_node.walk();
     for array_child in array_node.children(&mut array_cursor) {
-        if array_child.kind() == "field_type" {
-            let extracted = extract_field_types(&array_child, source);
-            if let Some((_, ft, m)) = extracted.into_iter().next() {
-                element_type = ft;
-                mutable = m;
-            }
+        if array_child.kind() == "storage_type" {
+            let (ft, m) = extract_storage_type_with_mut(&array_child, source);
+            element_type = ft;
+            mutable = m;
         }
     }
     TypeKind::Array {
@@ -1922,7 +1870,15 @@ fn extract_memory(memory_node: &Node, source: &str, index: usize) -> Option<Memo
         if child.kind() == "memory64_type" {
             is_memory64 = true;
         }
-        if child.kind() == "memory_fields_type" {
+        if child.kind() == "memory_fields_data" {
+            // Inline data form: check for memory64_type
+            let mut fields_cursor = child.walk();
+            for fields_child in child.children(&mut fields_cursor) {
+                if fields_child.kind() == "memory64_type" {
+                    is_memory64 = true;
+                }
+            }
+        } else if child.kind() == "memory_fields_type" {
             let mut fields_cursor = child.walk();
             for fields_child in child.children(&mut fields_cursor) {
                 // Check for memory64_type in memory_fields_type
@@ -2489,13 +2445,53 @@ fn extract_elem_segment(elem_node: &Node, source: &str, index: usize) -> Option<
         }
     }
 
+    // Determine elem segment ref type
+    let ref_type = extract_elem_ref_type(elem_node, source);
+
     Some(ElemSegment {
         name,
         index,
+        ref_type,
         func_names,
         line: elem_node.range().start_point.row as u32,
         range: name_range,
     })
+}
+
+/// Extract the ref type from an elem segment node.
+/// Detects `funcref`, `externref`, `(ref func)`, `(ref extern)`, etc.
+/// Defaults to Funcref if no explicit type is found.
+fn extract_elem_ref_type(node: &Node, source: &str) -> ValueType {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        let kind = child.kind();
+        if kind == "elem_list" {
+            // elem_list may contain a ref_type or value_type child
+            let mut inner = child.walk();
+            for gc in child.children(&mut inner) {
+                let gk = gc.kind();
+                if gk == "ref_type"
+                    || gk == "value_type"
+                    || gk == "ref_type_ref"
+                    || gk == "ref_type_concrete"
+                {
+                    let text = node_text(&gc, source).trim().to_string();
+                    if let Some(vt) = ValueType::try_parse(&text) {
+                        return vt;
+                    }
+                }
+            }
+        }
+        // Check for inline ref type keywords at top level
+        if kind == "ref_type" || kind == "value_type" {
+            let text = node_text(&child, source).trim().to_string();
+            if let Some(vt) = ValueType::try_parse(&text) {
+                return vt;
+            }
+        }
+    }
+    // If elem uses `func` keyword (abbreviated), it's funcref
+    ValueType::Funcref
 }
 
 /// Find identifier in data or elem segment nodes.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -199,6 +199,8 @@ fn context_from_instruction_text(instr_text: &str) -> Option<InstructionContext>
     } else if first_token == "table.init" || first_token == "elem.drop" {
         Some(InstructionContext::Elem)
     // Check GC/struct/array instructions (they take type indices)
+    // Note: array.new_data/elem/init_data/init_elem also return Type here;
+    // their multi-index handling is done in references.rs
     } else if first_token.starts_with("struct.")
         || first_token.starts_with("array.")
         || first_token == "ref.cast"
@@ -209,6 +211,9 @@ fn context_from_instruction_text(instr_text: &str) -> Option<InstructionContext>
         Some(InstructionContext::Type)
     } else if first_token == "ref.func" || first_token == "return_call" {
         Some(InstructionContext::Call)
+    // br_on_cast/br_on_cast_fail: first index is branch label, rest are types (handled in references.rs)
+    } else if first_token == "br_on_cast" || first_token == "br_on_cast_fail" {
+        Some(InstructionContext::Type)
     } else if first_token.starts_with("br") {
         Some(InstructionContext::Branch)
     } else if first_token.starts_with("call") && first_token != "call_indirect" {


### PR DESCRIPTION
## Summary

- Memory64-aware address types for load/store/grow/size/copy/fill/init operations
- SIMD instruction consumed type signatures (splat, extract/replace lane, shifts, etc.)
- Table.init/table.copy typed operands with table64 support and ref type compatibility checks
- GC reference contexts: array.new_data/elem multi-index, br_on_cast branch+type split
- Subtype variance: contravariant params, covariant results, invariant mutable fields
- Immutable array mutation check (array.set/fill/copy/init_data/init_elem)
- Fix array_type parser to use storage_type for mutability detection
- Tag result type validation, throw typed consumed operands
- Data/elem offset type checking for memory64/table64 targets
- Grammar: allow empty (field) in struct types

Spec test results: 5969 pass (+154), 77 fail (-154), 0 regressions, 480 unit tests pass