### PR TITLE
feat: named ref resolution, implicit finality, and struct/array mutability checks

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -2,19 +2,20 @@
 
 **Generated**: 2026-02-20
 **Baseline**: commit 488fa6b4
-**Updated**: 2026-02-20 (Phase 1 complete)
+**Updated**: 2026-02-20 (Phase 1 complete, re-analyzed at commit 18da9a8c)
 
-## Current Results (after Phase 1)
+## Current Results
 
-| Category | Pass | Total | Rate | Delta |
+| Category | Pass | Total | Rate | Delta from baseline |
 |---|---|---|---|---|
 | Modules (valid) | 2092 | 2128 | 98.3% | +0 |
 | assert_invalid | 2667 | 2689 | 99.2% | **+17** |
 | assert_malformed | 1229 | 1229 | 100.0% | **+1** |
 | **TOTAL (non-skip)** | **5988** | **6046** | **99.0%** | **+18** |
-| Skipped (runtime) | 58577 | — | — | — |
+| Skipped (runtime) | 57766 | — | — | — |
+| Skipped (binary/linking) | 810 | — | — | — |
 
-**58 total failures** across 21 files (was 76 across 25).
+**58 total failures** across 21 files (down from 76 across 25 at baseline).
 
 ### Phase 1 Changes (completed)
 - **array.copy/fill/init_data/init_elem**: Element type validation (+7 assert_invalid)
@@ -23,7 +24,7 @@
 - **throw_ref**: Stack operand validation (+2 assert_invalid)
 - **struct duplicate fields**: Duplicate field name detection (+1 assert_malformed)
 
-## Previous Baseline
+## Baseline (pre-Phase 1)
 
 | Category | Pass | Total | Rate |
 |---|---|---|---|
@@ -32,140 +33,146 @@
 | assert_malformed | 1228 | 1229 | 99.9% |
 | **TOTAL (non-skip)** | **5970** | **6046** | **98.7%** |
 
-**76 total failures** across 25 files.
+## Per-File Failures (58 remaining)
 
-## Per-File Failures
-
-| File | Mod | Inv | Mal | Total |
+| File | Mod | Inv | Total | Root Cause |
 |---|---|---|---|---|
-| type-subtyping.wast | 11 | 7 | 0 | 18 |
-| type-rec.wast | 0 | 9 | 0 | 9 |
-| try_table.wast | 1 | 5 | 0 | 6 |
-| br_on_cast_fail.wast | 3 | 2 | 0 | 5 |
-| br_on_cast.wast | 3 | 2 | 0 | 5 |
-| array.wast | 4 | 0 | 0 | 4 |
-| return_call_ref.wast | 1 | 2 | 0 | 3 |
-| array_copy.wast | 0 | 3 | 0 | 3 |
-| instance.wast | 2 | 0 | 0 | 2 |
-| table.wast | 2 | 0 | 0 | 2 |
-| array_fill.wast | 0 | 2 | 0 | 2 |
-| array_init_elem.wast | 0 | 2 | 0 | 2 |
-| struct.wast | 0 | 1 | 1 | 2 |
-| throw_ref.wast | 0 | 2 | 0 | 2 |
-| annotations.wast | 1 | 0 | 0 | 1 |
-| call_indirect64.wast | 1 | 0 | 0 | 1 |
-| i31.wast | 1 | 0 | 0 | 1 |
-| id.wast | 1 | 0 | 0 | 1 |
-| memory.wast | 1 | 0 | 0 | 1 |
-| memory64.wast | 1 | 0 | 0 | 1 |
-| ref_as_non_null.wast | 0 | 1 | 0 | 1 |
-| stack.wast | 1 | 0 | 0 | 1 |
-| table-sub.wast | 1 | 0 | 0 | 1 |
-| table64.wast | 1 | 0 | 0 | 1 |
-| array_init_data.wast | 0 | 1 | 0 | 1 |
+| type-subtyping.wast | 11 | 7 | **18** | Subtype variance |
+| type-rec.wast | 0 | 9 | **9** | Rec type groups |
+| array.wast | 4 | 0 | **4** | Structref placeholder |
+| br_on_cast_fail.wast | 3 | 0 | **3** | Cast stack effects |
+| br_on_cast.wast | 3 | 0 | **3** | Cast stack effects |
+| return_call_ref.wast | 1 | 2 | **3** | Ref type resolution |
+| instance.wast | 2 | 0 | **2** | Definition syntax |
+| table.wast | 1 | 1 | **2** | Definition + structref |
+| try_table.wast | 1 | 1 | **2** | Import aliasing + type |
+| annotations.wast | 1 | 0 | **1** | Grammar |
+| array_copy.wast | 0 | 1 | **1** | Array type matching |
+| call_indirect64.wast | 1 | 0 | **1** | Table64 index type |
+| i31.wast | 1 | 0 | **1** | i31ref type |
+| id.wast | 1 | 0 | **1** | Quoted identifiers |
+| memory.wast | 1 | 0 | **1** | Definition syntax |
+| memory64.wast | 1 | 0 | **1** | Definition syntax |
+| ref_as_non_null.wast | 0 | 1 | **1** | Ref type narrowing |
+| stack.wast | 1 | 0 | **1** | Flat call_indirect |
+| struct.wast | 0 | 1 | **1** | GC field type |
+| table-sub.wast | 1 | 0 | **1** | Ref subtyping |
+| table64.wast | 1 | 0 | **1** | Definition syntax |
 
