### PR TITLE
Consolidate native/WASM divergences using node_kind!/node_copy! macros

### DIFF
--- a/src/diagnostics_core/local_init.rs
+++ b/src/diagnostics_core/local_init.rs
@@ -52,9 +52,7 @@ pub(crate) fn check_uninitialized_locals(
     // Find and walk the instr_list
     let mut cursor = func_node.walk();
     for child in func_node.children(&mut cursor) {
-        let kind = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let kind = &*kind;
+        node_kind!(kind = child);
         if kind == "instr_list" {
             walk_body(
                 &child,
@@ -80,9 +78,7 @@ fn find_non_defaultable_locals(func_node: &Node, source: &str, func: &Function) 
 
     let mut cursor = func_node.walk();
     for child in func_node.children(&mut cursor) {
-        let kind = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let kind = &*kind;
+        node_kind!(kind = child);
 
         if kind == "func_locals" || kind == "func_locals_one" || kind == "func_locals_many" {
             scan_locals_node(&child, source, num_params, &mut local_counter, &mut result);
@@ -101,9 +97,7 @@ fn scan_locals_node(
     local_counter: &mut usize,
     result: &mut HashSet<usize>,
 ) {
-    let kind = node.kind();
-    #[cfg(all(feature = "wasm", not(feature = "native")))]
-    let kind = &*kind;
+    node_kind!(kind = node);
 
     match kind {
         "value_type" | "value_type_ref_type" | "value_type_num_type" => {
@@ -125,9 +119,7 @@ fn scan_locals_node(
 /// Walks down through `value_type → value_type_ref_type → ref_type → ref_type_ref/ref_type_concrete`
 /// and checks for the absence of `null`.
 fn is_non_nullable_ref_in_ast(node: &Node, source: &str) -> bool {
-    let kind = node.kind();
-    #[cfg(all(feature = "wasm", not(feature = "native")))]
-    let kind = &*kind;
+    node_kind!(kind = node);
 
     match kind {
         "ref_type_ref" | "ref_type_concrete" => {
@@ -204,9 +196,7 @@ fn walk_node(
     initialized: &mut HashSet<usize>,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
-    let kind = node.kind();
-    #[cfg(all(feature = "wasm", not(feature = "native")))]
-    let kind = &*kind;
+    node_kind!(kind = node);
 
     match kind {
         "instr_plain" => {
@@ -225,9 +215,7 @@ fn walk_node(
             let mut cursor = node.walk();
             let mut instr_plain = None;
             for child in node.children(&mut cursor) {
-                let ck = child.kind();
-                #[cfg(all(feature = "wasm", not(feature = "native")))]
-                let ck = &*ck;
+                node_kind!(ck = child);
                 if ck == "expr" {
                     walk_node(
                         &child,
@@ -361,9 +349,7 @@ fn walk_if_body(
 ) {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        let ck = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let ck = &*ck;
+        node_kind!(ck = child);
 
         match ck {
             // Linear format: else branch is in a separate node
@@ -412,9 +398,7 @@ fn walk_if_body(
 fn is_block_if(node: &Node) -> bool {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        let ck = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let ck = &*ck;
+        node_kind!(ck = child);
         if ck == "block_if" {
             return true;
         }
@@ -458,9 +442,7 @@ fn check_local_instruction(
 fn resolve_local_index_from_node(node: &Node, source: &str, func: &Function) -> Option<usize> {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        let ck = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let ck = &*ck;
+        node_kind!(ck = child);
 
         if ck == "index" || ck == "identifier" || ck == "nat" {
             let text = source[child.byte_range()].trim();
@@ -470,9 +452,7 @@ fn resolve_local_index_from_node(node: &Node, source: &str, func: &Function) -> 
             // Check inside index node for identifier/nat children
             let mut ic = child.walk();
             for idx_child in child.children(&mut ic) {
-                let ik = idx_child.kind();
-                #[cfg(all(feature = "wasm", not(feature = "native")))]
-                let ik = &*ik;
+                node_kind!(ik = idx_child);
                 if ik == "identifier" || ik == "nat" {
                     let id_text = source[idx_child.byte_range()].trim();
                     if let Some(idx) = resolve_local_text(id_text, func) {

--- a/src/diagnostics_core/tree_walk.rs
+++ b/src/diagnostics_core/tree_walk.rs
@@ -303,9 +303,7 @@ pub fn walk_tree_for_diagnostics(
 /// Check if an ERROR node is in a value type context (params, results, locals, globals)
 fn is_value_type_context(node: &Node) -> bool {
     if let Some(parent) = node.parent() {
-        let pk = parent.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let pk = &*pk;
+        node_kind!(pk = parent);
         matches!(
             pk,
             "func_type_params_many"
@@ -387,9 +385,7 @@ fn collect_local_uses(
     func: &crate::symbols::Function,
     used: &mut HashSet<usize>,
 ) {
-    let kind = node.kind();
-    #[cfg(all(feature = "wasm", not(feature = "native")))]
-    let kind = &*kind;
+    node_kind!(kind = node);
 
     if kind == "instr_plain" || kind == "expr1_plain" {
         let text = &source[node.byte_range()];
@@ -435,9 +431,7 @@ fn resolve_local_index(
 ) -> Option<usize> {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        let ck = child.kind();
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        let ck = &*ck;
+        node_kind!(ck = child);
 
         if ck == "index" || ck == "identifier" || ck == "nat" {
             let text = source[child.byte_range()].trim();
@@ -447,9 +441,7 @@ fn resolve_local_index(
             // Check inside index node for identifier/nat children
             let mut ic = child.walk();
             for idx_child in child.children(&mut ic) {
-                let ik = idx_child.kind();
-                #[cfg(all(feature = "wasm", not(feature = "native")))]
-                let ik = &*ik;
+                node_kind!(ik = idx_child);
                 if ik == "identifier" || ik == "nat" {
                     let id_text = source[idx_child.byte_range()].trim();
                     if let Some(idx) = resolve_local_text(id_text, func) {

--- a/src/features/folding/mod.rs
+++ b/src/features/folding/mod.rs
@@ -98,77 +98,53 @@ fn is_comment_kind(kind: &str) -> bool {
 }
 
 /// Recursively collect foldable nodes from the tree-sitter AST.
+macro_rules! collect_foldable_nodes_body {
+    ($node:ident, $cursor:ident, $ranges:ident) => {{
+        node_kind!(kind = $node);
+
+        let is_foldable = is_foldable_kind(kind);
+        let is_comment = is_comment_kind(kind);
+
+        if is_foldable || is_comment {
+            let start_line = $node.start_position().row as u32;
+            let end_line = $node.end_position().row as u32;
+
+            // Only fold if it spans multiple lines
+            if end_line > start_line {
+                $ranges.push(FoldingRangeResult {
+                    start_line,
+                    end_line,
+                    kind: if is_comment {
+                        FoldingRangeKind::Comment
+                    } else {
+                        FoldingRangeKind::Region
+                    },
+                });
+            }
+        }
+
+        // Recurse into children
+        for child in $node.children($cursor) {
+            let mut child_cursor = child.walk();
+            collect_foldable_nodes(child, &mut child_cursor, $ranges);
+        }
+    }};
+}
 #[cfg(feature = "native")]
 fn collect_foldable_nodes<'a>(
     node: Node<'a>,
     cursor: &mut TreeCursor<'a>,
     ranges: &mut Vec<FoldingRangeResult>,
 ) {
-    let kind = node.kind();
-
-    let is_foldable = is_foldable_kind(kind);
-    let is_comment = is_comment_kind(kind);
-
-    if is_foldable || is_comment {
-        let start_line = node.start_position().row as u32;
-        let end_line = node.end_position().row as u32;
-
-        // Only fold if it spans multiple lines
-        if end_line > start_line {
-            ranges.push(FoldingRangeResult {
-                start_line,
-                end_line,
-                kind: if is_comment {
-                    FoldingRangeKind::Comment
-                } else {
-                    FoldingRangeKind::Region
-                },
-            });
-        }
-    }
-
-    // Recurse into children
-    for child in node.children(cursor) {
-        let mut child_cursor = child.walk();
-        collect_foldable_nodes(child, &mut child_cursor, ranges);
-    }
+    collect_foldable_nodes_body!(node, cursor, ranges);
 }
-
-/// Recursively collect foldable nodes from the tree-sitter AST (WASM version).
 #[cfg(all(feature = "wasm", not(feature = "native")))]
 fn collect_foldable_nodes(
     node: Node,
     cursor: &mut TreeCursor,
     ranges: &mut Vec<FoldingRangeResult>,
 ) {
-    let kind = node.kind();
-
-    let is_foldable = is_foldable_kind(&kind);
-    let is_comment = is_comment_kind(&kind);
-
-    if is_foldable || is_comment {
-        let start_line = node.start_position().row as u32;
-        let end_line = node.end_position().row as u32;
-
-        // Only fold if it spans multiple lines
-        if end_line > start_line {
-            ranges.push(FoldingRangeResult {
-                start_line,
-                end_line,
-                kind: if is_comment {
-                    FoldingRangeKind::Comment
-                } else {
-                    FoldingRangeKind::Region
-                },
-            });
-        }
-    }
-
-    // Recurse into children
-    for child in node.children(cursor) {
-        let mut child_cursor = child.walk();
-        collect_foldable_nodes(child, &mut child_cursor, ranges);
-    }
+    collect_foldable_nodes_body!(node, cursor, ranges);
 }
 
 #[cfg(feature = "native")]

--- a/src/features/signature/call_info.rs
+++ b/src/features/signature/call_info.rs
@@ -28,16 +28,7 @@ pub struct CallInfo {
 /// Walks up the tree from `node` to find a call instruction and extracts the
 /// function/type name and argument count.
 pub fn find_function_call_ast(node: &Node, document: &str) -> Option<CallInfo> {
-    let mut current = {
-        #[cfg(feature = "native")]
-        {
-            *node
-        }
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        {
-            node.clone()
-        }
-    };
+    let mut current = node_copy!(node);
 
     loop {
         let kind = current.kind();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -98,7 +98,7 @@ pub fn determine_instruction_context(node: Node, document: &str) -> InstructionC
     let mut current = node;
 
     loop {
-        let kind = current.kind();
+        node_kind!(kind = current);
 
         // Check for instruction contexts
         if kind == "instr_plain"
@@ -112,12 +112,7 @@ pub fn determine_instruction_context(node: Node, document: &str) -> InstructionC
         }
 
         // Check for block/loop contexts (both instr_* and block_* variants)
-        #[cfg(feature = "native")]
         if is_block_kind(kind) {
-            return InstructionContext::Block;
-        }
-        #[cfg(all(feature = "wasm", not(feature = "native")))]
-        if is_block_kind(kind.as_str()) {
             return InstructionContext::Block;
         }
 
@@ -465,18 +460,20 @@ pub fn position_to_byte(source: &str, position: Position) -> usize {
     byte_offset
 }
 
-/// Find the AST node at the given position (native version - returns borrowed node)
+/// Find the AST node at the given position.
+macro_rules! node_at_position_body {
+    ($tree:ident, $source:ident, $position:ident) => {{
+        let byte_offset = position_to_byte($source, $position);
+        find_deepest_node($tree.root_node(), byte_offset)
+    }};
+}
 #[cfg(feature = "native")]
 pub fn node_at_position<'a>(tree: &'a Tree, source: &str, position: Position) -> Option<Node<'a>> {
-    let byte_offset = position_to_byte(source, position);
-    find_deepest_node(tree.root_node(), byte_offset)
+    node_at_position_body!(tree, source, position)
 }
-
-/// Find the AST node at the given position (WASM version - returns owned node)
 #[cfg(all(feature = "wasm", not(feature = "native")))]
 pub fn node_at_position(tree: &Tree, source: &str, position: Position) -> Option<Node> {
-    let byte_offset = position_to_byte(source, position);
-    find_deepest_node(tree.root_node(), byte_offset)
+    node_at_position_body!(tree, source, position)
 }
 
 /// Check if the given position is inside a comment (block or line)


### PR DESCRIPTION
Replace duplicated function implementations and inline `#[cfg]` blocks with shared macros across 5 files:

- `folding/mod.rs`: Deduplicate `collect_foldable_nodes` via body macro
- `utils.rs`: Deduplicate `node_at_position` via body macro; simplify `determine_instruction_context` with `node_kind!`
- `call_info.rs`: Replace inline cfg block with `node_copy!`
- `tree_walk.rs`: Replace 3 inline cfg blocks with `node_kind!`
- `local_init.rs`: Replace ~12 inline cfg blocks with `node_kind!`