### PR TITLE
Add non-nullable abstract ref types and fix type narrowing for br_on_null/non_null/ref.as_non_null/br_on_cast

### DIFF
--- a/src/diagnostics/semantic_diagnostics.rs
+++ b/src/diagnostics/semantic_diagnostics.rs
@@ -3467,4 +3467,133 @@ mod tests {
             "table.fill with invalid index should be flagged"
         );
     }
+
+    #[test]
+    fn test_br_on_null_type_narrowing() {
+        // br_on_null pops (ref null ht), branches to label with t*, pushes (ref ht) on fallthrough
+        let document = r#"(module
+  (type $t (func))
+  (func (param (ref null $t)) (result (ref $t))
+    (block
+      (br_on_null 0 (local.get 0))
+      (return)
+    )
+    (unreachable)
+  )
+)"#;
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        let errors: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.severity == Some(DiagnosticSeverity::ERROR))
+            .collect();
+        assert!(
+            errors.is_empty(),
+            "br_on_null should narrow type to non-nullable, got: {:?}",
+            errors
+        );
+    }
+
+    #[test]
+    fn test_br_on_non_null_valid() {
+        // br_on_non_null pops (ref null ht), branches with label types, falls through with t*
+        let document = r#"(module
+  (type $t (func))
+  (func (param (ref null $t)) (result)
+    (block (result (ref $t))
+      (br_on_non_null 0 (local.get 0))
+      (unreachable)
+    )
+    (drop)
+  )
+)"#;
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        let errors: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.severity == Some(DiagnosticSeverity::ERROR))
+            .collect();
+        assert!(
+            errors.is_empty(),
+            "br_on_non_null should be valid, got: {:?}",
+            errors
+        );
+    }
+
+    #[test]
+    fn test_ref_as_non_null_type_narrowing() {
+        // ref.as_non_null converts (ref null ht) to (ref ht)
+        let document = r#"(module
+  (type $t (func))
+  (func (param (ref null $t)) (result (ref $t))
+    (ref.as_non_null (local.get 0))
+  )
+)"#;
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        let errors: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.severity == Some(DiagnosticSeverity::ERROR))
+            .collect();
+        assert!(
+            errors.is_empty(),
+            "ref.as_non_null should narrow to non-nullable type, got: {:?}",
+            errors
+        );
+    }
+
+    #[test]
+    fn test_br_on_cast_non_nullable_diff_type() {
+        // br_on_cast with non-nullable cast type should produce non-nullable fallthrough
+        let document = r#"(module
+  (type $t (sub (struct)))
+  (func (param (ref $t)) (result (ref struct))
+    (block (result (ref $t))
+      (br_on_cast 0 (ref struct) (ref $t) (local.get 0))
+    )
+  )
+)"#;
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        let errors: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.severity == Some(DiagnosticSeverity::ERROR))
+            .collect();
+        assert!(
+            errors.is_empty(),
+            "br_on_cast with non-nullable types should be valid, got: {:?}",
+            errors
+        );
+    }
+
+    #[test]
+    fn test_block_result_ref_non_nullable() {
+        // Block result type (ref any) should be parsed as non-nullable
+        let document = r#"(module
+  (func (param anyref) (result (ref any))
+    (ref.as_non_null (local.get 0))
+  )
+)"#;
+        let mut parser = create_parser();
+        let tree = parser.parse(document, None).unwrap();
+        let symbols = parse_document(document).unwrap();
+        let diagnostics = provide_semantic_diagnostics(&tree, document, &symbols);
+        let errors: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.severity == Some(DiagnosticSeverity::ERROR))
+            .collect();
+        assert!(
+            errors.is_empty(),
+            "Function with (ref any) result should accept non-nullable anyref, got: {:?}",
+            errors
+        );
+    }
 }

--- a/src/diagnostics_core/semantic.rs
+++ b/src/diagnostics_core/semantic.rs
@@ -628,6 +628,35 @@ fn process_instruction(
         return;
     }
 
