### PR TITLE
fix annotations, call_indirect64, and quoted identifier spec test failures

### DIFF
--- a/grammars/tree-sitter-wat/grammar.js
+++ b/grammars/tree-sitter-wat/grammar.js
@@ -14,7 +14,7 @@ const imm = rule => token.immediate(rule);
 module.exports = grammar({
   name: "wat",
 
-  externals: $ => [$.comment_block, $.comment_block_annot],
+  externals: $ => [$.comment_block, $.comment_block_annot, $.annotation],
 
   extras: $ => [$.annotation, $.comment_block, $.comment_line, /[\s\uFEFF\u2060\u200B\u00A0]/],
 
@@ -27,16 +27,7 @@ module.exports = grammar({
 
     align_offset_value: $ => imm(/[0-9]+(_?[0-9]+)*|0x[0-9A-Fa-f]+(_?[0-9A-Fa-f]+)*/),
 
-    // proposal: annotations
-    annotation: $ => seq("(@", choice($.identifier_pattern, $.string), repeat($.annotation_part), ")"),
-
-    // proposal: annotations
-    annotation_parens: $ => seq("(", repeat($.annotation_part), ")"),
-
-    // proposal: annotations
-    // proposal: annotations
-    annotation_part: $ =>
-      choice($.comment_block_annot, $.comment_line_annot, $.annotation_parens, $.reserved, $.identifier, $.string),
+    // proposal: annotations (handled by external scanner)
 
     custom_annotation: $ => seq(
       /@[0-9A-Za-z!#$%&'*+-./:<=>?@\\^_'|~]+/,
@@ -73,7 +64,6 @@ module.exports = grammar({
 
     comment_line: $ => prec.left(token(seq(";;", /.*/))),
 
-    comment_line_annot: $ => prec.left(token(seq(";;", /.*/))),
 
     dec_float: $ =>
       token(
@@ -944,7 +934,7 @@ module.exports = grammar({
     string: $ => seq('"', repeat(choice(imm(prec(PREC.STRING, /[^"\\\n]+|\\\r?\n/)), $.escape_sequence)), '"'),
 
     table_fields_elem: $ =>
-      seq($.ref_type, "(", "elem", choice(repeat($.index), seq($.elem_expr, repeat($.elem_expr))), ")"),
+      seq(optional($.table64_type), $.ref_type, "(", "elem", choice(repeat($.index), seq($.elem_expr, repeat($.elem_expr))), ")"),
 
     table_fields_type: $ => seq(optional($.import), $.table_type, optional($.expr)),
 

--- a/grammars/tree-sitter-wat/src/scanner.c
+++ b/grammars/tree-sitter-wat/src/scanner.c
@@ -1,17 +1,20 @@
-// External scanner for nested block comments in WAT.
+// External scanner for nested block comments and annotations in WAT.
 //
 // Tree-sitter's stateless lexer cannot track nesting depth, so we handle
-// block comments (which nest per the WAT spec) with a custom scanner.
+// block comments (which nest per the WAT spec) and annotations (which
+// contain strings with ')' characters) with a custom scanner.
 //
-// The two external tokens are:
+// The three external tokens are:
 //   0 - COMMENT_BLOCK       (used in extras)
 //   1 - COMMENT_BLOCK_ANNOT (used inside annotation_part)
+//   2 - ANNOTATION          (entire annotation including parens)
 
 #include "tree_sitter/parser.h"
 
 enum TokenType {
   COMMENT_BLOCK,
   COMMENT_BLOCK_ANNOT,
+  ANNOTATION,
 };
 
 void *tree_sitter_wat_external_scanner_create(void) {
@@ -73,6 +76,95 @@ static bool scan_block_comment(TSLexer *lexer) {
   return false;
 }
 
+/// Scan an annotation starting after the '(' has been consumed.
+/// The lexer should be positioned at '@'.
+/// Tracks paren depth, skipping strings and comments.
+/// Returns true when the matching ')' is found.
+static bool scan_annotation(TSLexer *lexer) {
+  // We expect '@' next
+  if (lexer->lookahead != '@') return false;
+  lexer->advance(lexer, false);
+
+  // Paren depth starts at 1 (the opening '(' was already consumed)
+  int depth = 1;
+
+  while (depth > 0 && !lexer->eof(lexer)) {
+    switch (lexer->lookahead) {
+      case '"':
+        // Skip string literal (handles \\, \", and other escapes)
+        lexer->advance(lexer, false);
+        while (!lexer->eof(lexer) && lexer->lookahead != '"') {
+          if (lexer->lookahead == '\\') {
+            lexer->advance(lexer, false); // skip backslash
+            if (!lexer->eof(lexer)) {
+              lexer->advance(lexer, false); // skip escaped char
+            }
+          } else {
+            lexer->advance(lexer, false);
+          }
+        }
+        if (!lexer->eof(lexer)) {
+          lexer->advance(lexer, false); // skip closing '"'
+        }
+        break;
+
+      case '(':
+        lexer->advance(lexer, false);
+        if (lexer->lookahead == ';') {
+          // Block comment — skip nested (;...;)
+          lexer->advance(lexer, false);
+          int comment_depth = 1;
+          while (comment_depth > 0 && !lexer->eof(lexer)) {
+            if (lexer->lookahead == '(') {
+              lexer->advance(lexer, false);
+              if (lexer->lookahead == ';') {
+                comment_depth++;
+                lexer->advance(lexer, false);
+              }
+            } else if (lexer->lookahead == ';') {
+              lexer->advance(lexer, false);
+              if (lexer->lookahead == ')') {
+                comment_depth--;
+                lexer->advance(lexer, false);
+              }
+            } else {
+              lexer->advance(lexer, false);
+            }
+          }
+        } else {
+          // Nested paren
+          depth++;
+        }
+        break;
+
+      case ';':
+        lexer->advance(lexer, false);
+        if (lexer->lookahead == ';') {
+          // Line comment — skip to end of line
+          while (!lexer->eof(lexer) && lexer->lookahead != '\n') {
+            lexer->advance(lexer, false);
+          }
+        }
+        // If it was ';' followed by ')', that's just ';' then ')' — ')' handled next iteration
+        break;
+
+      case ')':
+        depth--;
+        lexer->advance(lexer, false);
+        if (depth == 0) {
+          return true;
+        }
+        break;
+
+      default:
+        lexer->advance(lexer, false);
+        break;
+    }
+  }
+
+  return false;
+}
+
 bool tree_sitter_wat_external_scanner_scan(
   void *payload,
   TSLexer *lexer,
@@ -81,7 +173,7 @@ bool tree_sitter_wat_external_scanner_scan(
   (void)payload;
 
   // Only attempt if at least one of our symbols is valid
-  if (!valid_symbols[COMMENT_BLOCK] && !valid_symbols[COMMENT_BLOCK_ANNOT]) {
+  if (!valid_symbols[COMMENT_BLOCK] && !valid_symbols[COMMENT_BLOCK_ANNOT] && !valid_symbols[ANNOTATION]) {
     return false;
   }
 
@@ -97,16 +189,52 @@ bool tree_sitter_wat_external_scanner_scan(
   // Mark the start position
   lexer->mark_end(lexer);
 
-  if (!scan_block_comment(lexer)) return false;
+  // Peek at next char to distinguish (;...) block comment vs (@...) annotation
+  lexer->advance(lexer, false);
 
-  lexer->mark_end(lexer);
-
-  // Prefer COMMENT_BLOCK_ANNOT when both are valid (annotation context)
-  if (valid_symbols[COMMENT_BLOCK_ANNOT]) {
-    lexer->result_symbol = COMMENT_BLOCK_ANNOT;
-  } else {
-    lexer->result_symbol = COMMENT_BLOCK;
+  if (lexer->lookahead == '@' && valid_symbols[ANNOTATION]) {
+    // Annotation: (@name ...)
+    if (!scan_annotation(lexer)) return false;
+    lexer->mark_end(lexer);
+    lexer->result_symbol = ANNOTATION;
+    return true;
   }
 
-  return true;
+  if (lexer->lookahead == ';' && (valid_symbols[COMMENT_BLOCK] || valid_symbols[COMMENT_BLOCK_ANNOT])) {
+    // Block comment: (; ... ;)
+    // scan_block_comment expects lexer at '(' but we already consumed it.
+    // Consume the ';' and then scan the body directly.
+    lexer->advance(lexer, false);
+
+    int depth = 1;
+    while (depth > 0 && !lexer->eof(lexer)) {
+      if (lexer->lookahead == '(') {
+        lexer->advance(lexer, false);
+        if (lexer->lookahead == ';') {
+          depth++;
+          lexer->advance(lexer, false);
+        }
+      } else if (lexer->lookahead == ';') {
+        lexer->advance(lexer, false);
+        if (lexer->lookahead == ')') {
+          depth--;
+          if (depth == 0) {
+            lexer->advance(lexer, false);
+            lexer->mark_end(lexer);
+            if (valid_symbols[COMMENT_BLOCK_ANNOT]) {
+              lexer->result_symbol = COMMENT_BLOCK_ANNOT;
+            } else {
+              lexer->result_symbol = COMMENT_BLOCK;
+            }
+            return true;
+          }
+          lexer->advance(lexer, false);
+        }
+      } else {
+        lexer->advance(lexer, false);
+      }
+    }
+  }
+
+  return false;
 }

--- a/src/bin/wast-runner.rs
+++ b/src/bin/wast-runner.rs
@@ -142,16 +142,34 @@ fn find_matching_close_paren(source: &str, start: usize) -> Option<usize> {
             continue;
         }
         match bytes[i] {
-            b'(' => depth += 1,
+            b'"' => {
+                // String literal — skip, handling escape sequences
+                i += 1;
+                while i < bytes.len() && bytes[i] != b'"' {
+                    if bytes[i] == b'\\' {
+                        i += 1; // skip backslash
+                    }
+                    i += 1;
+                }
+                if i < bytes.len() {
+                    i += 1; // skip closing '"'
+                }
+            }
+            b'(' => {
+                depth += 1;
+                i += 1;
+            }
             b')' => {
                 depth -= 1;
                 if depth == 0 {
                     return Some(i);
                 }
+                i += 1;
             }
-            _ => {}
+            _ => {
+                i += 1;
+            }
         }
-        i += 1;
     }
     None
 }

--- a/src/diagnostics_core/module_checks.rs
+++ b/src/diagnostics_core/module_checks.rs
@@ -17,6 +17,7 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::core::types::{Diagnostic, Range};
+use crate::parser::normalize_identifier;
 use crate::symbols::{Function, SymbolTable, TypeKind, ValueType};
 use crate::utils::{node_text, node_to_range};
 
@@ -1865,7 +1866,7 @@ pub fn check_block_label_mismatch(node: &Node, source: &str) -> Vec<Diagnostic> 
     // Find opening label: first identifier child (right after the keyword)
     // Find end label: identifier child that comes after "end" anonymous node
     // For if: also check identifier after "else" anonymous node
-    let mut opening_label: Option<&str> = None;
+    let mut opening_label: Option<String> = None;
 
     let mut cursor = node.walk();
     let children: Vec<_> = node.children(&mut cursor).collect();
@@ -1883,7 +1884,7 @@ pub fn check_block_label_mismatch(node: &Node, source: &str) -> Vec<Diagnostic> 
                     continue;
                 }
             }
-            opening_label = Some(node_text(child, source));
+            opening_label = Some(normalize_identifier(node_text(child, source)));
             break;
         }
     }
@@ -1899,12 +1900,24 @@ pub fn check_block_label_mismatch(node: &Node, source: &str) -> Vec<Diagnostic> 
         if child.is_named() {
             if ck == "identifier" {
                 if after_end {
-                    let end_label = node_text(child, source);
-                    check_label_match(opening_label, end_label, child, "end", &mut diagnostics);
+                    let end_label = normalize_identifier(node_text(child, source));
+                    check_label_match(
+                        opening_label.as_deref(),
+                        &end_label,
+                        child,
+                        "end",
+                        &mut diagnostics,
+                    );
                     after_end = false;
                 } else if after_else {
-                    let else_label = node_text(child, source);
-                    check_label_match(opening_label, else_label, child, "else", &mut diagnostics);
+                    let else_label = normalize_identifier(node_text(child, source));
+                    check_label_match(
+                        opening_label.as_deref(),
+                        &else_label,
+                        child,
+                        "else",
+                        &mut diagnostics,
+                    );
                     after_else = false;
                 }
             } else {

--- a/src/diagnostics_core/references.rs
+++ b/src/diagnostics_core/references.rs
@@ -5,6 +5,7 @@
 #![allow(clippy::borrow_deref_ref)]
 
 use crate::core::types::{Diagnostic, Position};
+use crate::parser::normalize_identifier;
 use crate::symbols::SymbolTable;
 use crate::utils::{find_containing_function, node_to_range, InstructionContext, STRUCT_OPS};
 
@@ -114,12 +115,16 @@ fn find_undefined_identifiers(
     node_kind!(kind = node);
 
     if kind == "identifier" {
-        let identifier_name = &source[node.byte_range()];
+        let raw_name = &source[node.byte_range()];
 
         // Only check identifiers that start with $
-        if !identifier_name.starts_with('$') {
+        if !raw_name.starts_with('$') {
             return diagnostics;
         }
+
+        // Normalize quoted identifiers: $"fh" → $fh
+        let normalized = normalize_identifier(raw_name);
+        let identifier_name: &str = &normalized;
 
         // Find the containing function for this reference (needed for locals and labels)
         let start_point = node.start_position();

--- a/src/features/hover/mod.rs
+++ b/src/features/hover/mod.rs
@@ -568,24 +568,26 @@ fn provide_annotation_hover(
         node_kind!(kind = current);
 
         if kind == "annotation" {
-            // Found annotation - extract the name from identifier_pattern child
-            #[cfg(feature = "native")]
-            let mut cursor = current.walk();
-            #[cfg(feature = "native")]
-            let children_iter = current.children(&mut cursor);
-
-            #[cfg(all(feature = "wasm", not(feature = "native")))]
-            let children_iter = (0..current.child_count()).filter_map(|i| current.child(i));
-
-            for child in children_iter {
-                node_kind!(child_kind = child);
-
-                if child_kind == "identifier_pattern" {
-                    let annotation_name = &document[child.start_byte()..child.end_byte()];
-                    return Some(format_annotation_hover(annotation_name));
+            // Annotation is an opaque external token — extract name from raw text.
+            // Format: (@name ...) or (@"quoted name" ...)
+            let text = &document[current.start_byte()..current.end_byte()];
+            // Skip the leading "(@"
+            let after_prefix = &text[2..];
+            let annotation_name = if let Some(stripped) = after_prefix.strip_prefix('"') {
+                // Quoted name: extract content between quotes
+                if let Some(end_quote) = stripped.find('"') {
+                    &stripped[..end_quote]
+                } else {
+                    return None;
                 }
-            }
-            return None;
+            } else {
+                // Unquoted name: read until whitespace or ')'
+                let end = after_prefix
+                    .find(|c: char| c.is_whitespace() || c == ')')
+                    .unwrap_or(after_prefix.len());
+                &after_prefix[..end]
+            };
+            return Some(format_annotation_hover(annotation_name));
         }
 
         if let Some(parent) = current.parent() {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -570,7 +570,7 @@ fn extract_imported_tag(desc_node: &Node, source: &str, index: usize) -> Option<
 fn extract_identifier_info(node: &Node, source: &str) -> (Option<String>, Option<Range>) {
     if let Some(id_node) = crate::utils::find_child_by_kind(node, "identifier") {
         (
-            Some(node_text(&id_node, source).to_string()),
+            Some(normalize_identifier(node_text(&id_node, source))),
             Some(node_to_range(&id_node)),
         )
     } else {
@@ -850,7 +850,7 @@ fn extract_parameters(
                     let mut one_cursor = param_child.walk();
                     for one_child in param_child.children(&mut one_cursor) {
                         if one_child.kind() == "identifier" {
-                            name_opt = Some(node_text(&one_child, source).to_string());
+                            name_opt = Some(normalize_identifier(node_text(&one_child, source)));
                             range_opt = Some(node_to_range(&one_child));
                         } else if one_child.kind() == "value_type" {
                             type_opt = Some(resolve(&one_child));
@@ -1087,7 +1087,7 @@ fn extract_locals(func_node: &Node, source: &str, symbols: Option<&SymbolTable>)
                     let mut one_cursor = locals_child.walk();
                     for one_child in locals_child.children(&mut one_cursor) {
                         if one_child.kind() == "identifier" {
-                            name_opt = Some(node_text(&one_child, source).to_string());
+                            name_opt = Some(normalize_identifier(node_text(&one_child, source)));
                             range_opt = Some(node_to_range(&one_child));
                         } else if one_child.kind() == "value_type" {
                             type_opt = Some(resolve(&one_child));
@@ -1145,7 +1145,7 @@ fn visit_node_for_blocks(node: &Node, source: &str, blocks: &mut Vec<BlockLabel>
     if BLOCK_KINDS_STATEMENT.contains(&kind_str) || BLOCK_KINDS_EXPR.contains(&kind_str) {
         // Check if it has a label
         if let Some(id_node) = crate::utils::find_child_by_kind(node, "identifier") {
-            let label = node_text(&id_node, source).to_string();
+            let label = normalize_identifier(node_text(&id_node, source));
             let block_type = block_type_from_kind(kind_str).to_string();
 
             blocks.push(BlockLabel {
@@ -1394,7 +1394,7 @@ fn extract_rec_types(
                     let id_node = &children_vec[i];
                     i += 1;
                     (
-                        Some(node_text(id_node, source).to_string()),
+                        Some(normalize_identifier(node_text(id_node, source))),
                         Some(node_to_range(id_node)),
                     )
                 } else {
@@ -2179,6 +2179,17 @@ fn extract_table(
                     is_table64 = true;
                 }
             }
+        } else if child.kind() == "table_fields_elem" {
+            // Handle inline elem: (table i64? ref_type (elem ...))
+            let mut elem_cursor = child.walk();
+            for elem_child in child.children(&mut elem_cursor) {
+                if elem_child.kind() == "table64_type" {
+                    is_table64 = true;
+                } else if elem_child.kind() == "ref_type" {
+                    ref_type = extract_ref_type_resolved(&elem_child, source, symbols);
+                    ref_type_non_nullable = is_ref_type_non_nullable(&elem_child, source);
+                }
+            }
         }
     }
 
@@ -2423,6 +2434,96 @@ pub(crate) fn parse_wat_nat(text: &str) -> Option<u64> {
         u64::from_str_radix(&text[2..], 16).ok()
     } else {
         text.parse::<u64>().ok()
+    }
+}
+
+/// Normalize a quoted identifier (`$"..."`) to its unquoted form (`$name`).
+/// Per the WAT spec, `$"fh"` and `$fh` refer to the same identifier.
+/// Also decodes escape sequences: `\xx` hex bytes, `\u{xxxx}` unicode, `\t`, `\n`, `\r`, `\\`, `\"`.
+/// Hex byte escapes produce raw bytes that are accumulated and decoded as UTF-8.
+/// Unquoted identifiers (`$name`) are returned as-is.
+pub(crate) fn normalize_identifier(text: &str) -> String {
+    if text.starts_with("$\"") && text.ends_with('"') && text.len() >= 3 {
+        // Strip $"..." wrapper
+        let inner = &text[2..text.len() - 1];
+        // Build output as raw bytes, then convert to String at the end
+        let mut out: Vec<u8> = Vec::with_capacity(inner.len() + 1);
+        out.push(b'$');
+
+        let bytes = inner.as_bytes();
+        let mut i = 0;
+        while i < bytes.len() {
+            if bytes[i] == b'\\' && i + 1 < bytes.len() {
+                i += 1;
+                match bytes[i] {
+                    b't' => {
+                        out.push(b'\t');
+                        i += 1;
+                    }
+                    b'n' => {
+                        out.push(b'\n');
+                        i += 1;
+                    }
+                    b'r' => {
+                        out.push(b'\r');
+                        i += 1;
+                    }
+                    b'\\' => {
+                        out.push(b'\\');
+                        i += 1;
+                    }
+                    b'"' => {
+                        out.push(b'"');
+                        i += 1;
+                    }
+                    b'\'' => {
+                        out.push(b'\'');
+                        i += 1;
+                    }
+                    b'u' if i + 1 < bytes.len() && bytes[i + 1] == b'{' => {
+                        // Unicode escape: \u{xxxx} → encode as UTF-8 bytes
+                        i += 2; // skip 'u{'
+                        let start = i;
+                        while i < bytes.len() && bytes[i] != b'}' {
+                            i += 1;
+                        }
+                        if let Ok(code) = u32::from_str_radix(&inner[start..i], 16) {
+                            if let Some(c) = char::from_u32(code) {
+                                let mut buf = [0u8; 4];
+                                let encoded = c.encode_utf8(&mut buf);
+                                out.extend_from_slice(encoded.as_bytes());
+                            }
+                        }
+                        if i < bytes.len() {
+                            i += 1; // skip '}'
+                        }
+                    }
+                    _ => {
+                        // Hex byte escape: \xx → raw byte
+                        if i + 1 < bytes.len() {
+                            let hex = &inner[i..i + 2];
+                            if let Ok(byte) = u8::from_str_radix(hex, 16) {
+                                out.push(byte);
+                                i += 2;
+                            } else {
+                                out.push(bytes[i]);
+                                i += 1;
+                            }
+                        } else {
+                            out.push(bytes[i]);
+                            i += 1;
+                        }
+                    }
+                }
+            } else {
+                out.push(bytes[i]);
+                i += 1;
+            }
+        }
+
+        String::from_utf8_lossy(&out).into_owned()
+    } else {
+        text.to_string()
     }
 }
 
@@ -2944,7 +3045,7 @@ fn find_identifier_in_data_or_elem(node: &Node, source: &str) -> (Option<String>
         // Direct identifier (shouldn't happen, but handle it)
         if child.kind() == "identifier" {
             return (
-                Some(node_text(&child, source).to_string()),
+                Some(normalize_identifier(node_text(&child, source))),
                 Some(node_to_range(&child)),
             );
         }
@@ -2954,7 +3055,7 @@ fn find_identifier_in_data_or_elem(node: &Node, source: &str) -> (Option<String>
             for index_child in child.children(&mut index_cursor) {
                 if index_child.kind() == "identifier" {
                     return (
-                        Some(node_text(&index_child, source).to_string()),
+                        Some(normalize_identifier(node_text(&index_child, source))),
                         Some(node_to_range(&index_child)),
                     );
                 }


### PR DESCRIPTION
## Summary
- **External scanner for annotations**: Move annotation parsing to scanner.c to handle strings containing `)` inside annotations (fixes annotations.wast)
- **table64 inline elem syntax**: Add optional `i64` to `table_fields_elem` grammar rule and parser extraction (fixes call_indirect64.wast)
- **Quoted identifier normalization**: Add `normalize_identifier()` that decodes `$"fh"` → `$fh` with full escape sequence support (fixes id.wast)
- **wast-runner fix**: `find_matching_close_paren()` now skips string literals to avoid premature module truncation

Spec test improvement: 2974 → 2991 passing (+17), valid modules 1038/1038 (100%), zero regressions.

Closes #226