### PR TITLE
feat: GC instruction validation — array ops, br_on_cast, try_table catch, throw_ref, struct fields

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,171 @@
+# WAST Spec Test Coverage Plan
+
+**Generated**: 2026-02-20
+**Baseline**: commit 488fa6b4
+**Updated**: 2026-02-20 (Phase 1 complete)
+
+## Current Results (after Phase 1)
+
+| Category | Pass | Total | Rate | Delta |
+|---|---|---|---|---|
+| Modules (valid) | 2092 | 2128 | 98.3% | +0 |
+| assert_invalid | 2667 | 2689 | 99.2% | **+17** |
+| assert_malformed | 1229 | 1229 | 100.0% | **+1** |
+| **TOTAL (non-skip)** | **5988** | **6046** | **99.0%** | **+18** |
+| Skipped (runtime) | 58577 | — | — | — |
+
+**58 total failures** across 21 files (was 76 across 25).
+
+### Phase 1 Changes (completed)
+- **array.copy/fill/init_data/init_elem**: Element type validation (+7 assert_invalid)
+- **br_on_cast/br_on_cast_fail**: Cast type hierarchy validation (+4 assert_invalid)
+- **try_table catch clauses**: Handler type validation against target labels (+4 assert_invalid)
+- **throw_ref**: Stack operand validation (+2 assert_invalid)
+- **struct duplicate fields**: Duplicate field name detection (+1 assert_malformed)
+
+## Previous Baseline
+
+| Category | Pass | Total | Rate |
+|---|---|---|---|
+| Modules (valid) | 2092 | 2128 | 98.3% |
+| assert_invalid | 2650 | 2689 | 98.5% |
+| assert_malformed | 1228 | 1229 | 99.9% |
+| **TOTAL (non-skip)** | **5970** | **6046** | **98.7%** |
+
+**76 total failures** across 25 files.
+
+## Per-File Failures
+
+| File | Mod | Inv | Mal | Total |
+|---|---|---|---|---|
+| type-subtyping.wast | 11 | 7 | 0 | 18 |
+| type-rec.wast | 0 | 9 | 0 | 9 |
+| try_table.wast | 1 | 5 | 0 | 6 |
+| br_on_cast_fail.wast | 3 | 2 | 0 | 5 |
+| br_on_cast.wast | 3 | 2 | 0 | 5 |
+| array.wast | 4 | 0 | 0 | 4 |
+| return_call_ref.wast | 1 | 2 | 0 | 3 |
+| array_copy.wast | 0 | 3 | 0 | 3 |
+| instance.wast | 2 | 0 | 0 | 2 |
+| table.wast | 2 | 0 | 0 | 2 |
+| array_fill.wast | 0 | 2 | 0 | 2 |
+| array_init_elem.wast | 0 | 2 | 0 | 2 |
+| struct.wast | 0 | 1 | 1 | 2 |
+| throw_ref.wast | 0 | 2 | 0 | 2 |
+| annotations.wast | 1 | 0 | 0 | 1 |
+| call_indirect64.wast | 1 | 0 | 0 | 1 |
+| i31.wast | 1 | 0 | 0 | 1 |
+| id.wast | 1 | 0 | 0 | 1 |
+| memory.wast | 1 | 0 | 0 | 1 |
+| memory64.wast | 1 | 0 | 0 | 1 |
+| ref_as_non_null.wast | 0 | 1 | 0 | 1 |
+| stack.wast | 1 | 0 | 0 | 1 |
+| table-sub.wast | 1 | 0 | 0 | 1 |
+| table64.wast | 1 | 0 | 0 | 1 |
+| array_init_data.wast | 0 | 1 | 0 | 1 |
+
+## Failure Root Causes
+
+| Root Cause | Mod | Inv | Mal | Total | Description |
+|---|---|---|---|---|---|
+| GC rec types & subtyping | 11 | 16 | 0 | **27** | Recursive type groups, type equivalence across rec boundaries, variance violations |
+| GC instruction validation | 6 | 10 | 0 | **16** | br_on_cast/fail nullability, array ops mutability/types, try_table catch types |
+| Module definition syntax | 5 | 0 | 0 | **5** | `(module definition ...)` wast syntax (instance.wast, memory.wast, table.wast) |
+| Memory64/Table64 edge cases | 3 | 0 | 0 | **3** | 64-bit index types in memory.size, table ops, call_indirect64 |
+| Misc single-file issues | 11 | 13 | 1 | **25** | Quoted IDs, annotations, multi-value stack, throw_ref, struct field dup, ref_as_non_null |
+
+## Prioritized Phases
+
+### Phase 1: GC Instruction Validation (~16 fixes)
+**Feasibility**: Medium | **Impact**: High
+
+Root cause: The type checker doesn't understand GC-specific instructions well enough.
+
+**Subphase 1a: Array operation type validation (+8)**
+- `array_copy.wast`: 3 invalid — need to check array element type compatibility and mutability for `array.copy`
+- `array_fill.wast`: 2 invalid — need to check `array.fill` element type (packed i8/i16 → i32 widening)
+- `array_init_data.wast`: 1 invalid — need to verify array type is numeric/vector for `array.init_data`
+- `array_init_elem.wast`: 2 invalid — need element type matching for `array.init_elem`
+- **Files**: `semantic.rs`, `type_check.rs`
+
+**Subphase 1b: br_on_cast / br_on_cast_fail validation (+4)**
+- 2 invalid each for br_on_cast and br_on_cast_fail — nullability constraint on cast types
+- **Files**: `semantic.rs`, `type_check.rs`
+
+**Subphase 1c: try_table catch type validation (+5)**
+- try_table.wast: 5 invalid — catch/catch_ref handler type mismatches
+- **Files**: `semantic.rs`, `type_check.rs`
+
+**Subphase 1d: Miscellaneous GC type checking (+4)**
+- return_call_ref.wast: 2 invalid — return type subtyping
+- throw_ref.wast: 2 invalid — exnref type on stack
+- ref_as_non_null.wast: 1 invalid — nullable→non-nullable cast type narrowing
+- struct.wast: 1 invalid — struct field type mismatch
+- **Files**: `semantic.rs`, `type_check.rs`
+
+### Phase 2: GC Rec Types & Subtyping (~27 fixes)
+**Feasibility**: Hard | **Impact**: Highest
+
+Root cause: The parser/type system doesn't model recursive type groups (`rec`), so type equivalence across rec boundaries and subtype variance cannot be validated.
+
+- type-subtyping.wast: 18 failures — need proper rec type group handling, covariant/contravariant field checking
+- type-rec.wast: 9 failures — need `rec` group type equivalence, forward references within rec groups
+- **Files**: `parser.rs` (type representation), `module_checks.rs` (subtype validation), `type_check.rs` (type matching)
+- **Prerequisite**: Need a proper GC type representation in the symbol table that tracks:
+  - Rec group membership and boundaries
+  - Structural type definitions (struct fields, array element, func params/results)
+  - Subtype declarations (`sub` / `sub final`)
+  - Type equivalence rules for iso-recursive types
+
+### Phase 3: Module False Positives (~14 module fixes)
+**Feasibility**: Medium | **Impact**: Medium
+
+**Subphase 3a: GC module validity (+10)**
+- br_on_cast.wast: 3 module — false positive errors on valid br_on_cast usage
+- br_on_cast_fail.wast: 3 module — same for br_on_cast_fail
+- array.wast: 4 module — false positive errors on valid array operations (rec types, GC refs)
+- **Root cause**: Lack of rec type awareness causes spurious "unknown type" or "type mismatch" errors
+- **Files**: `references.rs`, `module_checks.rs`, `semantic.rs`
+
+**Subphase 3b: Memory/Table/Instance module syntax (+5)**
+- instance.wast: 2 — `(module definition ...)` wast syntax
+- memory.wast: 1 — same
+- table.wast: 2 — same
+- memory64.wast: 1 — 64-bit index type for memory.size
+- table64.wast: 1 — 64-bit index type for table operations
+- call_indirect64.wast: 1 — 64-bit call_indirect
+- **Files**: `wast-runner` (module definition parsing), `semantic.rs` (64-bit index types)
+
+**Subphase 3c: Misc module fixes (+5)**
+- annotations.wast: 1 — quoted annotation names `(@"name")`
+- id.wast: 1 — quoted identifier normalization `$"fh"` ≡ `$fh`
+- i31.wast: 1 — i31ref table init expression
+- stack.wast: 1 — multi-value block stack validation
+- table-sub.wast: 1 — table copy with subtype refs
+- **Files**: `grammar.js`, `parser.rs`, `semantic.rs`
+
+### Phase 4: Structural Validation (+2)
+**Feasibility**: Easy | **Impact**: Low
+
+- struct.wast: 1 malformed — duplicate field detection in struct types
+- return_call_ref.wast: 1 module — return type subtyping validation
+- **Files**: `module_checks.rs`, `semantic.rs`
+
+## Projected Pass Rates
+
+| Phase | Pass | Total | Rate | Delta |
+|---|---|---|---|---|
+| Baseline | 5970 | 6046 | 98.7% | — |
+| After Phase 1 | ~5986 | 6046 | ~99.0% | +16 |
+| After Phase 2 | ~6013 | 6046 | ~99.5% | +27 |
+| After Phase 3 | ~6027 | 6046 | ~99.7% | +14 |
+| After Phase 4 | ~6029 | 6046 | ~99.7% | +2 |
+
+**Remaining ~17 failures** after all phases would be primarily `(module definition)` wast syntax (not WAT) and edge cases requiring full iso-recursive type system.
+
+## Recommended Next Step
+
+**Start with Phase 1a** (array operation type validation). It has the best effort-to-fix ratio:
+- 8 assert_invalid fixes from adding type checks for 4 array instructions
+- Self-contained changes in `semantic.rs` / `type_check.rs`
+- No prerequisite infrastructure changes needed