+    if instr_name == "br_on_null" {
+        // br_on_null l : [t* (ref null ht)] -> [t* (ref ht)]
+        // Pop ref operand, validate label types, push non-nullable ref
+        let ref_type = checker.pop_val().unwrap_or(ValueType::Unknown);
+        if let Some(depth) = get_branch_depth(node, source, checker) {
+            if let Some(label_types) = checker.pop_label_types_for_instr(depth, node, instr_name) {
+                checker.push_vals(&label_types);
+            }
+        }
+        checker.push_val(make_non_nullable(&ref_type));
+        return;
+    }
+
+    if instr_name == "br_on_non_null" {
+        // br_on_non_null l : [t* (ref null ht)] -> [t*]
+        // The branch target label expects [t* (ref ht)]
+        checker.pop_expect(&ValueType::Unknown, node);
+        if let Some(depth) = get_branch_depth(node, source, checker) {
+            if let Some(label_types) = checker.label_types_vec(depth) {
+                if !label_types.is_empty() {
+                    let t_star = &label_types[..label_types.len() - 1];
+                    checker.pop_vals_for_instr(t_star, node, instr_name);
+                    checker.push_vals(t_star);
+                }
+            }
+        }
+        return;
+    }
+
     // br_on_cast and br_on_cast_fail are conditional branches:
     // They consume 1 ref value and push 1 ref value (the fallthrough type).
     // br_on_cast: branches if cast succeeds, falls through with source type.
@@ -787,6 +816,13 @@ fn process_instruction(
         );
         // Push the actual result type (not Unknown)
         checker.push_val(result_type);
+        return;
+    }
+
+    if instr_name == "ref.as_non_null" {
+        // ref.as_non_null : [(ref null ht)] -> [(ref ht)]
+        let ref_type = checker.pop_val().unwrap_or(ValueType::Unknown);
+        checker.push_val(make_non_nullable(&ref_type));
         return;
     }
 