-## Failure Root Causes
+## Failure Root Causes (58 total)
 
-| Root Cause | Mod | Inv | Mal | Total | Description |
-|---|---|---|---|---|---|
-| GC rec types & subtyping | 11 | 16 | 0 | **27** | Recursive type groups, type equivalence across rec boundaries, variance violations |
-| GC instruction validation | 6 | 10 | 0 | **16** | br_on_cast/fail nullability, array ops mutability/types, try_table catch types |
-| Module definition syntax | 5 | 0 | 0 | **5** | `(module definition ...)` wast syntax (instance.wast, memory.wast, table.wast) |
-| Memory64/Table64 edge cases | 3 | 0 | 0 | **3** | 64-bit index types in memory.size, table ops, call_indirect64 |
-| Misc single-file issues | 11 | 13 | 1 | **25** | Quoted IDs, annotations, multi-value stack, throw_ref, struct field dup, ref_as_non_null |
+| Root Cause | Mod | Inv | Total | Description |
+|---|---|---|---|---|
+| Function subtype variance | 11 | 7 | **18** | `module_checks.rs` requires exact match; spec allows covariant returns + contravariant params |
+| Rec type groups | 0 | 9 | **9** | No rec group modeling; can't validate type equivalence or forward refs within rec |
+| GC concrete ref resolution | 8 | 0 | **8** | All concrete GC types map to Structref placeholder — loses arrayref/funcref/i31ref distinction |
+| br_on_cast/fail stack | 6 | 0 | **6** | Type checker doesn't model type narrowing after cast; false stack underflow |
+| Module definition syntax | 6 | 0 | **6** | `(module definition ...)` wast syntax not supported by grammar |
+| GC type checking gaps | 0 | 6 | **6** | Missing: array type match, ref narrowing, return_call_ref return types, struct fields |
+| Miscellaneous | 5 | 0 | **5** | Annotations grammar, call_indirect64, quoted IDs, flat call_indirect, imported tag aliasing |
 
 ## Prioritized Phases
 
-### Phase 1: GC Instruction Validation (~16 fixes)
-**Feasibility**: Medium | **Impact**: High
+### Phase 2: Function Subtype Variance (~18 fixes)
+**Feasibility**: Medium | **Impact**: Highest | **Files**: `module_checks.rs`
 