--- a/src/diagnostics_core/module_checks.rs
+++ b/src/diagnostics_core/module_checks.rs
@@ -450,6 +450,7 @@ fn check_duplicate_identifiers(module: &Node, source: &str, diagnostics: &mut Ve
             }
             "module_field_type" => {
                 check_identifier_dup(field, source, &mut seen_type, "type", diagnostics);
+                check_duplicate_struct_fields(field, source, diagnostics);
             }
             "module_field_tag" => {
                 check_identifier_dup(field, source, &mut seen_tag, "tag", diagnostics);
@@ -466,6 +467,7 @@ fn check_duplicate_identifiers(module: &Node, source: &str, diagnostics: &mut Ve
                     node_kind!(ck = child);
                     if ck == "module_field_type" {
                         check_identifier_dup(&child, source, &mut seen_type, "type", diagnostics);
+                        check_duplicate_struct_fields(&child, source, diagnostics);
                     }
                 }
             }
@@ -573,6 +575,68 @@ fn check_tag_no_results(node: &Node, _source: &str, diagnostics: &mut Vec<Diagno
         false
     }
     has_results(node, diagnostics);
+}
+
+/// Check for duplicate named fields within a struct type definition.
+fn check_duplicate_struct_fields(
+    type_node: &Node,
+    source: &str,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let mut seen_fields: HashMap<String, Range> = HashMap::new();
+    find_struct_and_check_fields(type_node, source, &mut seen_fields, diagnostics);
+}
+
+/// Recursively find struct_type nodes and check their fields for duplicates.
+fn find_struct_and_check_fields(
+    node: &Node,
+    source: &str,
+    seen: &mut HashMap<String, Range>,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        let kind = child.kind();
+        if kind == "struct_type" {
+            collect_struct_field_names(&child, source, seen, diagnostics);
+        } else {
+            find_struct_and_check_fields(&child, source, seen, diagnostics);
+        }
+    }
+}
+
+/// Collect and check named fields in a struct for duplicates.
+fn collect_struct_field_names(
+    node: &Node,
+    source: &str,
+    seen: &mut HashMap<String, Range>,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        let kind = child.kind();
+        if kind == "field_type" {
+            // Check for identifier children (named fields)
+            let mut inner_cursor = child.walk();
+            for inner_child in child.children(&mut inner_cursor) {
+                if inner_child.kind() == "identifier" {
+                    let name = node_text(&inner_child, source).to_string();
+                    let range = node_to_range(&inner_child);
+                    if let std::collections::hash_map::Entry::Vacant(e) = seen.entry(name.clone()) {
+                        e.insert(range);
+                    } else {
+                        diagnostics.push(Diagnostic::error(
+                            range,
+                            format!("duplicate field {}", name),
+                        ));
+                    }
+                }
+            }
+        } else if kind != "(" && kind != ")" && kind != "struct" {
+            // Recurse into other structural nodes
+            collect_struct_field_names(&child, source, seen, diagnostics);
+        }
+    }
 }
 
 // ============================================================================

