### PR TITLE
defrag: eliminate redundant allocations, merge duplicate loops, and optimize keyword matching

### DIFF
--- a/src/diagnostics_core/module_checks.rs
+++ b/src/diagnostics_core/module_checks.rs
@@ -41,15 +41,14 @@ pub fn validate_module_structure(
 
     check_memory_limits(symbols, &mut diagnostics);
     check_table_limits(symbols, &mut diagnostics);
-    check_min_gt_max(symbols, &mut diagnostics);
     check_duplicate_locals(symbols, &mut diagnostics);
 
     // Find the module node for AST-based checks
     if let Some(module_node) = find_module_node(root) {
-        check_multiple_starts(&module_node, source, &mut diagnostics);
+        check_multiple_starts(&module_node, &mut diagnostics);
         check_start_signature(&module_node, source, symbols, &mut diagnostics);
         check_duplicate_exports(&module_node, source, &mut diagnostics);
-        check_import_ordering(&module_node, source, &mut diagnostics);
+        check_import_ordering(&module_node, &mut diagnostics);
         check_duplicate_identifiers(&module_node, source, &mut diagnostics);
         check_inline_type_mismatches(&module_node, source, symbols, &mut diagnostics);
         check_constant_expressions(&module_node, source, symbols, &mut diagnostics);
@@ -160,35 +159,7 @@ fn check_memory_limits(symbols: &SymbolTable, diagnostics: &mut Vec<Diagnostic>)
                     ),
                 ));
             }