-Root cause: The type checker doesn't understand GC-specific instructions well enough.
+Root cause: The subtype check in `module_checks.rs` emits "Function subtype signature must match parent exactly" — it requires identical signatures. The spec allows:
+- **Covariant** return types (subtype may return a subtype of parent's return)
+- **Contravariant** param types (subtype may accept a supertype of parent's param)
 
-**Subphase 1a: Array operation type validation (+8)**
-- `array_copy.wast`: 3 invalid — need to check array element type compatibility and mutability for `array.copy`
-- `array_fill.wast`: 2 invalid — need to check `array.fill` element type (packed i8/i16 → i32 widening)
-- `array_init_data.wast`: 1 invalid — need to verify array type is numeric/vector for `array.init_data`
-- `array_init_elem.wast`: 2 invalid — need element type matching for `array.init_elem`
-- **Files**: `semantic.rs`, `type_check.rs`
+**Module fixes (11)**: type-subtyping.wast lines 177, 188, 229, 422, 438, 486, 497, 652, 659, 668, 677
+- All fail with "Function subtype signature must match parent exactly"
+- Fix: Replace exact-match with `is_subtype(sub_return, parent_return)` and `is_subtype(parent_param, sub_param)`
 
-**Subphase 1b: br_on_cast / br_on_cast_fail validation (+4)**
-- 2 invalid each for br_on_cast and br_on_cast_fail — nullability constraint on cast types
-- **Files**: `semantic.rs`, `type_check.rs`
+**Invalid fixes (7)**: type-subtyping.wast lines 139, 205, 215, 726, 734, 851, 883
+- "no errors (expected type mismatch/sub type)" — need to validate variance violations
+- Fix: Detect when subtype attempts *invalid* variance (contravariant returns, covariant params, `sub final` violations)
 
-**Subphase 1c: try_table catch type validation (+5)**
-- try_table.wast: 5 invalid — catch/catch_ref handler type mismatches
-- **Files**: `semantic.rs`, `type_check.rs`
+**Prerequisite**: Need `is_subtype(a, b)` for ValueType/ref types. Partial support exists (type_check.rs has `is_subtype_of` for stack checking); needs extension to handle concrete type indices.
 
-**Subphase 1d: Miscellaneous GC type checking (+4)**
-- return_call_ref.wast: 2 invalid — return type subtyping
-- throw_ref.wast: 2 invalid — exnref type on stack
-- ref_as_non_null.wast: 1 invalid — nullable→non-nullable cast type narrowing
-- struct.wast: 1 invalid — struct field type mismatch
-- **Files**: `semantic.rs`, `type_check.rs`
+### Phase 3: GC Concrete Type Resolution (~14 fixes)
+**Feasibility**: Hard | **Impact**: High | **Files**: `parser.rs`, `semantic.rs`, `type_check.rs`
 
-### Phase 2: GC Rec Types & Subtyping (~27 fixes)
-**Feasibility**: Hard | **Impact**: Highest
+Root cause: The parser maps all concrete GC types (`ref $my_array`, `ref $my_struct`, etc.) to `ValueType::Structref` as a placeholder. This means the type checker can't distinguish arrayref from structref from funcref at concrete type boundaries.
 
-Root cause: The parser/type system doesn't model recursive type groups (`rec`), so type equivalence across rec boundaries and subtype variance cannot be validated.
+**Module fixes (8)**:
+- array.wast: 4 — "expected arrayref, found structref" (concrete array type → should be arrayref)
+- table.wast:93 — "expected funcref, found structref" (concrete func type used as funcref)
+- table-sub.wast:1 — type mismatch on ref subtype table copy
+- return_call_ref.wast:213 — "expected (ref null 2), found (ref 1)" (concrete type refs)
+- i31.wast:128 — i31ref table init expression
 
-- type-subtyping.wast: 18 failures — need proper rec type group handling, covariant/contravariant field checking
-- type-rec.wast: 9 failures — need `rec` group type equivalence, forward references within rec groups
-- **Files**: `parser.rs` (type representation), `module_checks.rs` (subtype validation), `type_check.rs` (type matching)
-- **Prerequisite**: Need a proper GC type representation in the symbol table that tracks:
-  - Rec group membership and boundaries
-  - Structural type definitions (struct fields, array element, func params/results)
-  - Subtype declarations (`sub` / `sub final`)
-  - Type equivalence rules for iso-recursive types
+**Invalid fixes (6)**:
+- array_copy.wast:41 — "array types do not match" (needs concrete type tracking)
+- ref_as_non_null.wast:31, struct.wast:58, try_table.wast:470, return_call_ref.wast:231,286 — various type mismatches requiring concrete GC type knowledge
 
-### Phase 3: Module False Positives (~14 module fixes)
-**Feasibility**: Medium | **Impact**: Medium
+**Approach**: Add `ValueType::Ref(TypeIndex)` variant or enhance the symbol table to track concrete type kinds (struct/array/func) so subtype checks can query the structural type.
 
-**Subphase 3a: GC module validity (+10)**
-- br_on_cast.wast: 3 module — false positive errors on valid br_on_cast usage
-- br_on_cast_fail.wast: 3 module — same for br_on_cast_fail
-- array.wast: 4 module — false positive errors on valid array operations (rec types, GC refs)
-- **Root cause**: Lack of rec type awareness causes spurious "unknown type" or "type mismatch" errors
-- **Files**: `references.rs`, `module_checks.rs`, `semantic.rs`
+### Phase 4: Rec Type Groups (~9 fixes)
+**Feasibility**: Hard | **Impact**: Medium | **Files**: `parser.rs`, `module_checks.rs`
 
-**Subphase 3b: Memory/Table/Instance module syntax (+5)**
-- instance.wast: 2 — `(module definition ...)` wast syntax
-- memory.wast: 1 — same
-- table.wast: 2 — same
-- memory64.wast: 1 — 64-bit index type for memory.size
-- table64.wast: 1 — 64-bit index type for table operations
-- call_indirect64.wast: 1 — 64-bit call_indirect
-- **Files**: `wast-runner` (module definition parsing), `semantic.rs` (64-bit index types)
+Root cause: No modeling of `(rec ...)` type groups. The spec requires:
+- Types within the same rec group can forward-reference each other
+- Type equivalence is defined per rec group (iso-recursive)
+- Rec group boundaries affect type identity
 
-**Subphase 3c: Misc module fixes (+5)**
-- annotations.wast: 1 — quoted annotation names `(@"name")`
-- id.wast: 1 — quoted identifier normalization `$"fh"` ≡ `$fh`
-- i31.wast: 1 — i31ref table init expression
-- stack.wast: 1 — multi-value block stack validation
-- table-sub.wast: 1 — table copy with subtype refs
-- **Files**: `grammar.js`, `parser.rs`, `semantic.rs`
+**Fixes (9 invalid)**: type-rec.wast lines 28, 51, 59, 93, 103, 114, 124, 204, 216
+- Line 28: "expected unknown type" — rec group forward ref should be invalid when referencing beyond group
+- Lines 51+: "expected type mismatch" — rec type equivalence violations
 
-### Phase 4: Structural Validation (+2)
-**Feasibility**: Easy | **Impact**: Low
+**Approach**: Track rec group membership in symbol table; add rec group boundary checks to type validation.
 
-- struct.wast: 1 malformed — duplicate field detection in struct types
-- return_call_ref.wast: 1 module — return type subtyping validation
-- **Files**: `module_checks.rs`, `semantic.rs`
+### Phase 5: br_on_cast/fail Stack Modeling (~6 fixes)
+**Feasibility**: Medium | **Impact**: Medium | **Files**: `semantic.rs`, `type_check.rs`
+
+Root cause: `br_on_cast` and `br_on_cast_fail` have complex stack effects — they narrow the type on the stack based on the cast result. The current type checker doesn't model this, causing false "Stack underflow" and "type mismatch" errors.
+
+**Fixes (6 modules)**:
+- br_on_cast.wast: 3 (lines 3, 104, 211)
+- br_on_cast_fail.wast: 3 (lines 3, 104, 226)
+
+**Approach**: When processing `br_on_cast`, push the *difference type* (non-cast result) back onto the stack after the branch. Similarly for `br_on_cast_fail` (push the cast result type). Requires understanding the input type and cast target type.
+
+### Phase 6: Module Definition Syntax (~6 fixes)
+**Feasibility**: Easy | **Impact**: Low | **Files**: `wast-runner` or `grammar.js`
+
+Root cause: `(module definition ...)` is a WAST-only syntax for defining module instances. Not valid WAT — only appears in test harness contexts.
+
+**Fixes (6 modules)**:
+- instance.wast: 2 (lines 3, 109)
+- memory.wast:8, memory64.wast:8, table.wast:9, table64.wast:9
+
+**Approach**: Have wast-runner skip or handle `(module definition ...)` directives gracefully.
+
+### Phase 7: Miscellaneous (~5 fixes)
+**Feasibility**: Easy-Medium | **Impact**: Low
+
+| Fix | File | Issue |
+|---|---|---|
+| annotations.wast:1 | `grammar.js` | Annotation with special chars causes parse error at line 15 |
+| call_indirect64.wast:3 | `semantic.rs` | `table i64 funcref` — call_indirect with i64 table index |
+| id.wast:1 | `parser.rs` | `$"fh"` quoted identifier should normalize to `$fh` |
+| stack.wast:156 | `semantic.rs` | Flat (non-folded) call_indirect inside block — stack tracking |
+| try_table.wast:10 | `parser.rs` | Imported tag/func aliases not resolved across registered modules |
 
 ## Projected Pass Rates
 
-| Phase | Pass | Total | Rate | Delta |
-|---|---|---|---|---|
-| Baseline | 5970 | 6046 | 98.7% | — |
-| After Phase 1 | ~5986 | 6046 | ~99.0% | +16 |
-| After Phase 2 | ~6013 | 6046 | ~99.5% | +27 |
-| After Phase 3 | ~6027 | 6046 | ~99.7% | +14 |
-| After Phase 4 | ~6029 | 6046 | ~99.7% | +2 |
-
-**Remaining ~17 failures** after all phases would be primarily `(module definition)` wast syntax (not WAT) and edge cases requiring full iso-recursive type system.
+| Phase | Pass | Total | Rate | Delta | Cumulative |
+|---|---|---|---|---|---|
+| Current (Phase 1 done) | 5988 | 6046 | 99.04% | — | — |
+| After Phase 2 | ~6006 | 6046 | ~99.3% | +18 | +18 |
+| After Phase 3 | ~6020 | 6046 | ~99.6% | +14 | +32 |
+| After Phase 4 | ~6029 | 6046 | ~99.7% | +9 | +41 |
+| After Phase 5 | ~6035 | 6046 | ~99.8% | +6 | +47 |
+| After Phase 6 | ~6041 | 6046 | ~99.9% | +6 | +53 |
+| After Phase 7 | ~6046 | 6046 | ~100% | +5 | +58 |
 
 ## Recommended Next Step
 
-**Start with Phase 1a** (array operation type validation). It has the best effort-to-fix ratio:
-- 8 assert_invalid fixes from adding type checks for 4 array instructions
-- Self-contained changes in `semantic.rs` / `type_check.rs`
-- No prerequisite infrastructure changes needed
+**Start with Phase 2** (function subtype variance). It has the best effort-to-fix ratio:
+- 18 fixes (11 modules + 7 invalid) from a single file (`module_checks.rs`)
+- The existing "Function subtype signature must match parent exactly" check just needs covariant/contravariant awareness
+- No new data structures needed — just enhance the comparison logic
+- `is_subtype_of` already partially exists in `type_check.rs` — extend for ref types
+
+**Alternative quick wins**: Phase 6 (module definition syntax, 6 easy fixes) and Phase 7 (miscellaneous, 5 varied fixes) are simpler but lower impact.

--- a/src/diagnostics_core/subtype.rs
+++ b/src/diagnostics_core/subtype.rs
@@ -123,6 +123,12 @@ fn check_structural_compatibility(
                     }
                 } else {
                     // Immutable fields: covariant (child must be subtype of parent)
+                    if *child_mut {
+                        diagnostics.push(Diagnostic::error(
+                            range,
+                            format!("Struct field {} mutability mismatch", i),
+                        ));
+                    }
                     if !types_compatible_with_symbols(child_type, parent_type, symbols) {
                         diagnostics.push(Diagnostic::error(
                             range,
@@ -164,6 +170,12 @@ fn check_structural_compatibility(
                 }
             } else {
                 // Immutable array: covariant
+                if *child_mut {
+                    diagnostics.push(Diagnostic::error(
+                        range,
+                        "Array mutability mismatch".to_string(),
+                    ));
+                }
                 if !types_compatible_with_symbols(child_elem, parent_elem, symbols) {
                     diagnostics.push(Diagnostic::error(
                         range,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1173,7 +1173,15 @@ fn extract_types(root: &Node, source: &str, symbol_table: &mut SymbolTable) {
                     let mut field_cursor = module_child.walk();
                     for field_child in module_child.children(&mut field_cursor) {
                         if field_child.kind() == "module_field_type" {
-                            if let Some(type_def) = extract_type(&field_child, source, type_index) {
+                            if let Some(mut type_def) =
+                                extract_type(&field_child, source, type_index)
+                            {
+                                resolve_type_kind_refs(
+                                    &field_child,
+                                    source,
+                                    symbol_table,
+                                    &mut type_def.kind,
+                                );
                                 symbol_table.add_type(type_def);
                                 type_index += 1;
                             }
@@ -1189,7 +1197,13 @@ fn extract_types(root: &Node, source: &str, symbol_table: &mut SymbolTable) {
             let mut field_cursor = child.walk();
             for field_child in child.children(&mut field_cursor) {
                 if field_child.kind() == "module_field_type" {
-                    if let Some(type_def) = extract_type(&field_child, source, type_index) {
+                    if let Some(mut type_def) = extract_type(&field_child, source, type_index) {
+                        resolve_type_kind_refs(
+                            &field_child,
+                            source,
+                            symbol_table,
+                            &mut type_def.kind,
+                        );
                         symbol_table.add_type(type_def);
                         type_index += 1;
                     }
@@ -1202,19 +1216,26 @@ fn extract_types(root: &Node, source: &str, symbol_table: &mut SymbolTable) {
     }
 }
 
-/// Extract types from a rec group
+/// Extract types from a rec group.
+///
+/// Uses a two-pass approach: first adds all types to the symbol table (without resolving
+/// named refs), then resolves refs in a second pass. This handles self-referential and
+/// mutually-recursive types within rec groups.
 fn extract_rec_types(
     rec_node: &Node,
     source: &str,
     symbol_table: &mut SymbolTable,
     mut type_index: usize,
 ) -> usize {
-    // The rec node's children are flattened: "(", "rec", "(", "type", id?, type_field, ")", "(", "type", ..., ")", ")"
-    // We need to parse this as a sequence, looking for patterns: "(" "type" [id] type_field ")"
+    let start_type_index = type_index;
 
     let mut cursor = rec_node.walk();
     let children_vec: Vec<_> = rec_node.children(&mut cursor).collect();
 
+    // Track which children_vec positions hold type definition nodes (for pass 2)
+    let mut type_node_positions: Vec<usize> = Vec::new();
+
+    // Pass 1: extract types and add to symbol table (without resolving named refs)
     let mut i = 0;
     while i < children_vec.len() {
         let child = &children_vec[i];
@@ -1222,10 +1243,8 @@ fn extract_rec_types(
         // Look for pattern: "(" followed by "type"
         if child.kind() == "(" && i + 1 < children_vec.len() && children_vec[i + 1].kind() == "type"
         {
-            // Found start of a type definition
             i += 2; // Skip "(" and "type"
 
-            // Check for optional identifier
             let (name, name_range) =
                 if i < children_vec.len() && children_vec[i].kind() == "identifier" {
                     let id_node = &children_vec[i];
@@ -1238,7 +1257,6 @@ fn extract_rec_types(
                     (None, None)
                 };
 
-            // Next should be the type_field or direct struct_type/array_type
             if i < children_vec.len() {
                 let type_node = &children_vec[i];
                 if type_node.kind() == "struct_type"
@@ -1246,10 +1264,10 @@ fn extract_rec_types(
                     || type_node.kind() == "type_field"
                     || type_node.kind() == "sub_type"
                 {
-                    // Extract the type
                     if let Some(type_def) = extract_type_from_single_node(
                         type_node, source, type_index, name, name_range,
                     ) {
+                        type_node_positions.push(i);
                         symbol_table.add_type(type_def);
                         type_index += 1;
                     }
@@ -1257,19 +1275,239 @@ fn extract_rec_types(
                 }
             }
 
-            // Skip until we find the closing ")"
+            // Skip until closing ")"
             while i < children_vec.len() && children_vec[i].kind() != ")" {
                 i += 1;
             }
             if i < children_vec.len() && children_vec[i].kind() == ")" {
-                i += 1; // Skip the ")"
+                i += 1;
             }
         } else {
             i += 1;
         }
     }
 
+    // Pass 2: resolve named refs now that all rec group types are in the symbol table
+    for (offset, &node_pos) in type_node_positions.iter().enumerate() {
+        let sym_idx = start_type_index + offset;
+        let type_node = &children_vec[node_pos];
+        // Temporarily take the kind out to avoid borrow conflict
+        // (resolve_type_kind_refs needs &SymbolTable + &mut TypeKind)
+        let placeholder = TypeKind::Func {
+            params: Vec::new(),
+            results: Vec::new(),
+        };
+        let mut kind = std::mem::replace(&mut symbol_table.types[sym_idx].kind, placeholder);
+        resolve_type_kind_refs(type_node, source, symbol_table, &mut kind);
+        symbol_table.types[sym_idx].kind = kind;
+    }
+
     type_index
+}
+
+/// Resolve named type references in a TypeKind that were left as Structref placeholders.
+///
+/// During initial extraction, `extract_ref_type` can't resolve named indices like `$t1`
+/// because it doesn't have symbol table access. These fall back to `ValueType::Structref`.
+/// This function walks the AST structurally — matching func_type params/results,
+/// struct fields, and array elements — to resolve only the specific Structref values
+/// that came from named references.
+fn resolve_type_kind_refs(
+    type_ast: &Node,
+    source: &str,
+    symbols: &SymbolTable,
+    kind: &mut TypeKind,
+) {
+    resolve_refs_in_subtree(type_ast, source, symbols, kind);
+}
+
+/// Recursively search for the func_type/struct_type/array_type node and resolve refs.
+fn resolve_refs_in_subtree(node: &Node, source: &str, symbols: &SymbolTable, kind: &mut TypeKind) {
+    node_kind!(k = node);
+    match k {
+        "func_type" => {
+            if let TypeKind::Func { params, results } = kind {
+                resolve_func_type_refs(node, source, symbols, params, results);
+            }
+            return;
+        }
+        "struct_type" => {
+            if let TypeKind::Struct { fields } = kind {
+                resolve_struct_type_refs(node, source, symbols, fields);
+            }
+            return;
+        }
+        "array_type" => {
+            if let TypeKind::Array { element_type, .. } = kind {
+                resolve_array_type_refs(node, source, symbols, element_type);
+            }
+            return;
+        }
+        _ => {}
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        resolve_refs_in_subtree(&child, source, symbols, kind);
+    }
+}
+
+/// Resolve named refs in a func_type node, walking params then results positionally.
+fn resolve_func_type_refs(
+    func_type_node: &Node,
+    source: &str,
+    symbols: &SymbolTable,
+    params: &mut [ValueType],
+    results: &mut [ValueType],
+) {
+    let mut param_idx = 0;
+    let mut result_idx = 0;
+    let mut cursor = func_type_node.walk();
+    for child in func_type_node.children(&mut cursor) {
+        node_kind!(ck = child);
+        if ck == "func_type_params" {
+            let mut params_cursor = child.walk();
+            for param_child in child.children(&mut params_cursor) {
+                node_kind!(pk = param_child);
+                if pk == "func_type_params_one" || pk == "func_type_params_many" {
+                    let mut inner_cursor = param_child.walk();
+                    for inner_child in param_child.children(&mut inner_cursor) {
+                        if inner_child.kind() == "value_type" {
+                            try_resolve_at(&inner_child, source, symbols, params, &mut param_idx);
+                        }
+                    }
+                }
+            }
+        } else if ck == "func_type_results" {
+            let mut results_cursor = child.walk();
+            for result_child in child.children(&mut results_cursor) {
+                if result_child.kind() == "value_type" {
+                    try_resolve_at(&result_child, source, symbols, results, &mut result_idx);
+                }
+            }
+        }
+    }
+}
+
+/// Resolve named refs in a struct_type node, walking field_type children positionally.
+fn resolve_struct_type_refs(
+    struct_type_node: &Node,
+    source: &str,
+    symbols: &SymbolTable,
+    fields: &mut [(Option<String>, ValueType, bool)],
+) {
+    let mut field_idx = 0;
+    let mut cursor = struct_type_node.walk();
+    for child in struct_type_node.children(&mut cursor) {
+        if child.kind() == "field_type" {
+            let mut fc = child.walk();
+            for fc_child in child.children(&mut fc) {
+                if fc_child.kind() == "storage_type" {
+                    if field_idx < fields.len() && fields[field_idx].1 == ValueType::Structref {
+                        if let Some(resolved) =
+                            try_resolve_named_ref_in_subtree(&fc_child, source, symbols)
+                        {
+                            fields[field_idx].1 = resolved;
+                        }
+                    }
+                    field_idx += 1;
+                }
+            }
+        }
+    }
+}
+
+/// Resolve a named ref in an array_type node's storage_type child.
+fn resolve_array_type_refs(
+    array_type_node: &Node,
+    source: &str,
+    symbols: &SymbolTable,
+    element_type: &mut ValueType,
+) {
+    if *element_type != ValueType::Structref {
+        return;
+    }
+    let mut cursor = array_type_node.walk();
+    for child in array_type_node.children(&mut cursor) {
+        if child.kind() == "storage_type" {
+            if let Some(resolved) = try_resolve_named_ref_in_subtree(&child, source, symbols) {
+                *element_type = resolved;
+            }
+            return;
+        }
+    }
+}
+
+/// Try to resolve a Structref at `types[*idx]`, then increment `*idx`.
+fn try_resolve_at(
+    value_type_node: &Node,
+    source: &str,
+    symbols: &SymbolTable,
+    types: &mut [ValueType],
+    idx: &mut usize,
+) {
+    if *idx < types.len() && types[*idx] == ValueType::Structref {
+        if let Some(resolved) = try_resolve_named_ref_in_subtree(value_type_node, source, symbols) {
+            types[*idx] = resolved;
+        }
+    }
+    *idx += 1;
+}
+
+/// Recursively search a subtree for a `ref_type_concrete` or `ref_type_ref` with a named
+/// index, and resolve it via the symbol table.
+fn try_resolve_named_ref_in_subtree(
+    node: &Node,
+    source: &str,
+    symbols: &SymbolTable,
+) -> Option<ValueType> {
+    node_kind!(k = node);
+    if k == "ref_type_concrete" || k == "ref_type_ref" {
+        let mut cursor = node.walk();
+        let mut named_index = None;
+        let mut nullable = false;
+        let mut has_ref_kind = false;
+
+        for child in node.children(&mut cursor) {
+            node_kind!(ck = child);
+            match ck {
+                "index" => {
+                    let text = node_text(&child, source);
+                    if text.starts_with('$') {
+                        named_index = Some(text);
+                    }
+                }
+                "null" => nullable = true,
+                "ref_kind" => has_ref_kind = true,
+                _ => {
+                    if node_text(&child, source) == "null" {
+                        nullable = true;
+                    }
+                }
+            }
+        }
+
+        if !has_ref_kind {
+            if let Some(name) = named_index {
+                if let Some(type_def) = symbols.get_type_by_name(name) {
+                    let idx = type_def.index as u32;
+                    return Some(if nullable {
+                        ValueType::RefNull(idx)
+                    } else {
+                        ValueType::Ref(idx)
+                    });
+                }
+            }
+        }
+        return None;
+    }
+
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if let Some(resolved) = try_resolve_named_ref_in_subtree(&child, source, symbols) {
+            return Some(resolved);
+        }
+    }
+    None
 }
 
 /// Extract a type from a single node (struct_type, array_type, or type_field)
@@ -1285,11 +1523,13 @@ fn extract_type_from_single_node(
         results: Vec::new(),
     };
     let mut parent_ref: Option<String> = None;
-    let mut is_final = false;
+    let mut is_final = true;
 
     node_kind!(type_kind = type_node);
     match type_kind {
         "sub_type" => {
+            // sub without explicit "final" keyword defaults to non-final
+            is_final = false;
             // Process sub_type children: (sub final? index? def_type)
             let mut sub_cursor = type_node.walk();
             for sub_child in type_node.children(&mut sub_cursor) {
@@ -1475,11 +1715,13 @@ fn extract_type(type_node: &Node, source: &str, index: usize) -> Option<TypeDef>
         results: Vec::new(),
     };
     let mut parent_ref: Option<String> = None;
-    let mut is_final = false;
+    let mut is_final = true;
     let mut cursor = type_node.walk();
     for child in type_node.children(&mut cursor) {
         // Handle sub_type: (sub final? supertype_index? def_type)
         if child.kind() == "sub_type" {
+            // sub without explicit "final" keyword defaults to non-final
+            is_final = false;
             let mut sub_cursor = child.walk();
             for sub_child in child.children(&mut sub_cursor) {
                 node_kind!(sub_kind = sub_child);
@@ -1562,6 +1804,8 @@ fn extract_type(type_node: &Node, source: &str, index: usize) -> Option<TypeDef>
                     kind = extract_array_kind(&field_child, source);
                 } else if field_child.kind() == "sub_type" {
                     // Handle sub_type inside type_field: (sub final? index? def_type)
+                    // sub without explicit "final" keyword defaults to non-final
+                    is_final = false;
                     let mut sub_cursor = field_child.walk();
                     for sub_child in field_child.children(&mut sub_cursor) {
                         node_kind!(sub_kind = sub_child);


### PR DESCRIPTION
## Summary

- **Named type reference resolution**: Resolve named indices like `$t1` in type definitions that previously fell back to `Structref` placeholders. Walks the AST structurally (func params/results, struct fields, array elements) to match positions correctly. Two-pass approach for rec groups handles self-referential and mutually-recursive types.
- **Implicit finality**: Types declared without `sub` are now correctly treated as `sub final` per spec, catching invalid extensions of non-sub types.
- **Struct/array mutability mismatch**: Detect when a child type adds mutability to an immutable parent field (struct fields and array elements).

Spec test improvement: +15 passing (5988 → 6003), 58 → 43 failures, zero regressions.