--- a/src/diagnostics_core/semantic.rs
+++ b/src/diagnostics_core/semantic.rs
@@ -16,7 +16,7 @@ use crate::core::types::Diagnostic;
 use crate::instruction_metadata::{
     infer_simd_instruction_arity, is_terminating_instruction, lookup_instruction_arity, OperandMode,
 };
-use crate::symbols::{Memory, SymbolTable, Table, TypeDef, TypeKind, ValueType};
+use crate::symbols::{ElemSegment, Memory, SymbolTable, Table, TypeDef, TypeKind, ValueType};
 use crate::utils::node_to_range;
 
 use super::sequence_always_terminates;
@@ -386,8 +386,8 @@ fn process_block_body(node: &Node, source: &str, symbols: &SymbolTable, checker:
                 process_block_body(&child, source, symbols, checker);
             }
             "catch_clause" => {
-                // Catch clauses in try_table are label declarations, not code blocks.
-                // Reference checking is handled in tree_walk.rs.
+                // Validate catch clause types against the target label's expected types.
+                check_catch_clause_types(&child, source, symbols, checker);
             }
             "instr_else" | "else" => {
                 // At else: validate then branch, reset stack for else branch
@@ -688,7 +688,8 @@ fn process_instruction(
             checker.pop_function_return_types(node, instr_name);
         }
         // For 'throw', pop tag parameter types
-        if instr_name == "throw" {
+        // For 'throw_ref', pop exnref operand
+        if instr_name == "throw" || instr_name == "throw_ref" {
             let consumed = get_instruction_consumed_types(node, instr_name, symbols, source);
             if !consumed.is_empty() {
                 checker.pop_vals_for_instr(&consumed, node, instr_name);
@@ -810,8 +811,13 @@ fn process_instruction(
         check_table_copy_types(node, symbols, source, checker);
     }
 
-    // Check immutable array for array mutation instructions
-    check_immutable_array(instr_name, node, symbols, source, checker);
+    // Check array mutation/bulk instructions for mutability and type compatibility
+    check_array_operations(instr_name, node, symbols, source, checker);
+
+    // Check br_on_cast/br_on_cast_fail cast type hierarchy
+    if instr_name == "br_on_cast" || instr_name == "br_on_cast_fail" {
+        check_br_on_cast_types(node, source, checker);
+    }
 
     let produced = infer_instruction_result_types(instr_name, node, symbols, source);
     // If we know the instruction produces N values but couldn't infer types, pad with Unknown
@@ -1087,12 +1093,24 @@ fn derive_consumed_types_from_name(
         } // arrayref, index
         "array.set" => Some(vec![ValueType::Unknown, ValueType::I32, ValueType::Unknown]), // arrayref, index, value
         "array.len" => Some(vec![ValueType::Unknown]), // arrayref
-        "array.fill" => Some(vec![
-            ValueType::Unknown,
-            ValueType::I32,
-            ValueType::Unknown,
-            ValueType::I32,
-        ]), // arrayref, index, value, len
+        "array.fill" => {
+            // arrayref, i32 offset, value, i32 length
+            // Resolve element type from the type index to type-check the value operand
+            let val_ty = resolve_first_type_index(node, symbols, source)
+                .and_then(|td| match &td.kind {
+                    TypeKind::Array { element_type, .. } => {
+                        Some(unpack_storage_type(*element_type))
+                    }
+                    _ => None,
+                })
+                .unwrap_or(ValueType::Unknown);
+            Some(vec![
+                ValueType::Unknown,
+                ValueType::I32,
+                val_ty,
+                ValueType::I32,
+            ])
+        }
         "array.copy" => Some(vec![
             ValueType::Unknown,
             ValueType::I32,
@@ -2162,6 +2180,10 @@ fn process_folded_block_body(
                 // folded ifs are handled by process_folded_block_expr, but handle as fallback)
                 process_folded_if_bodies_from_if_block(&child, source, symbols, checker);
             }
+            "catch_clause" => {
+                // Validate catch clause types against the target label's expected types.
+                check_catch_clause_types(&child, source, symbols, checker);
+            }
             // Direct instruction children (body without instr_list wrapper)
             "instr" | "instr_plain" | "expr" | "instr_block" | "instr_loop" | "instr_if"
             | "instr_call" | "instr_list_call" => {
@@ -3071,15 +3093,22 @@ fn resolve_table_copy_addr_types(
     }
 }
 
-/// Check if an array mutation instruction targets an immutable array type.
-fn check_immutable_array(
+/// Check array mutation instructions for mutability and type compatibility.
+///
+/// Validates:
+/// - array.set/fill/copy/init_data/init_elem: destination array must be mutable
+/// - array.copy: source and destination element types must match
+/// - array.fill: value type must match element type
+/// - array.init_data: element type must be numeric or vector
+/// - array.init_elem: elem segment type must match element type
+fn check_array_operations(
     instr_name: &str,
     node: &Node,
     symbols: &SymbolTable,
     source: &str,
     checker: &mut TypeChecker,
 ) {
-    // Only check mutation instructions
+    // Only check array mutation/bulk instructions
     if !matches!(
         instr_name,
         "array.set" | "array.fill" | "array.copy" | "array.init_data" | "array.init_elem"
@@ -3087,17 +3116,148 @@ fn check_immutable_array(
         return;
     }
 
-    // Resolve the first type index to a TypeDef
-    if let Some(type_def) = resolve_first_type_index(node, symbols, source) {
+    // Resolve the first (destination) type index
+    let dest_type_def = resolve_first_type_index(node, symbols, source);
+
+    // Check mutability for destination array
+    if let Some(type_def) = dest_type_def {
         if let TypeKind::Array { mutable, .. } = &type_def.kind {
             if !mutable {
                 checker.diagnostics.push(
                     Diagnostic::error(node_to_range(node), "immutable array".to_string())
                         .with_code("immutable-array"),
                 );
+                return; // Don't report additional errors after mutability failure
             }
         }
     }
+
+    match instr_name {
+        "array.copy" => {
+            // Both type indices must resolve to array types with compatible element types
+            let dest_elem = dest_type_def.and_then(|td| match &td.kind {
+                TypeKind::Array { element_type, .. } => Some(*element_type),
+                _ => None,
+            });
+            let src_elem =
+                resolve_nth_type_index(node, symbols, source, 1).and_then(|td| match &td.kind {
+                    TypeKind::Array { element_type, .. } => Some(*element_type),
+                    _ => None,
+                });
+            if let (Some(dst), Some(src)) = (dest_elem, src_elem) {
+                if dst != src && !ref_types_compatible(src, dst) {
+                    checker.diagnostics.push(
+                        Diagnostic::error(
+                            node_to_range(node),
+                            "array types do not match".to_string(),
+                        )
+                        .with_code("type-mismatch"),
+                    );
+                }
+            }
+        }
+        "array.fill" => {
+            // Type checking handled via consumed types in get_instruction_consumed_types
+        }
+        "array.init_data" => {
+            // Element type must be numeric or vector (not a reference type)
+            if let Some(type_def) = dest_type_def {
+                if let TypeKind::Array { element_type, .. } = &type_def.kind {
+                    if !is_numeric_or_vector(*element_type) {
+                        checker.diagnostics.push(
+                            Diagnostic::error(
+                                node_to_range(node),
+                                "array type is not numeric or vector".to_string(),
+                            )
+                            .with_code("type-mismatch"),
+                        );
+                    }
+                }
+            }
+        }
+        "array.init_elem" => {
+            // Elem segment type must be compatible with array element type
+            if let Some(type_def) = dest_type_def {
+                if let TypeKind::Array { element_type, .. } = &type_def.kind {
+                    if let Some(elem_seg) = resolve_elem_for_array_init(node, symbols, source) {
+                        if !ref_types_compatible(elem_seg.ref_type, *element_type)
+                            && *element_type != elem_seg.ref_type
+                        {
+                            checker.diagnostics.push(
+                                Diagnostic::error(node_to_range(node), "type mismatch".to_string())
+                                    .with_code("type-mismatch"),
+                            );
+                        }
+                    }
+                }
+            }
+        }
+        _ => {} // array.set handled by mutability check only
+    }
+}
+
+/// Unpack packed storage types (i8, i16) to their stack representation (i32).
+fn unpack_storage_type(ty: ValueType) -> ValueType {
+    match ty {
+        ValueType::I8 | ValueType::I16 => ValueType::I32,
+        other => other,
+    }
+}
+
+/// Check if a ValueType is numeric (i32, i64, f32, f64) or packed (i8, i16).
+fn is_numeric_type(ty: ValueType) -> bool {
+    matches!(
+        ty,
+        ValueType::I32
+            | ValueType::I64
+            | ValueType::F32
+            | ValueType::F64
+            | ValueType::I8
+            | ValueType::I16
+    )
+}
+
+/// Check if a ValueType is numeric or vector (valid for array.init_data).
+fn is_numeric_or_vector(ty: ValueType) -> bool {
+    is_numeric_type(ty) || ty == ValueType::V128
+}
+
+/// Resolve the Nth type index (0-based) in an instruction to a TypeDef.
+fn resolve_nth_type_index<'a>(
+    node: &Node,
+    symbols: &'a SymbolTable,
+    source: &str,
+    n: usize,
+) -> Option<&'a TypeDef> {
+    let mut indices = Vec::new();
+    collect_instruction_indices(node, source, &mut indices);
+    let index_str = indices.get(n)?;
+    if let Some(t) = symbols.get_type_by_name(index_str) {
+        return Some(t);
+    }
+    if let Some(idx) = parse_wat_nat(index_str) {
+        return symbols.types.get(idx as usize);
+    }
+    None
+}
+
+/// Resolve the elem segment for array.init_elem instruction.
+/// array.init_elem $type $elem: first index is type, second is elem segment.
+fn resolve_elem_for_array_init<'a>(
+    node: &Node,
+    symbols: &'a SymbolTable,
+    source: &str,
+) -> Option<&'a ElemSegment> {
+    let mut indices = Vec::new();
+    collect_instruction_indices(node, source, &mut indices);
+    let elem_ref = indices.get(1)?;
+    if let Some(elem) = symbols.get_elem_by_name(elem_ref) {
+        return Some(elem);
+    }
+    if let Some(idx) = parse_wat_nat(elem_ref) {
+        return symbols.elem_segments.get(idx as usize);
+    }
+    None
 }
 
 /// Resolve the first type index in an instruction to a TypeDef.
@@ -3122,4 +3282,252 @@ fn ref_types_compatible(src: ValueType, dst: ValueType) -> bool {
         return true;
     }
     super::type_check::types_compatible(&src, &dst)
+}
+
+/// Check br_on_cast / br_on_cast_fail cast type hierarchy.
+///
+/// The instruction format is: `br_on_cast <label> <source_type> <target_type>`
+/// The target type must be a subtype of the source type.
+fn check_br_on_cast_types(node: &Node, source: &str, checker: &mut TypeChecker) {
+    // Extract the two heap type children (after the label index)
+    let heap_types = extract_heap_types_from_cast(node, source);
+    if heap_types.len() < 2 {
+        return;
+    }
+    let src_type = &heap_types[0];
+    let tgt_type = &heap_types[1];
+
+    // Target must be a subtype of source
+    if !is_heap_subtype(tgt_type, src_type) {
+        checker.diagnostics.push(
+            Diagnostic::error(node_to_range(node), "type mismatch".to_string())
+                .with_code("type-mismatch"),
+        );
+    }
+}
+
+/// Validate catch clause types in try_table against the target label's expected types.
+///
+/// Grammar: `(catch $tag $label)` / `(catch_ref $tag $label)` / `(catch_all $label)` / `(catch_all_ref $label)`
+///
+/// The types routed to the label are:
+/// - catch: tag parameter types
+/// - catch_ref: tag parameter types + exnref
+/// - catch_all: (empty)
+/// - catch_all_ref: exnref
+fn check_catch_clause_types(
+    node: &Node,
+    source: &str,
+    symbols: &SymbolTable,
+    checker: &mut TypeChecker,
+) {
+    let mut cursor = node.walk();
+    let mut catch_kind: Option<&str> = None;
+    let mut indices: Vec<&str> = Vec::new();
+
+    for child in node.children(&mut cursor) {
+        node_kind!(kind = child);
+        match kind.as_ref() {
+            "catch" | "catch_ref" | "catch_all" | "catch_all_ref" => {
+                catch_kind = Some(match kind.as_ref() {
+                    "catch" => "catch",
+                    "catch_ref" => "catch_ref",
+                    "catch_all" => "catch_all",
+                    _ => "catch_all_ref",
+                });
+            }
+            "index" | "identifier" => {
+                indices.push(source[child.byte_range()].trim());
+            }
+            _ => {}
+        }
+    }
+
+    let catch_kind = match catch_kind {
+        Some(k) => k,
+        None => return,
+    };
+
+    // Determine what types are sent to the label
+    let sent_types = match catch_kind {
+        "catch" | "catch_ref" => {
+            // First index is tag, second is label
+            let tag_ref = match indices.first() {
+                Some(r) => *r,
+                None => return,
+            };
+            let tag = symbols
+                .get_tag_by_name(tag_ref)
+                .or_else(|| parse_wat_nat(tag_ref).and_then(|i| symbols.tags.get(i as usize)));
+            let mut types = tag.map(|t| t.params.clone()).unwrap_or_default();
+            if catch_kind == "catch_ref" {
+                types.push(ValueType::Unknown); // exnref — no Exnref variant yet, Unknown matches anything
+            }
+            types
+        }
+        "catch_all" => vec![],
+        "catch_all_ref" => vec![ValueType::Unknown], // exnref placeholder
+        _ => return,
+    };
+
+    // Resolve the label index
+    let label_ref = match catch_kind {
+        "catch" | "catch_ref" => indices.get(1),
+        _ => indices.first(),
+    };
+    let label_ref = match label_ref {
+        Some(r) => *r,
+        None => return,
+    };
+
+    // Catch clause labels are relative to the scope OUTSIDE the try_table.
+    // Inside the type checker, the try_table frame is on top of the stack,
+    // so we add 1 to convert from the catch clause's perspective to the checker's.
+    let label_depth = if label_ref.starts_with('$') {
+        checker.resolve_label_depth(label_ref)
+    } else {
+        label_ref.parse::<usize>().ok().map(|d| d + 1)
+    };
+
+    let label_depth = match label_depth {
+        Some(d) => d,
+        None => return,
+    };
+
+    // Get expected label types
+    let label_types = match checker.label_types(label_depth) {
+        Some(t) => t.to_vec(),
+        None => return,
+    };
+
+    // Compare: sent types must match label types in count and type
+    if sent_types.len() != label_types.len() {
+        checker.diagnostics.push(
+            Diagnostic::error(node_to_range(node), "type mismatch".to_string())
+                .with_code("type-mismatch"),
+        );
+        return;
+    }
+
+    for (sent, expected) in sent_types.iter().zip(label_types.iter()) {
+        if !types_compatible_with_symbols(sent, expected, symbols) {
+            checker.diagnostics.push(
+                Diagnostic::error(node_to_range(node), "type mismatch".to_string())
+                    .with_code("type-mismatch"),
+            );
+            return;
+        }
+    }
+}
+
+/// Extract heap type strings from br_on_cast/br_on_cast_fail instruction node.
+///
+/// Returns the two heap type text values (skipping the label index).
+fn extract_heap_types_from_cast<'a>(node: &Node, source: &'a str) -> Vec<&'a str> {
+    let mut types = Vec::new();
+    let mut cursor = node.walk();
+    let mut past_index = false;
+
+    for child in node.children(&mut cursor) {
+        let kind = child.kind();
+        // Skip the op_ prefix and label index
+        if (kind == "index" || kind == "identifier") && !past_index {
+            past_index = true; // First index is the label
+            continue;
+        }
+        if !past_index {
+            // Look inside op_ nodes for the label index
+            if kind.starts_with("op_") {
+                let mut inner = child.walk();
+                for ic in child.children(&mut inner) {
+                    if ic.kind() == "index" || ic.kind() == "identifier" {
+                        past_index = true;
+                        break;
+                    }
+                }
+            }
+            continue;
+        }
+        // After the label, collect heap type values
+        if kind == "ref_kind" || kind == "ref_type_ref" || kind == "index" || kind == "identifier" {
+            types.push(source[child.byte_range()].trim());
+        } else if kind.ends_with("ref") {
+            // Abbreviated forms like "anyref", "funcref", etc.
+            types.push(source[child.byte_range()].trim());
+        }
+    }
+    types
+}
+
+/// Check if `sub` is a valid subtype of `sup` in the heap type hierarchy.
+///
+/// Hierarchy (from spec):
+/// - any > eq > {i31, struct, array, $concrete_struct, $concrete_array}
+/// - func > $concrete_func
+/// - extern
+/// - none (bottom of any), nofunc (bottom of func), noextern (bottom of extern)
+///
+/// Concrete type indices ($name or numeric) are considered subtypes of `any`/`eq`/`func`
+/// depending on what they define (struct/array/func), but without the symbol table
+/// we conservatively treat them as subtypes of both `any` and `func` hierarchies.
+fn is_heap_subtype(sub: &str, sup: &str) -> bool {
+    if sub == sup {
+        return true;
+    }
+    // Normalize abbreviated ref types
+    let sub = normalize_heap_type(sub);
+    let sup = normalize_heap_type(sup);
+    if sub == sup {
+        return true;
+    }
+
+    let sub_is_concrete = is_concrete_type_ref(&sub);
+    let sup_is_concrete = is_concrete_type_ref(&sup);
+
+    // If either is a concrete type index, we can't fully validate without
+    // symbol table — be conservative and only flag clearly invalid casts
+    if sub_is_concrete || sup_is_concrete {
+        // Concrete types are subtypes of most abstract supertypes
+        // We don't have enough info to flag these, so allow them
+        return true;
+    }
+
+    match sup.as_str() {
+        "any" => matches!(
+            sub.as_str(),
+            "eq" | "i31" | "struct" | "array" | "none" | "null"
+        ),
+        "eq" => matches!(sub.as_str(), "i31" | "struct" | "array" | "none" | "null"),
+        "func" => sub == "nofunc",
+        "extern" => sub == "noextern",
+        "exn" => sub == "noexn",
+        "struct" => sub == "none" || sub == "null",
+        "array" => sub == "none" || sub == "null",
+        "i31" => sub == "none" || sub == "null",
+        _ => false,
+    }
+}
+
+/// Check if a heap type string refers to a concrete type (index or ref form).
+fn is_concrete_type_ref(ty: &str) -> bool {
+    ty.starts_with('$') || ty.starts_with("(ref") || ty.parse::<u32>().is_ok()
+}
+
+/// Normalize abbreviated heap type names to their canonical form.
+fn normalize_heap_type(ty: &str) -> String {
+    match ty {
+        "anyref" => "any".to_string(),
+        "funcref" => "func".to_string(),
+        "externref" => "extern".to_string(),
+        "eqref" => "eq".to_string(),
+        "i31ref" => "i31".to_string(),
+        "structref" => "struct".to_string(),
+        "arrayref" => "array".to_string(),
+        "nullref" => "null".to_string(),
+        "nullfuncref" => "nofunc".to_string(),
+        "nullexternref" => "noextern".to_string(),
+        "exnref" => "exn".to_string(),
+        "nullexnref" => "noexn".to_string(),
+        other => other.to_string(),
+    }
 }


### PR DESCRIPTION
## Summary

Spec test improvement: +18 passing (5970→5988), 99.0% pass rate, zero regressions.

- **assert_invalid**: 2650→2667 (+17)
- **assert_malformed**: 1228→1229 (now 100%!)
- **Modules (valid)**: 2092/2128 (unchanged, no regressions)

## Changes

- **Array bulk ops** (copy/fill/init_data/init_elem): mutability + element type validation
- **br_on_cast/br_on_cast_fail**: cast type hierarchy validation (source must be supertype)
- **try_table catch clauses**: handler type validation against target label types
- **throw_ref**: pop exnref operand from stack (was missing in terminator handler)
- **Duplicate struct fields**: duplicate field name detection in module_checks