### PR TITLE
defrag: replace inline cfg blocks with node_kind! macro, consolidate duplicates

### DIFF
--- a/src/diagnostics_core/alignment_checks.rs
+++ b/src/diagnostics_core/alignment_checks.rs
@@ -27,11 +27,7 @@ pub fn check_alignment(node: &Node, source: &str, symbols: &SymbolTable) -> Vec<
 
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        let kind = child.kind();
-        #[cfg(feature = "native")]
-        let kind_ref = kind;
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let kind_ref = &*kind;
+        node_kind!(kind_ref = child);
 
         match kind_ref {
             "op_index_opt_offset_opt_align_opt"
@@ -101,11 +97,7 @@ pub fn check_alignment(node: &Node, source: &str, symbols: &SymbolTable) -> Vec<
 fn parse_align_value_u64(node: &Node, source: &str) -> Option<u64> {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        let kind = child.kind();
-        #[cfg(feature = "native")]
-        let kind_ref = kind;
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let kind_ref = &*kind;
+        node_kind!(kind_ref = child);
 
         if kind_ref == "align_offset_value" {
             let text = &source[child.byte_range()];
@@ -119,11 +111,7 @@ fn parse_align_value_u64(node: &Node, source: &str) -> Option<u64> {
 fn parse_offset_value(node: &Node, source: &str) -> Option<u64> {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        let kind = child.kind();
-        #[cfg(feature = "native")]
-        let kind_ref = kind;
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let kind_ref = &*kind;
+        node_kind!(kind_ref = child);
 
         if kind_ref == "align_offset_value" {
             let text = &source[child.byte_range()];

--- a/src/diagnostics_core/arity.rs
+++ b/src/diagnostics_core/arity.rs
@@ -26,12 +26,7 @@ pub fn check_instruction_parameter_count(node: &Node, source: &str) -> Vec<Diagn
     }
 
     let first_child = &children[0];
-    let instr_kind = first_child.kind();
-
-    #[cfg(feature = "native")]
-    let instr_kind_ref = instr_kind;
-    #[cfg(all(feature = "wasm", not(feature = "native")))]
-    let instr_kind_ref = &*instr_kind;
+    node_kind!(instr_kind_ref = first_child);
 
     match instr_kind_ref {
         "op_index" | "op_index_opt" | "op_gc" | "op_exception" => {
@@ -40,11 +35,7 @@ pub fn check_instruction_parameter_count(node: &Node, source: &str) -> Vec<Diagn
                 .iter()
                 .skip(1)
                 .filter(|c| {
-                    let k = c.kind();
-                    #[cfg(feature = "native")]
-                    let k_ref = k;
-                    #[cfg(all(feature = "wasm", not(feature = "native")))]
-                    let k_ref = &*k;
+                    node_kind!(k_ref = c);
                     k_ref == "index" || k_ref == "ref_type"
                 })
                 .count();
@@ -63,11 +54,7 @@ pub fn check_instruction_parameter_count(node: &Node, source: &str) -> Vec<Diagn
                 .iter()
                 .skip(1)
                 .filter(|c| {
-                    let k = c.kind();
-                    #[cfg(feature = "native")]
-                    let k_ref = k;
-                    #[cfg(all(feature = "wasm", not(feature = "native")))]
-                    let k_ref = &*k;
+                    node_kind!(k_ref = c);
                     matches!(k_ref, "int" | "float")
                 })
                 .count();
@@ -79,11 +66,7 @@ pub fn check_instruction_parameter_count(node: &Node, source: &str) -> Vec<Diagn
                 .iter()
                 .skip(1)
                 .filter(|c| {
-                    let k = c.kind();
-                    #[cfg(feature = "native")]
-                    let k_ref = k;
-                    #[cfg(all(feature = "wasm", not(feature = "native")))]
-                    let k_ref = &*k;
+                    node_kind!(k_ref = c);
                     matches!(k_ref, "index" | "expr")
                 })
                 .count();
@@ -95,11 +78,7 @@ pub fn check_instruction_parameter_count(node: &Node, source: &str) -> Vec<Diagn
                 .iter()
                 .skip(1)
                 .filter(|c| {
-                    let k = c.kind();
-                    #[cfg(feature = "native")]
-                    let k_ref = k;
-                    #[cfg(all(feature = "wasm", not(feature = "native")))]
-                    let k_ref = &*k;
+                    node_kind!(k_ref = c);
                     k_ref == "index"
                 })
                 .count();

--- a/src/diagnostics_core/gc_checks.rs
+++ b/src/diagnostics_core/gc_checks.rs
@@ -124,11 +124,7 @@ fn extract_two_indices(node: &Node, source: &str) -> Option<(String, String)> {
     let mut cursor = node.walk();
 
     for child in node.children(&mut cursor) {
-        let kind = child.kind();
-        #[cfg(feature = "native")]
-        let kind_ref = kind;
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let kind_ref = &*kind;
+        node_kind!(kind_ref = child);
 
         if kind_ref == "index" {
             // Index node may contain identifier or nat child
@@ -151,11 +147,7 @@ fn extract_two_indices(node: &Node, source: &str) -> Option<(String, String)> {
 fn extract_index_value(node: &Node, source: &str) -> String {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        let kind = child.kind();
-        #[cfg(feature = "native")]
-        let kind_ref = kind;
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let kind_ref = &*kind;
+        node_kind!(kind_ref = child);
 
         if kind_ref == "identifier" || kind_ref == "nat" {
             return source[child.byte_range()].trim().to_string();

--- a/src/diagnostics_core/memory_checks.rs
+++ b/src/diagnostics_core/memory_checks.rs
@@ -103,11 +103,7 @@ fn get_memory_for_instruction<'a>(
 ) -> Option<&'a crate::symbols::Memory> {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        let kind = child.kind();
-        #[cfg(feature = "native")]
-        let kind_ref = kind;
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let kind_ref = &*kind;
+        node_kind!(kind_ref = child);
 
         if kind_ref == "index" {
             let index_text = &source[child.byte_range()];

--- a/src/diagnostics_core/module_checks.rs
+++ b/src/diagnostics_core/module_checks.rs
@@ -667,14 +667,7 @@ fn check_inline_type_mismatches(
             node_kind!(ck = child);
             match ck {
                 "type_use" => {
-                    #[cfg(feature = "native")]
-                    {
-                        type_use_node = Some(child);
-                    }
-                    #[cfg(all(feature = "wasm", not(feature = "native")))]
-                    {
-                        type_use_node = Some(child.clone());
-                    }
+                    type_use_node = Some(node_copy!(&child));
                 }
                 "func_type_params" => {
                     has_inline_sig = true;
@@ -1302,7 +1295,7 @@ fn has_explicit_nullable_type(elem_node: &Node, source: &str) -> bool {
     for child in elem_node.children(&mut cursor) {
         node_kind!(ck = child);
         if ck == "elem_list" || ck == "ref_type" || ck == "value_type" {
-            let text = node_text(&child, source).trim().to_string();
+            let text = node_text(&child, source).trim();
             if text == "funcref" || text == "externref" {
                 return true;
             }
@@ -1311,7 +1304,7 @@ fn has_explicit_nullable_type(elem_node: &Node, source: &str) -> bool {
             for gc in child.children(&mut ec) {
                 node_kind!(gk = gc);
                 if gk == "ref_type" || gk == "ref_type_funcref" || gk == "ref_type_externref" {
-                    let gtext = node_text(&gc, source).trim().to_string();
+                    let gtext = node_text(&gc, source).trim();
                     if gtext == "funcref" || gtext == "externref" {
                         return true;
                     }
@@ -1580,41 +1573,23 @@ fn check_ref_func_declarations(
     symbols: &SymbolTable,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
-    // Step 1: Collect all functions declared in element segments
+    // Step 1: Collect all functions declared via elem segments, tables, globals, and exports
     let mut declared_funcs: HashSet<usize> = HashSet::new();
     for_each_module_field(module, |field| {
         node_kind!(fk = field);
-        if fk != "module_field_elem" {
-            return;
-        }
-        collect_elem_declared_funcs(field, source, symbols, &mut declared_funcs);
-    });
-
-    // Also collect functions referenced in inline elem expressions on tables
-    for_each_module_field(module, |field| {
-        node_kind!(fk = field);
-        if fk != "module_field_table" {
-            return;
-        }
-        collect_inline_table_elem_funcs(field, source, symbols, &mut declared_funcs);
-    });
-
-    // Also collect functions referenced via ref.func in global/table init expressions
-    // Per spec, ref.func in const init contexts counts as a function declaration
-    for_each_module_field(module, |field| {
-        node_kind!(fk = field);
-        if fk == "module_field_global" || fk == "module_field_table" {
-            collect_ref_func_in_const_expr(field, source, symbols, &mut declared_funcs);
-        }
-    });
-
-    // Also collect exported functions — per spec, exported functions are considered "declared"
-    for_each_module_field(module, |field| {
-        node_kind!(fk = field);
         match fk {
+            "module_field_elem" => {
+                collect_elem_declared_funcs(field, source, symbols, &mut declared_funcs);
+            }
+            "module_field_table" => {
+                collect_inline_table_elem_funcs(field, source, symbols, &mut declared_funcs);
+                collect_ref_func_in_const_expr(field, source, symbols, &mut declared_funcs);
+            }
+            "module_field_global" => {
+                collect_ref_func_in_const_expr(field, source, symbols, &mut declared_funcs);
+            }
             "module_field_export" => {
-                // Standalone export: (export "name" (func $idx))
-                collect_exported_func(field, source, symbols, &mut declared_funcs);
+                find_exported_func_recursive(field, source, symbols, &mut declared_funcs);
             }
             "module_field_func" => {
                 // Inline export: (func $f (export "name") ...)
@@ -1628,7 +1603,6 @@ fn check_ref_func_declarations(
                     }
                 }
                 if has_export {
-                    // Find the function's index from its identifier or position
                     let mut cursor2 = field.walk();
                     for child in field.children(&mut cursor2) {
                         node_kind!(ck = child);
@@ -1650,17 +1624,7 @@ fn check_ref_func_declarations(
     collect_ref_func_errors(module, source, symbols, &declared_funcs, diagnostics);
 }
 
-/// Collect function index from a standalone export node: (export "name" (func $idx))
-fn collect_exported_func(
-    export_node: &Node,
-    source: &str,
-    symbols: &SymbolTable,
-    declared: &mut HashSet<usize>,
-) {
-    // Walk recursively to find export_desc_func (nested inside export_desc)
-    find_exported_func_recursive(export_node, source, symbols, declared);
-}
-
+/// Find export_desc_func nodes recursively and collect their function indices.
 fn find_exported_func_recursive(
     node: &Node,
     source: &str,
@@ -2005,34 +1969,22 @@ fn check_duplicate_locals(symbols: &SymbolTable, diagnostics: &mut Vec<Diagnosti
     for func in &symbols.functions {
         let mut seen: HashMap<&str, Range> = HashMap::new();
 
-        // Check parameters first
-        for param in &func.parameters {
-            if let Some(ref name) = param.name {
-                if let Some(ref range) = param.range {
-                    if let Some(_first) = seen.get(name.as_str()) {
-                        diagnostics.push(Diagnostic::error(
-                            *range,
-                            format!("duplicate local {}", name),
-                        ));
-                    } else {
-                        seen.insert(name, *range);
-                    }
-                }
-            }
-        }
+        // Check parameters then locals (locals also conflict with params)
+        let entries = func
+            .parameters
+            .iter()
+            .map(|p| (&p.name, &p.range))
+            .chain(func.locals.iter().map(|l| (&l.name, &l.range)));
 
-        // Check locals (also conflicts with params)
-        for local in &func.locals {
-            if let Some(ref name) = local.name {
-                if let Some(ref range) = local.range {
-                    if let Some(_first) = seen.get(name.as_str()) {
-                        diagnostics.push(Diagnostic::error(
-                            *range,
-                            format!("duplicate local {}", name),
-                        ));
-                    } else {
-                        seen.insert(name, *range);
-                    }
+        for (name, range) in entries {
+            if let (Some(name), Some(range)) = (name, range) {
+                if seen.contains_key(name.as_str()) {
+                    diagnostics.push(Diagnostic::error(
+                        *range,
+                        format!("duplicate local {}", name),
+                    ));
+                } else {
+                    seen.insert(name, *range);
                 }
             }
         }
@@ -2196,8 +2148,7 @@ fn check_ref_for_forward_type(
 /// Count unique implicit function types (signatures not matching any explicit type).
 /// Only functions with inline signatures (no type_use) create implicit types.
 fn count_unique_implicit_types(symbols: &SymbolTable) -> usize {
-    // Use HashSet for O(1) dedup instead of O(n) Vec.any()
-    let mut seen = std::collections::HashSet::new();
+    let mut seen: HashSet<(Vec<ValueType>, Vec<ValueType>)> = HashSet::new();
     for type_def in &symbols.types {
         if let TypeKind::Func { params, results } = &type_def.kind {
             seen.insert((params.clone(), results.clone()));
@@ -3258,6 +3209,37 @@ fn check_block_node_type_use(
     }
 }
 
+macro_rules! check_block_children_for_type_use_body {
+    ($node:ident, $source:ident, $type_use_node:ident, $has_inline_sig:ident, $inline_params:ident, $inline_results:ident) => {{
+        let mut cursor = $node.walk();
+        for child in $node.children(&mut cursor) {
+            node_kind!(ck = child);
+            match ck {
+                "type_use" => *$type_use_node = Some(node_copy!(&child)),
+                "func_type_params" | "func_type_params_many" => {
+                    *$has_inline_sig = true;
+                    collect_value_types_recursive(&child, $source, $inline_params);
+                }
+                "func_type_results" => {
+                    *$has_inline_sig = true;
+                    collect_value_types_recursive(&child, $source, $inline_results);
+                }
+                "block_block" | "loop_block" | "block_if" | "if_block" | "block_try_table"
+                | "block_try" => {
+                    check_block_children_for_type_use(
+                        &child,
+                        $source,
+                        $type_use_node,
+                        $has_inline_sig,
+                        $inline_params,
+                        $inline_results,
+                    );
+                }
+                _ => {}
+            }
+        }
+    }};
+}
 #[cfg(feature = "native")]
 fn check_block_children_for_type_use<'a>(
     node: &Node<'a>,
@@ -3267,36 +3249,15 @@ fn check_block_children_for_type_use<'a>(
     inline_params: &mut Vec<String>,
     inline_results: &mut Vec<String>,
 ) {
-    let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
-        let ck = child.kind();
-        match ck {
-            "type_use" => *type_use_node = Some(child),
-            "func_type_params" | "func_type_params_many" => {
-                *has_inline_sig = true;
-                collect_value_types_recursive(&child, source, inline_params);
-            }
-            "func_type_results" => {
-                *has_inline_sig = true;
-                collect_value_types_recursive(&child, source, inline_results);
-            }
-            "block_block" | "loop_block" | "block_if" | "if_block" | "block_try_table"
-            | "block_try" => {
-                // Recurse one level
-                check_block_children_for_type_use(
-                    &child,
-                    source,
-                    type_use_node,
-                    has_inline_sig,
-                    inline_params,
-                    inline_results,
-                );
-            }
-            _ => {}
-        }
-    }
+    check_block_children_for_type_use_body!(
+        node,
+        source,
+        type_use_node,
+        has_inline_sig,
+        inline_params,
+        inline_results
+    )
 }
-
 #[cfg(all(feature = "wasm", not(feature = "native")))]
 fn check_block_children_for_type_use(
     node: &Node,
@@ -3306,34 +3267,14 @@ fn check_block_children_for_type_use(
     inline_params: &mut Vec<String>,
     inline_results: &mut Vec<String>,
 ) {
-    let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
-        let ck = child.kind();
-        let ck = ck.as_str();
-        match ck {
-            "type_use" => *type_use_node = Some(child.clone()),
-            "func_type_params" | "func_type_params_many" => {
-                *has_inline_sig = true;
-                collect_value_types_recursive(&child, source, inline_params);
-            }
-            "func_type_results" => {
-                *has_inline_sig = true;
-                collect_value_types_recursive(&child, source, inline_results);
-            }
-            "block_block" | "loop_block" | "block_if" | "if_block" | "block_try_table"
-            | "block_try" => {
-                check_block_children_for_type_use(
-                    &child,
-                    source,
-                    type_use_node,
-                    has_inline_sig,
-                    inline_params,
-                    inline_results,
-                );
-            }
-            _ => {}
-        }
-    }
+    check_block_children_for_type_use_body!(
+        node,
+        source,
+        type_use_node,
+        has_inline_sig,
+        inline_params,
+        inline_results
+    )
 }
 
 // ============================================================================

--- a/src/diagnostics_core/references.rs
+++ b/src/diagnostics_core/references.rs
@@ -201,15 +201,8 @@ fn find_undefined_identifiers(
         let in_index = node
             .parent()
             .map(|p| {
-                let pk = p.kind();
-                #[cfg(feature = "native")]
-                {
-                    pk == "index"
-                }
-                #[cfg(all(feature = "wasm", not(feature = "native")))]
-                {
-                    &*pk == "index"
-                }
+                node_kind!(pk = p);
+                pk == "index"
             })
             .unwrap_or(false);
 

--- a/src/diagnostics_core/simd_checks.rs
+++ b/src/diagnostics_core/simd_checks.rs
@@ -20,11 +20,7 @@ pub fn check_simd_lane_index(node: &Node, source: &str) -> Vec<Diagnostic> {
 
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        let kind = child.kind();
-        #[cfg(feature = "native")]
-        let kind_ref = kind;
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let kind_ref = &*kind;
+        node_kind!(kind_ref = child);
 
         if kind_ref == "op_simd_lane" {
             // op_simd_lane contains instr_name + int children
@@ -34,11 +30,7 @@ pub fn check_simd_lane_index(node: &Node, source: &str) -> Vec<Diagnostic> {
                 // Collect all int children and validate
                 let mut int_cursor = child.walk();
                 for int_child in child.children(&mut int_cursor) {
-                    let int_kind = int_child.kind();
-                    #[cfg(feature = "native")]
-                    let int_kind_ref = int_kind;
-                    #[cfg(all(feature = "wasm", not(feature = "native")))]
-                    let int_kind_ref = &*int_kind;
+                    node_kind!(int_kind_ref = int_child);
 
                     if int_kind_ref == "int" {
                         if let Some(diag) = validate_lane_value(&int_child, source, max_lane) {
@@ -55,11 +47,7 @@ pub fn check_simd_lane_index(node: &Node, source: &str) -> Vec<Diagnostic> {
                 // Find the int sibling (last int child of the instr_plain parent)
                 let mut parent_cursor = node.walk();
                 for sibling in node.children(&mut parent_cursor) {
-                    let sib_kind = sibling.kind();
-                    #[cfg(feature = "native")]
-                    let sib_kind_ref = sib_kind;
-                    #[cfg(all(feature = "wasm", not(feature = "native")))]
-                    let sib_kind_ref = &*sib_kind;
+                    node_kind!(sib_kind_ref = sibling);
 
                     if sib_kind_ref == "int" {
                         if let Some(diag) = validate_lane_value(&sibling, source, max_lane) {
@@ -81,11 +69,7 @@ fn find_instr_name(node: &Node, source: &str) -> String {
     let mut name = String::new();
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        let kind = child.kind();
-        #[cfg(feature = "native")]
-        let kind_ref = kind;
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let kind_ref = &*kind;
+        node_kind!(kind_ref = child);
 
         if kind_ref == "instr_name" {
             name.push_str(&source[child.byte_range()]);

--- a/src/diagnostics_core/tree_walk.rs
+++ b/src/diagnostics_core/tree_walk.rs
@@ -45,13 +45,7 @@ pub fn walk_tree_for_diagnostics(
     config: &DiagnosticConfig,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
-    let kind = node.kind();
-
-    // Normalize kind for cross-platform matching
-    #[cfg(feature = "native")]
-    let kind_str = kind;
-    #[cfg(all(feature = "wasm", not(feature = "native")))]
-    let kind_str = &*kind;
+    node_kind!(kind_str = node);
 
     // Check for packed types (i8/i16) used in value type positions (params, results, locals, globals)
     if kind_str == "ERROR" {

--- a/src/features/hover/mod.rs
+++ b/src/features/hover/mod.rs
@@ -581,37 +581,17 @@ fn provide_annotation_hover(
                 node_kind!(child_kind = child);
 
                 if child_kind == "identifier_pattern" {
-                    #[cfg(feature = "native")]
-                    let start = child.start_byte();
-                    #[cfg(feature = "native")]
-                    let end = child.end_byte();
-                    #[cfg(all(feature = "wasm", not(feature = "native")))]
-                    let start = child.start_byte();
-                    #[cfg(all(feature = "wasm", not(feature = "native")))]
-                    let end = child.end_byte();
-
-                    let annotation_name = &document[start..end];
+                    let annotation_name = &document[child.start_byte()..child.end_byte()];
                     return Some(format_annotation_hover(annotation_name));
                 }
             }
             return None;
         }
 
-        #[cfg(feature = "native")]
-        {
-            if let Some(parent) = current.parent() {
-                current = parent;
-            } else {
-                break;
-            }
-        }
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        {
-            if let Some(parent) = current.parent() {
-                current = parent;
-            } else {
-                break;
-            }
+        if let Some(parent) = current.parent() {
+            current = parent;
+        } else {
+            break;
         }
     }
 


### PR DESCRIPTION
## Summary

- Replace 16 inline kind-normalization `#[cfg]` blocks with `node_kind!` macro across 7 files
- Consolidate `check_block_children_for_type_use` duplicate into shared body macro
- Merge 4 `for_each_module_field` passes into 1 in `check_ref_func_declarations`
- DRY up `check_duplicate_locals` with iterator chain
- Remove unnecessary `.to_string()` allocations and redundant identical cfg blocks
- Inline trivial `collect_exported_func` wrapper

Net: -167 lines (88 added, 255 removed), 9 files changed. Zero test regressions, zero clippy warnings.