-        }
-    }
-}
-
-// ============================================================================
-// 2. Min > max for memories and tables
-// ============================================================================
-
-fn check_min_gt_max(symbols: &SymbolTable, diagnostics: &mut Vec<Diagnostic>) {
-    for memory in &symbols.memories {
-        if let Some(max) = memory.limits.1 {
             if memory.limits.0 > max {
-                let range = memory
-                    .range
-                    .unwrap_or_else(|| Range::from_coords(memory.line, 0, memory.line, 0));
-                diagnostics.push(Diagnostic::error(
-                    range,
-                    "Size minimum must not be greater than maximum",
-                ));
-            }
-        }
-    }
-
-    for table in &symbols.tables {
-        if let Some(max) = table.limits.1 {
-            if table.limits.0 > max {
-                let range = table
-                    .range
-                    .unwrap_or_else(|| Range::from_coords(table.line, 0, table.line, 0));
                 diagnostics.push(Diagnostic::error(
                     range,
                     "Size minimum must not be greater than maximum",
@@ -199,11 +170,10 @@ fn check_min_gt_max(symbols: &SymbolTable, diagnostics: &mut Vec<Diagnostic>) {
 }
 
 // ============================================================================
-// 3. Multiple start sections
+// 2. Multiple start sections
 // ============================================================================
 
-fn check_multiple_starts(module: &Node, source: &str, diagnostics: &mut Vec<Diagnostic>) {
-    let _ = source;
+fn check_multiple_starts(module: &Node, diagnostics: &mut Vec<Diagnostic>) {
     let mut seen_start = false;
     for_each_module_field(module, |field| {
         node_kind!(fk = field);
@@ -355,8 +325,7 @@ fn check_export_name(
 // 5. Import ordering
 // ============================================================================
 
-fn check_import_ordering(module: &Node, source: &str, diagnostics: &mut Vec<Diagnostic>) {
-    let _ = source;
+fn check_import_ordering(module: &Node, diagnostics: &mut Vec<Diagnostic>) {
     let mut seen_non_import = false;
 
     for_each_module_field(module, |field| {
@@ -1991,13 +1960,16 @@ fn check_duplicate_locals(symbols: &SymbolTable, diagnostics: &mut Vec<Diagnosti
 
         for (name, range) in entries {
             if let (Some(name), Some(range)) = (name, range) {
-                if seen.contains_key(name.as_str()) {
-                    diagnostics.push(Diagnostic::error(
-                        *range,
-                        format!("duplicate local {}", name),
-                    ));
-                } else {
-                    seen.insert(name, *range);
+                match seen.entry(name) {
+                    std::collections::hash_map::Entry::Occupied(_) => {
+                        diagnostics.push(Diagnostic::error(
+                            *range,
+                            format!("duplicate local {}", name),
+                        ));
+                    }
+                    std::collections::hash_map::Entry::Vacant(e) => {
+                        e.insert(*range);
+                    }
                 }
             }
         }
@@ -2335,28 +2307,36 @@ fn check_table_limits(symbols: &SymbolTable, diagnostics: &mut Vec<Diagnostic>) 
     const MAX_TABLE32_SIZE: u64 = 0xFFFF_FFFF; // 2^32 - 1
 
     for table in &symbols.tables {
-        // table64 has a much higher limit; skip the 32-bit check
-        if table.is_table64 {
-            continue;
-        }
-
         let range = table
             .range
             .unwrap_or_else(|| Range::from_coords(table.line, 0, table.line, 0));
 
-        if table.limits.0 > MAX_TABLE32_SIZE {
-            diagnostics.push(
-                Diagnostic::error(range, "table size must be at most 2^32-1")
-                    .with_code("table-size"),
-            );
-        }
-
-        if let Some(max) = table.limits.1 {
-            if max > MAX_TABLE32_SIZE {
+        // table64 has a much higher limit; skip the 32-bit size check
+        if !table.is_table64 {
+            if table.limits.0 > MAX_TABLE32_SIZE {
                 diagnostics.push(
                     Diagnostic::error(range, "table size must be at most 2^32-1")
                         .with_code("table-size"),
                 );
+            }
+
+            if let Some(max) = table.limits.1 {
+                if max > MAX_TABLE32_SIZE {
+                    diagnostics.push(
+                        Diagnostic::error(range, "table size must be at most 2^32-1")
+                            .with_code("table-size"),
+                    );
+                }
+            }
+        }
+
+        // Min > max check (applies to all tables including table64)
+        if let Some(max) = table.limits.1 {
+            if table.limits.0 > max {
+                diagnostics.push(Diagnostic::error(
+                    range,
+                    "Size minimum must not be greater than maximum",
+                ));
             }
         }
     }

--- a/src/diagnostics_core/semantic.rs
+++ b/src/diagnostics_core/semantic.rs
@@ -2130,13 +2130,11 @@ macro_rules! find_folded_block_child_body {
     }};
 }
 #[cfg(feature = "native")]
-fn find_folded_block_child<'a>(expr: &'a Node, source: &str) -> Option<(Node<'a>, &'static str)> {
-    let _ = source;
+fn find_folded_block_child<'a>(expr: &'a Node) -> Option<(Node<'a>, &'static str)> {
     find_folded_block_child_body!(expr)
 }
 #[cfg(all(feature = "wasm", not(feature = "native")))]
-fn find_folded_block_child(expr: &Node, source: &str) -> Option<(Node, &'static str)> {
-    let _ = source;
+fn find_folded_block_child(expr: &Node) -> Option<(Node, &'static str)> {
     find_folded_block_child_body!(expr)
 }
 
@@ -2435,7 +2433,7 @@ fn process_folded_expr(
 ) {
     // Check if this is a block-type expression (block, loop, if, try_table)
     // These need control frame tracking for proper stack validation.
-    if let Some((block_node, block_kind)) = find_folded_block_child(expr, source) {
+    if let Some((block_node, block_kind)) = find_folded_block_child(expr) {
         process_folded_block_expr(expr, &block_node, block_kind, source, symbols, checker);
         return;
     }

--- a/src/features/document_symbols_core.rs
+++ b/src/features/document_symbols_core.rs
@@ -182,7 +182,7 @@ fn local_to_symbol(local: &Variable) -> DocumentSymbolInfo {
 fn block_to_symbol(block: &BlockLabel) -> DocumentSymbolInfo {
     DocumentSymbolInfo {
         name: block.label.clone(),
-        detail: Some(block.block_type.clone()),
+        detail: Some(block.block_type.to_string()),
         kind: SymbolKindCore::Key,
         range: range_or_line(&block.range, block.line),
         children: None,
@@ -216,12 +216,10 @@ fn table_to_symbol(table: &Table) -> DocumentSymbolInfo {
         .clone()
         .unwrap_or_else(|| format!("(table {})", table.index));
 
-    let detail = format!(
-        "{} {} {}",
-        table.limits.0,
-        table.limits.1.map_or("".to_string(), |m| m.to_string()),
-        table.ref_type
-    );
+    let detail = match table.limits.1 {
+        Some(m) => format!("{} {} {}", table.limits.0, m, table.ref_type),
+        None => format!("{} {}", table.limits.0, table.ref_type),
+    };
 
     DocumentSymbolInfo {
         name,
@@ -238,14 +236,10 @@ fn memory_to_symbol(memory: &Memory) -> DocumentSymbolInfo {
         .clone()
         .unwrap_or_else(|| format!("(memory {})", memory.index));
 
-    let detail = format!(
-        "{}{}",
-        memory.limits.0,
-        memory
-            .limits
-            .1
-            .map_or("".to_string(), |m| format!(" {}", m))
-    );
+    let detail = match memory.limits.1 {
+        Some(m) => format!("{} {}", memory.limits.0, m),
+        None => memory.limits.0.to_string(),
+    };
 
     DocumentSymbolInfo {
         name,

--- a/src/features/symbols/mod.rs
+++ b/src/features/symbols/mod.rs
@@ -205,7 +205,7 @@ pub struct Parameter {
 #[derive(Debug, Clone)]
 pub struct BlockLabel {
     pub label: String,
-    pub block_type: String, // "block", "loop", "if", "try", "try_table"
+    pub block_type: &'static str, // "block", "loop", "if", "try", "try_table"
     pub line: u32,
     pub range: Option<Range>, // Used by symbol_lookup for go-to-definition
 }

--- a/src/features/symbols/tests.rs
+++ b/src/features/symbols/tests.rs
@@ -272,7 +272,7 @@ fn test_variable_creation() {
 fn test_block_label_creation() {
     let block = BlockLabel {
         label: "$exit".to_string(),
-        block_type: "block".to_string(),
+        block_type: "block",
         line: 42,
         range: None,
     };
@@ -318,7 +318,7 @@ fn test_complex_function() {
         }],
         blocks: vec![BlockLabel {
             label: "$exit".to_string(),
-            block_type: "block".to_string(),
+            block_type: "block",
             line: 10,
             range: None,
         }],

--- a/src/features/test_utils.rs
+++ b/src/features/test_utils.rs
@@ -57,7 +57,7 @@ pub fn create_test_symbols() -> SymbolTable {
         }],
         blocks: vec![BlockLabel {
             label: "$exit".to_string(),
-            block_type: "block".to_string(),
+            block_type: "block",
             line: 5,
             range: None,
         }],

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1146,7 +1146,7 @@ fn visit_node_for_blocks(node: &Node, source: &str, blocks: &mut Vec<BlockLabel>
         // Check if it has a label
         if let Some(id_node) = crate::utils::find_child_by_kind(node, "identifier") {
             let label = normalize_identifier(node_text(&id_node, source));
-            let block_type = block_type_from_kind(kind_str).to_string();
+            let block_type = block_type_from_kind(kind_str);
 
             blocks.push(BlockLabel {
                 label,
@@ -3018,8 +3018,8 @@ fn extract_elem_ref_type(node: &Node, source: &str) -> ValueType {
                     || gk == "ref_type_ref"
                     || gk == "ref_type_concrete"
                 {
-                    let text = node_text(&gc, source).trim().to_string();
-                    if let Some(vt) = ValueType::try_parse(&text) {
+                    let text = node_text(&gc, source).trim();
+                    if let Some(vt) = ValueType::try_parse(text) {
                         return vt;
                     }
                 }
@@ -3027,8 +3027,8 @@ fn extract_elem_ref_type(node: &Node, source: &str) -> ValueType {
         }
         // Check for inline ref type keywords at top level
         if kind == "ref_type" || kind == "value_type" {
-            let text = node_text(&child, source).trim().to_string();
-            if let Some(vt) = ValueType::try_parse(&text) {
+            let text = node_text(&child, source).trim();
+            if let Some(vt) = ValueType::try_parse(text) {
                 return vt;
             }
         }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -300,32 +300,26 @@ fn determine_catch_clause_context(node: &Node, document: &str) -> Option<Instruc
 /// - An instruction (e.g., "call ", "local.get", "memory.grow")
 /// - A declaration (e.g., "(func ", "(global ", "(memory ")
 fn line_contains_keyword(line: &str, keyword: &str) -> bool {
+    let bytes = line.as_bytes();
     for (i, _) in line.match_indices(keyword) {
-        // Check character before the match (if any)
-        let char_before = if i > 0 { line.chars().nth(i - 1) } else { None };
-
-        // Check character after the match (if any)
-        let char_after = line.chars().nth(i + keyword.len());
-
-        // The keyword should be preceded by non-identifier char or start of string
-        let valid_before = match char_before {
-            None => true,       // Start of line
-            Some('(') => true,  // Declaration like (func
-            Some(' ') => true,  // Instruction
-            Some('\t') => true, // Tab
-            Some(_) => false,   // Part of identifier like $my_array
+        // Check byte before the match (all boundary chars are ASCII, so byte indexing is safe)
+        let valid_before = if i > 0 {
+            matches!(bytes[i - 1], b'(' | b' ' | b'\t')
+        } else {
+            true // Start of line
         };
 
-        // The keyword should be followed by non-identifier char
-        let valid_after = match char_after {
-            None => true,                          // End of line
-            Some(' ') => true,                     // Keyword followed by space
-            Some('.') => true,                     // Instruction like local.get
-            Some('_') if keyword == "br" => true,  // br_if, br_table
-            Some(')') => true,                     // End of s-expr
-            Some('$') => true,                     // Keyword followed by identifier
-            Some(c) if c.is_ascii_digit() => true, // Like br0, call0
-            Some(_) => false,                      // Part of identifier
+        // Check byte after the match
+        let after = i + keyword.len();
+        let valid_after = if after < bytes.len() {
+            match bytes[after] {
+                b' ' | b'.' | b')' | b'$' => true,
+                b'_' if keyword == "br" => true, // br_if, br_table
+                c if c.is_ascii_digit() => true, // Like br0, call0
+                _ => false,
+            }
+        } else {
+            true // End of line
         };
 
         if valid_before && valid_after {


### PR DESCRIPTION
## Summary

- Change `BlockLabel::block_type` from `String` to `&'static str` to eliminate heap allocations
- Remove unnecessary `.to_string()` calls in parser and document symbols
- Merge `check_min_gt_max` into `check_memory_limits` and `check_table_limits` to eliminate redundant collection iterations
- Replace O(n) `chars().nth()` with O(1) byte indexing in `line_contains_keyword`
- Use HashMap entry API in `check_duplicate_locals` to avoid double lookup
- Remove unused `source` parameters from internal check functions