@@ -1079,7 +1115,7 @@ fn derive_consumed_types_from_name(
         "ref.null" => Some(vec![]),
         "ref.func" => Some(vec![]),
         "ref.is_null" => Some(vec![ValueType::Unknown]), // any ref
-        "ref.as_non_null" => Some(vec![ValueType::Unknown]), // any nullable ref
+        // ref.as_non_null handled specially in process_instruction
         "ref.eq" => Some(vec![ValueType::Eqref, ValueType::Eqref]),
 
         // GC instructions
@@ -1223,8 +1259,7 @@ fn derive_consumed_types_from_name(
         "memory.atomic.wait64" => Some(vec![ValueType::I32, ValueType::I64, ValueType::I64]),
         "memory.atomic.notify" => Some(vec![ValueType::I32, ValueType::I32]),
 
-        // Br_on_null/non_null
-        "br_on_null" | "br_on_non_null" => Some(vec![ValueType::Unknown]),
+        // br_on_null/br_on_non_null handled specially in process_instruction
 
         // Scalar binary operations — 2 operands of prefix type
         name if is_binary_scalar(name) => {
@@ -2758,6 +2793,80 @@ fn get_block_param_types(block_node: &Node, source: &str, symbols: &SymbolTable)
     types
 }
 
+/// Parse a ref_type node from the tree-sitter AST into a ValueType.
+/// Handles `(ref null? heap_type)` forms that `try_parse` can't handle.
+fn parse_ref_type_from_node(node: &Node, source: &str) -> ValueType {
+    // First try the simple text-based parse for abbreviated forms
+    let type_text = source[node.byte_range()].trim();
+    if let Some(t) = ValueType::try_parse(type_text) {
+        return t;
+    }
+
+    // Look for ref_type_ref child (handles `(ref null? (ref_kind | index))`)
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        node_kind!(kind = child);
+        match kind.as_ref() {
+            "ref_type_ref" => return parse_ref_type_ref_node(&child, source),
+            "value_type_ref_type" | "ref_type" => {
+                return parse_ref_type_from_node(&child, source);
+            }
+            _ => {}
+        }
+    }
+
+    // If the node itself is a ref_type_ref, parse directly
+    if node.kind() == "ref_type_ref" {
+        return parse_ref_type_ref_node(node, source);
+    }
+
+    ValueType::Unknown
+}
+
+/// Parse a `ref_type_ref` node: `(ref null? (ref_kind | index))`
+fn parse_ref_type_ref_node(node: &Node, source: &str) -> ValueType {
+    let mut is_null = false;
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        let ck = child.kind();
+        if ck == "null" || source[child.byte_range()].trim() == "null" {
+            is_null = true;
+        } else if ck == "ref_kind" {
+            let text = source[child.byte_range()].trim();
+            return match (text, is_null) {
+                ("func", true) => ValueType::Funcref,
+                ("func", false) => ValueType::FuncrefNN,
+                ("extern", true) => ValueType::Externref,
+                ("extern", false) => ValueType::ExternrefNN,
+                ("any", true) => ValueType::Anyref,
+                ("any", false) => ValueType::AnyrefNN,
+                ("eq", true) => ValueType::Eqref,
+                ("eq", false) => ValueType::EqrefNN,
+                ("i31", true) => ValueType::I31ref,
+                ("i31", false) => ValueType::I31refNN,
+                ("struct", true) => ValueType::Structref,
+                ("struct", false) => ValueType::StructrefNN,
+                ("array", true) => ValueType::Arrayref,
+                ("array", false) => ValueType::ArrayrefNN,
+                ("null" | "none", _) => ValueType::Nullref,
+                ("nofunc", _) => ValueType::NullFuncref,
+                ("noextern", _) => ValueType::NullExternref,
+                _ => ValueType::Unknown,
+            };
+        } else if ck == "index" || ck == "identifier" {
+            let text = source[child.byte_range()].trim();
+            if let Some(n) = parse_wat_nat(text) {
+                return if is_null {
+                    ValueType::RefNull(n as u32)
+                } else {
+                    ValueType::Ref(n as u32)
+                };
+            }
+        }
+    }
+    ValueType::Unknown
+}
+
 /// Parse result types from a func_type_results node
 fn parse_func_type_results(results_node: &Node, source: &str) -> Vec<ValueType> {
     let mut types = Vec::new();
@@ -2766,12 +2875,7 @@ fn parse_func_type_results(results_node: &Node, source: &str) -> Vec<ValueType> 
         node_kind!(kind = child);
 
         if kind == "value_type" || kind == "ref_type" {
-            let type_text = &source[child.byte_range()];
-            if let Some(t) = ValueType::try_parse(type_text.trim()) {
-                types.push(t);
-            } else {
-                types.push(ValueType::Unknown);
-            }
+            types.push(parse_ref_type_from_node(&child, source));
         }
     }
     types
@@ -2791,22 +2895,12 @@ fn parse_result_types(block_type: &Node, source: &str) -> Vec<ValueType> {
                 node_kind!(inner_kind = inner_child);
 
                 if inner_kind == "value_type" || inner_kind == "ref_type" {
-                    let type_text = &source[inner_child.byte_range()];
-                    if let Some(t) = ValueType::try_parse(type_text.trim()) {
-                        types.push(t);
-                    } else {
-                        types.push(ValueType::Unknown);
-                    }
+                    types.push(parse_ref_type_from_node(&inner_child, source));
                 }
             }
         }
         if kind == "value_type" || kind == "ref_type" {
-            let type_text = &source[child.byte_range()];
-            if let Some(t) = ValueType::try_parse(type_text.trim()) {
-                types.push(t);
-            } else {
-                types.push(ValueType::Unknown);
-            }
+            types.push(parse_ref_type_from_node(&child, source));
         }
     }
 
@@ -3352,7 +3446,7 @@ fn check_br_on_cast_types(
                     let branch_vt = if branch_nullable {
                         make_nullable(&branch_type)
                     } else {
-                        branch_type
+                        make_non_nullable(&branch_type)
                     };
                     if !types_compatible_with_symbols(&branch_vt, label_type, symbols) {
                         checker.diagnostics.push(
@@ -3376,7 +3470,7 @@ fn check_br_on_cast_types(
         let ft_vt = if ft_nullable {
             make_nullable(&ft_type)
         } else {
-            ft_type
+            make_non_nullable(&ft_type)
         };
         checker.push_val(ft_vt);
     } else {
@@ -3384,11 +3478,34 @@ fn check_br_on_cast_types(
     }
 }
 
-/// Make a ValueType nullable (Ref→RefNull, abstract→nullable variant).
+/// Make a ValueType nullable (Ref→RefNull, NN→nullable variant).
 fn make_nullable(vt: &ValueType) -> ValueType {
     match vt {
         ValueType::Ref(n) => ValueType::RefNull(*n),
-        // Abstract types: funcref/anyref/etc. are already nullable in our representation
+        ValueType::FuncrefNN => ValueType::Funcref,
+        ValueType::ExternrefNN => ValueType::Externref,
+        ValueType::AnyrefNN => ValueType::Anyref,
+        ValueType::EqrefNN => ValueType::Eqref,
+        ValueType::I31refNN => ValueType::I31ref,
+        ValueType::StructrefNN => ValueType::Structref,
+        ValueType::ArrayrefNN => ValueType::Arrayref,
+        // Already nullable or not a ref
+        other => *other,
+    }
+}
+
+/// Make a ValueType non-nullable (RefNull→Ref, nullable abstract→NN variant).
+fn make_non_nullable(vt: &ValueType) -> ValueType {
+    match vt {
+        ValueType::RefNull(n) => ValueType::Ref(*n),
+        ValueType::Funcref => ValueType::FuncrefNN,
+        ValueType::Externref => ValueType::ExternrefNN,
+        ValueType::Anyref => ValueType::AnyrefNN,
+        ValueType::Eqref => ValueType::EqrefNN,
+        ValueType::I31ref => ValueType::I31refNN,
+        ValueType::Structref => ValueType::StructrefNN,
+        ValueType::Arrayref => ValueType::ArrayrefNN,
+        // Already non-nullable or not a ref
         other => *other,
     }
 }

--- a/src/diagnostics_core/type_check.rs
+++ b/src/diagnostics_core/type_check.rs
@@ -70,19 +70,43 @@ pub fn types_compatible(actual: &ValueType, expected: &ValueType) -> bool {
 fn is_ref_subtype(sub: &ValueType, sup: &ValueType) -> bool {
     use ValueType::*;
     match (sub, sup) {
-        // nullref is bottom for internal ref hierarchy
+        // nullref is bottom for internal ref hierarchy (nullable only)
         (Nullref, Anyref | Eqref | I31ref | Structref | Arrayref) => true,
-        // nullfuncref is bottom for func hierarchy
+        // nullfuncref is bottom for func hierarchy (nullable only)
         (NullFuncref, Funcref) => true,
-        // nullexternref is bottom for extern hierarchy
+        // nullexternref is bottom for extern hierarchy (nullable only)
         (NullExternref, Externref) => true,
-        // i31ref, structref, arrayref <: eqref <: anyref
+        // NOTE: Nullref/NullFuncref/NullExternref are NOT subtypes of NN variants
+        // (they carry null, NN variants don't accept null)
+
+        // NN variants are subtypes of their nullable counterparts
+        (FuncrefNN, Funcref) => true,
+        (ExternrefNN, Externref) => true,
+        (AnyrefNN, Anyref) => true,
+        (EqrefNN, Eqref) => true,
+        (I31refNN, I31ref) => true,
+        (StructrefNN, Structref) => true,
+        (ArrayrefNN, Arrayref) => true,
+
+        // NN hierarchy mirrors nullable: EqrefNN <: AnyrefNN, etc.
+        (I31refNN | StructrefNN | ArrayrefNN | EqrefNN, AnyrefNN) => true,
+        (I31refNN | StructrefNN | ArrayrefNN, EqrefNN) => true,
+        // NN <: nullable supertype (cross-nullability)
+        (I31refNN | StructrefNN | ArrayrefNN | EqrefNN, Anyref) => true,
+        (I31refNN | StructrefNN | ArrayrefNN, Eqref) => true,
+
+        // i31ref, structref, arrayref <: eqref <: anyref (nullable hierarchy)
         (I31ref | Structref | Arrayref | Eqref, Anyref) => true,
         (I31ref | Structref | Arrayref, Eqref) => true,
-        // Concrete Ref(n)/RefNull(n) are subtypes of all abstract ref supertypes.
+
+        // Concrete Ref(n)/RefNull(n) are subtypes of nullable abstract ref supertypes.
         // Without symbol table we can't distinguish struct/array/func kinds, so we
         // accept all abstract supertypes (precise checking done by types_compatible_with_symbols).
         (Ref(_) | RefNull(_), Funcref | Anyref | Eqref | Arrayref | Structref) => true,
+        // Non-null concrete ref is also subtype of NN abstract supertypes
+        (Ref(_), FuncrefNN | AnyrefNN | EqrefNN | ArrayrefNN | StructrefNN) => true,
+        // RefNull(n) is NOT a subtype of NN variants (implicit by absence)
+
         // NullFuncref is bottom of func hierarchy — subtype of all nullable func refs
         (NullFuncref, RefNull(_) | Structref) => true,
         // Nullref is bottom of internal ref hierarchy — subtype of all nullable internal refs
@@ -166,19 +190,34 @@ fn is_concrete_ref_subtype(sub: &ValueType, sup: &ValueType, symbols: &SymbolTab
     }
 
     // Check concrete type against abstract supertypes
-    // In the Wasm spec, abstract types like structref/arrayref/funcref are nullable,
-    // so both Ref(n) and RefNull(n) are subtypes.
     let type_def = match symbols.get_type_by_index(sub_idx as usize) {
         Some(td) => td,
         None => return false,
     };
 
-    matches!(
+    // Nullable abstract supertypes: both Ref(n) and RefNull(n) are subtypes
+    if matches!(
         (&type_def.kind, sup),
         (TypeKind::Struct { .. }, Structref | Eqref | Anyref)
             | (TypeKind::Array { .. }, Arrayref | Eqref | Anyref)
             | (TypeKind::Func { .. }, Funcref)
-    )
+    ) {
+        return true;
+    }
+
+    // Non-nullable abstract supertypes: only Ref(n) (non-null) is a subtype
+    if !sub_nullable
+        && matches!(
+            (&type_def.kind, sup),
+            (TypeKind::Struct { .. }, StructrefNN | EqrefNN | AnyrefNN)
+                | (TypeKind::Array { .. }, ArrayrefNN | EqrefNN | AnyrefNN)
+                | (TypeKind::Func { .. }, FuncrefNN)
+        )
+    {
+        return true;
+    }
+
+    false
 }
 
 /// Check if `child_idx` is a declared subtype of `parent_idx` via the parent chain.

--- a/src/features/symbols/mod.rs
+++ b/src/features/symbols/mod.rs
@@ -24,6 +24,14 @@ pub enum ValueType {
     Nullref,
     NullFuncref,
     NullExternref,
+    // Non-nullable abstract ref variants: (ref func), (ref extern), etc.
+    FuncrefNN,
+    ExternrefNN,
+    AnyrefNN,
+    EqrefNN,
+    I31refNN,
+    StructrefNN,
+    ArrayrefNN,
     Ref(u32),     // Typed reference to a type index
     RefNull(u32), // Nullable typed reference
     Unknown,
@@ -49,6 +57,13 @@ impl std::fmt::Display for ValueType {
             ValueType::Nullref => write!(f, "nullref"),
             ValueType::NullFuncref => write!(f, "nullfuncref"),
             ValueType::NullExternref => write!(f, "nullexternref"),
+            ValueType::FuncrefNN => write!(f, "(ref func)"),
+            ValueType::ExternrefNN => write!(f, "(ref extern)"),
+            ValueType::AnyrefNN => write!(f, "(ref any)"),
+            ValueType::EqrefNN => write!(f, "(ref eq)"),
+            ValueType::I31refNN => write!(f, "(ref i31)"),
+            ValueType::StructrefNN => write!(f, "(ref struct)"),
+            ValueType::ArrayrefNN => write!(f, "(ref array)"),
             ValueType::Ref(idx) => write!(f, "(ref {})", idx),
             ValueType::RefNull(idx) => write!(f, "(ref null {})", idx),
             ValueType::Unknown => write!(f, "unknown"),
@@ -96,19 +111,64 @@ impl From<&wast::core::ValType<'_>> for ValueType {
             wast::core::ValType::F64 => ValueType::F64,
             wast::core::ValType::V128 => ValueType::V128,
             wast::core::ValType::Ref(ref_type) => match &ref_type.heap {
-                wast::core::HeapType::Abstract { ty, .. } => match ty {
-                    wast::core::AbstractHeapType::Func => ValueType::Funcref,
-                    wast::core::AbstractHeapType::Extern => ValueType::Externref,
-                    wast::core::AbstractHeapType::Struct => ValueType::Structref,
-                    wast::core::AbstractHeapType::Array => ValueType::Arrayref,
-                    wast::core::AbstractHeapType::I31 => ValueType::I31ref,
-                    wast::core::AbstractHeapType::Any => ValueType::Anyref,
-                    wast::core::AbstractHeapType::Eq => ValueType::Eqref,
-                    wast::core::AbstractHeapType::None => ValueType::Nullref,
-                    wast::core::AbstractHeapType::NoFunc => ValueType::NullFuncref,
-                    wast::core::AbstractHeapType::NoExtern => ValueType::NullExternref,
-                    _ => ValueType::Unknown,
-                },
+                wast::core::HeapType::Abstract { ty, .. } => {
+                    let nullable = ref_type.nullable;
+                    match ty {
+                        wast::core::AbstractHeapType::Func => {
+                            if nullable {
+                                ValueType::Funcref
+                            } else {
+                                ValueType::FuncrefNN
+                            }
+                        }
+                        wast::core::AbstractHeapType::Extern => {
+                            if nullable {
+                                ValueType::Externref
+                            } else {
+                                ValueType::ExternrefNN
+                            }
+                        }
+                        wast::core::AbstractHeapType::Struct => {
+                            if nullable {
+                                ValueType::Structref
+                            } else {
+                                ValueType::StructrefNN
+                            }
+                        }
+                        wast::core::AbstractHeapType::Array => {
+                            if nullable {
+                                ValueType::Arrayref
+                            } else {
+                                ValueType::ArrayrefNN
+                            }
+                        }
+                        wast::core::AbstractHeapType::I31 => {
+                            if nullable {
+                                ValueType::I31ref
+                            } else {
+                                ValueType::I31refNN
+                            }
+                        }
+                        wast::core::AbstractHeapType::Any => {
+                            if nullable {
+                                ValueType::Anyref
+                            } else {
+                                ValueType::AnyrefNN
+                            }
+                        }
+                        wast::core::AbstractHeapType::Eq => {
+                            if nullable {
+                                ValueType::Eqref
+                            } else {
+                                ValueType::EqrefNN
+                            }
+                        }
+                        wast::core::AbstractHeapType::None => ValueType::Nullref,
+                        wast::core::AbstractHeapType::NoFunc => ValueType::NullFuncref,
+                        wast::core::AbstractHeapType::NoExtern => ValueType::NullExternref,
+                        _ => ValueType::Unknown,
+                    }
+                }
                 wast::core::HeapType::Concrete(idx) => match idx {
                     wast::token::Index::Num(n, _) => {
                         if ref_type.nullable {


### PR DESCRIPTION
Closes #224

Add 7 non-nullable abstract ref type variants (FuncrefNN, AnyrefNN, etc.) to ValueType and implement proper type narrowing for br_on_null, br_on_non_null, ref.as_non_null, and br_on_cast/br_on_cast_fail.

- Extended ValueType enum with NN variants and updated Display, From<wast>, and subtyping rules
- Added make_non_nullable helper and parse_ref_type_from_node for (ref null? heap_type) AST parsing
- Special instruction handling for br_on_null, br_on_non_null, ref.as_non_null (removed from generic path)
- Fixed br_on_cast fallthrough/branch types to use make_non_nullable when non-nullable