### PR TITLE
defrag: optimize hot paths, eliminate redundant wrappers and allocations

### DIFF
--- a/src/diagnostics_core/module_checks.rs
+++ b/src/diagnostics_core/module_checks.rs
@@ -17,7 +17,7 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::core::types::{Diagnostic, Range};
-use crate::parser::normalize_identifier;
+use crate::parser::{normalize_identifier, parse_wat_nat};
 use crate::symbols::{Function, SymbolTable, TypeKind, ValueType};
 use crate::utils::{node_text, node_to_range};
 
@@ -2109,8 +2109,8 @@ fn check_ref_for_forward_type(
                         }
                     }
                 } else if ik == "nat" || ik == "dec_nat" || ik == "hex_nat" {
-                    if let Ok(idx) = parse_nat(node_text(&idx_child, source)) {
-                        if idx > current_type_index {
+                    if let Some(idx) = parse_wat_nat(node_text(&idx_child, source)) {
+                        if (idx as usize) > current_type_index {
                             diagnostics.push(
                                 Diagnostic::error(
                                     node_to_range(&idx_child),
@@ -2162,14 +2162,9 @@ fn walk_for_unknown_type_refs(
 ) {
     node_kind!(kind = node);
 
-    // Check ref_type nodes for numeric heap type indices
-    if kind == "ref_type" || kind == "_heap_type_or_ref" {
-        check_heap_type_index(node, source, max_type_count, diagnostics);
-    }
-
-    // Also check value_type_ref_type which can contain heap types
-    if kind == "value_type_ref_type" {
-        check_heap_type_index(node, source, max_type_count, diagnostics);
+    // Check ref_type/heap_type/value_type_ref_type nodes for numeric heap type indices
+    if kind == "ref_type" || kind == "_heap_type_or_ref" || kind == "value_type_ref_type" {
+        find_type_index_in_ref(node, node, source, max_type_count, diagnostics);
     }
 
     // Check type_use nodes (e.g., call_indirect (type N))
@@ -2183,23 +2178,6 @@ fn walk_for_unknown_type_refs(
     for child in node.children(&mut cursor) {
         walk_for_unknown_type_refs(&child, source, max_type_count, diagnostics);
     }
-}
-
-/// Check if a ref_type node contains an out-of-bounds numeric type index.
-/// Recursively searches for nat nodes within the ref_type's children.
-fn check_heap_type_index(
-    ref_type_node: &Node,
-    source: &str,
-    type_count: usize,
-    diagnostics: &mut Vec<Diagnostic>,
-) {
-    find_type_index_in_ref(
-        ref_type_node,
-        ref_type_node,
-        source,
-        type_count,
-        diagnostics,
-    );
 }
 
 /// Recursively search for numeric type indices within a ref_type subtree.
@@ -2217,8 +2195,8 @@ fn find_type_index_in_ref(
         // A nat/dec_nat/hex_nat inside a ref type is a numeric type index
         if ck == "nat" || ck == "dec_nat" || ck == "hex_nat" {
             let text = node_text(&child, source);
-            if let Ok(idx) = parse_nat(text) {
-                if idx >= type_count {
+            if let Some(idx) = parse_wat_nat(text) {
+                if (idx as usize) >= type_count {
                     diagnostics.push(
                         Diagnostic::error(node_to_range(root), format!("unknown type {}", idx))
                             .with_code("unknown-type"),
@@ -2257,8 +2235,8 @@ fn check_type_use_index(
 
                 if ick == "nat" || ick == "dec_nat" || ick == "hex_nat" {
                     let text = node_text(&idx_child, source);
-                    if let Ok(idx) = parse_nat(text) {
-                        if idx >= type_count {
+                    if let Some(idx) = parse_wat_nat(text) {
+                        if (idx as usize) >= type_count {
                             diagnostics.push(
                                 Diagnostic::error(
                                     node_to_range(type_use_node),
@@ -2277,8 +2255,8 @@ fn check_type_use_index(
             }
             // The index node might directly contain the numeric text
             let text = node_text(&child, source);
-            if let Ok(idx) = parse_nat(text) {
-                if idx >= type_count {
+            if let Some(idx) = parse_wat_nat(text) {
+                if (idx as usize) >= type_count {
                     diagnostics.push(
                         Diagnostic::error(
                             node_to_range(type_use_node),
@@ -2290,13 +2268,6 @@ fn check_type_use_index(
             }
         }
     }
-}
-
-/// Parse a nat (natural number) from text, handling hex prefix.
-fn parse_nat(text: &str) -> Result<usize, ()> {
-    crate::parser::parse_wat_nat(text)
-        .map(|v| v as usize)
-        .ok_or(())
 }
 
 // ============================================================================
@@ -2765,7 +2736,7 @@ fn resolve_data_offset_type(node: &Node, source: &str, symbols: &SymbolTable) ->
                             ValueType::I32
                         };
                     }
-                    if let Some(n) = crate::parser::parse_wat_nat(idx_text) {
+                    if let Some(n) = parse_wat_nat(idx_text) {
                         if let Some(mem) = symbols.memories.get(n as usize) {
                             return if mem.is_memory64 {
                                 ValueType::I64
@@ -2841,7 +2812,7 @@ fn resolve_elem_offset_type(node: &Node, source: &str, symbols: &SymbolTable) ->
                             ValueType::I32
                         };
                     }
-                    if let Some(n) = crate::parser::parse_wat_nat(idx_text) {
+                    if let Some(n) = parse_wat_nat(idx_text) {
                         if let Some(table) = symbols.tables.get(n as usize) {
                             return if table.is_table64 {
                                 ValueType::I64
@@ -3458,9 +3429,10 @@ fn resolve_call_indirect_table_idx(node: &Node, source: &str, symbols: &SymbolTa
                     return i;
                 }
                 // Not a table name — could be a type name, skip
-            } else if let Ok(idx) = parse_nat(text) {
+            } else if let Some(idx) = parse_wat_nat(text) {
                 // Numeric index — if it's within table count, it's a table index
                 // (For single-table modules, the first numeric index is the type index)
+                let idx = idx as usize;
                 if idx < symbols.tables.len() && symbols.tables.len() > 1 {
                     return idx;
                 }

--- a/src/diagnostics_core/semantic.rs
+++ b/src/diagnostics_core/semantic.rs
@@ -4104,8 +4104,8 @@ fn is_heap_subtype(sub: &str, sup: &str) -> bool {
         return true;
     }
 
-    let sub_is_concrete = is_concrete_type_ref(&sub);
-    let sup_is_concrete = is_concrete_type_ref(&sup);
+    let sub_is_concrete = is_concrete_type_ref(sub);
+    let sup_is_concrete = is_concrete_type_ref(sup);
 
     // If either is a concrete type index, we can't fully validate without
     // symbol table — be conservative and only flag clearly invalid casts
@@ -4115,12 +4115,9 @@ fn is_heap_subtype(sub: &str, sup: &str) -> bool {
         return true;
     }
 
-    match sup.as_str() {
-        "any" => matches!(
-            sub.as_str(),
-            "eq" | "i31" | "struct" | "array" | "none" | "null"
-        ),
-        "eq" => matches!(sub.as_str(), "i31" | "struct" | "array" | "none" | "null"),
+    match sup {
+        "any" => matches!(sub, "eq" | "i31" | "struct" | "array" | "none" | "null"),
+        "eq" => matches!(sub, "i31" | "struct" | "array" | "none" | "null"),
         "func" => sub == "nofunc",
         "extern" => sub == "noextern",
         "exn" => sub == "noexn",
@@ -4137,20 +4134,21 @@ fn is_concrete_type_ref(ty: &str) -> bool {
 }
 
 /// Normalize abbreviated heap type names to their canonical form.
-fn normalize_heap_type(ty: &str) -> String {
+/// Returns a `&str` (either static or a slice of the input) to avoid allocation.
+fn normalize_heap_type(ty: &str) -> &str {
     match ty {
-        "anyref" => "any".to_string(),
-        "funcref" => "func".to_string(),
-        "externref" => "extern".to_string(),
-        "eqref" => "eq".to_string(),
-        "i31ref" => "i31".to_string(),
-        "structref" => "struct".to_string(),
-        "arrayref" => "array".to_string(),
-        "nullref" => "null".to_string(),
-        "nullfuncref" => "nofunc".to_string(),
-        "nullexternref" => "noextern".to_string(),
-        "exnref" => "exn".to_string(),
-        "nullexnref" => "noexn".to_string(),
-        other => other.to_string(),
+        "anyref" => "any",
+        "funcref" => "func",
+        "externref" => "extern",
+        "eqref" => "eq",
+        "i31ref" => "i31",
+        "structref" => "struct",
+        "arrayref" => "array",
+        "nullref" => "null",
+        "nullfuncref" => "nofunc",
+        "nullexternref" => "noextern",
+        "exnref" => "exn",
+        "nullexnref" => "noexn",
+        other => other,
     }
 }

--- a/src/diagnostics_core/tree_walk.rs
+++ b/src/diagnostics_core/tree_walk.rs
@@ -92,7 +92,9 @@ pub fn walk_tree_for_diagnostics(
             }
         }
 
-        if !found_instr_list && !expected_results.is_empty() && !has_inline_import(&node) {
+        let is_import = has_inline_import(&node);
+
+        if !found_instr_list && !expected_results.is_empty() && !is_import {
             diagnostics.push(Diagnostic::error(
                 node_to_range(&node),
                 format!(
@@ -103,7 +105,7 @@ pub fn walk_tree_for_diagnostics(
         }
 
         // Check for uninitialized non-nullable ref locals
-        if !has_inline_import(&node) {
+        if !is_import {
             diagnostics.extend(
                 crate::diagnostics_core::local_init::check_uninitialized_locals(
                     &node, source, symbols,
@@ -112,7 +114,7 @@ pub fn walk_tree_for_diagnostics(
         }
 
         // Check for unused locals and parameters
-        if !has_inline_import(&node) {
+        if !is_import {
             check_unused_locals(&node, source, symbols, diagnostics);
         }
     }
@@ -209,31 +211,13 @@ pub fn walk_tree_for_diagnostics(
 
     // Check SIMD lane indices, alignment constraints, and GC struct field access
     if kind_str == "instr_plain" {
-        diagnostics.extend(crate::diagnostics_core::simd_checks::check_simd_lane_index(
-            &node, source,
-        ));
-        diagnostics.extend(crate::diagnostics_core::alignment_checks::check_alignment(
-            &node, source, symbols,
-        ));
-        diagnostics.extend(
-            crate::diagnostics_core::gc_checks::check_struct_field_access(&node, source, symbols),
-        );
+        check_instruction_diagnostics(&node, source, symbols, diagnostics);
     } else if kind_str == "expr1_plain" {
         // In folded form, instr_plain is a child that won't be visited separately
         let mut cursor = node.walk();
         for child in node.children(&mut cursor) {
             if child.kind() == "instr_plain" {
-                diagnostics.extend(crate::diagnostics_core::simd_checks::check_simd_lane_index(
-                    &child, source,
-                ));
-                diagnostics.extend(crate::diagnostics_core::alignment_checks::check_alignment(
-                    &child, source, symbols,
-                ));
-                diagnostics.extend(
-                    crate::diagnostics_core::gc_checks::check_struct_field_access(
-                        &child, source, symbols,
-                    ),
-                );
+                check_instruction_diagnostics(&child, source, symbols, diagnostics);
                 break;
             }
         }
@@ -300,6 +284,24 @@ pub fn walk_tree_for_diagnostics(
     }
 }
 
+/// Run SIMD lane, alignment, and GC struct field checks on an instr_plain node.
+fn check_instruction_diagnostics(
+    instr_node: &Node,
+    source: &str,
+    symbols: &SymbolTable,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    diagnostics.extend(crate::diagnostics_core::simd_checks::check_simd_lane_index(
+        instr_node, source,
+    ));
+    diagnostics.extend(crate::diagnostics_core::alignment_checks::check_alignment(
+        instr_node, source, symbols,
+    ));
+    diagnostics.extend(
+        crate::diagnostics_core::gc_checks::check_struct_field_access(instr_node, source, symbols),
+    );
+}
+
 /// Check if an ERROR node is in a value type context (params, results, locals, globals)
 fn is_value_type_context(node: &Node) -> bool {
     if let Some(parent) = node.parent() {
@@ -343,7 +345,7 @@ fn check_unused_locals(
     }
 
     // Collect all used indices by scanning the function body
-    let mut used_indices: HashSet<usize> = HashSet::new();
+    let mut used_indices: HashSet<usize> = HashSet::with_capacity(total);
     collect_local_uses(func_node, source, func, &mut used_indices);
 
     // Check parameters

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2452,8 +2452,19 @@ fn extract_tag(tag_node: &Node, source: &str, index: usize, symbols: &SymbolTabl
 }
 
 /// Parse a WAT natural number, handling hex (0x...) and underscore separators.
+/// Avoids allocation when text contains no underscores (the common case).
 pub(crate) fn parse_wat_nat(text: &str) -> Option<u64> {
-    let text = text.trim().replace('_', "");
+    let text = text.trim();
+    // Fast path: no underscores (common case avoids String allocation)
+    if !text.contains('_') {
+        return if text.starts_with("0x") || text.starts_with("0X") {
+            u64::from_str_radix(&text[2..], 16).ok()
+        } else {
+            text.parse::<u64>().ok()
+        };
+    }
+    // Slow path: strip underscores
+    let text = text.replace('_', "");
     if text.starts_with("0x") || text.starts_with("0X") {
         u64::from_str_radix(&text[2..], 16).ok()
     } else {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -387,39 +387,29 @@ pub fn get_line_at_position(document: &str, line_num: usize) -> Option<&str> {
 pub fn get_word_at_position(document: &str, position: Position) -> Option<String> {
     let line = get_line_at_position(document, position.line as usize)?;
 
-    let chars: Vec<char> = line.chars().collect();
-
-    // Convert UTF-16 offset to char index
-    let mut utf16_count = 0u32;
-    let mut col = 0usize;
-    for ch in &chars {
-        if utf16_count >= position.character {
-            break;
-        }
-        utf16_count += ch.len_utf16() as u32;
-        col += 1;
-    }
-
-    if col > chars.len() {
+    // Convert UTF-16 offset to byte offset directly (no Vec<char> allocation)
+    let byte_col = utf16_offset_to_byte_offset(line, position.character);
+    if byte_col > line.len() {
         return None;
     }
 
-    // Find word boundaries
-    let mut start = col;
-    let mut end = col;
+    // Find word start by scanning backwards from byte_col
+    let start = line[..byte_col]
+        .char_indices()
+        .rev()
+        .take_while(|&(_, c)| is_word_char(c))
+        .last()
+        .map_or(byte_col, |(i, _)| i);
 
-    // Move back to start of word
-    while start > 0 && is_word_char(chars.get(start - 1).copied()?) {
-        start -= 1;
-    }
-
-    // Move forward to end of word
-    while end < chars.len() && is_word_char(chars.get(end).copied()?) {
-        end += 1;
-    }
+    // Find word end by scanning forwards from byte_col
+    let end = line[byte_col..]
+        .char_indices()
+        .take_while(|&(_, c)| is_word_char(c))
+        .last()
+        .map_or(byte_col, |(i, c)| byte_col + i + c.len_utf8());
 
     if start < end {
-        Some(chars[start..end].iter().collect())
+        Some(line[start..end].to_string())
     } else {
         None
     }
@@ -446,18 +436,36 @@ pub fn utf16_offset_to_byte_offset(line: &str, utf16_offset: u32) -> usize {
     byte_offset
 }
 
-/// Convert an LSP Position to a byte offset in the source text
+/// Convert an LSP Position to a byte offset in the source text.
+/// Uses direct byte scanning for newlines instead of allocating line iterators.
 pub fn position_to_byte(source: &str, position: Position) -> usize {
-    let mut byte_offset = 0;
+    let target_line = position.line as usize;
+    let bytes = source.as_bytes();
 
-    for (current_line, line) in source.lines().enumerate() {
-        if current_line == position.line as usize {
-            return byte_offset + utf16_offset_to_byte_offset(line, position.character);
-        }
-        byte_offset += line.len() + 1; // +1 for newline
+    if target_line == 0 {
+        return utf16_offset_to_byte_offset(source, position.character);
     }
 
-    byte_offset
+    let mut current_line = 0;
+    for (i, &b) in bytes.iter().enumerate() {
+        if b == b'\n' {
+            current_line += 1;
+            if current_line == target_line {
+                let line_start = i + 1;
+                let line_end = bytes[line_start..]
+                    .iter()
+                    .position(|&b| b == b'\n')
+                    .map_or(source.len(), |p| line_start + p);
+                return line_start
+                    + utf16_offset_to_byte_offset(
+                        &source[line_start..line_end],
+                        position.character,
+                    );
+            }
+        }
+    }
+
+    source.len()
 }
 
 /// Find the AST node at the given position.
@@ -616,6 +624,13 @@ pub fn determine_context_with_fallback(
 ) -> InstructionContext {
     if let Some(node) = node_at_position(tree, document, position) {
         let ast_context = determine_instruction_context(node, document);
+
+        // Fast path: AST gave a definitive non-General, non-Block context
+        if ast_context != InstructionContext::General && ast_context != InstructionContext::Block {
+            return ast_context;
+        }
+
+        // Slow path: fall back to line-based detection
         let line_context = get_line_at_position(document, position.line as usize)
             .map(determine_context_from_line)
             .unwrap_or(InstructionContext::General);

--- a/tests/incremental_parsing.rs
+++ b/tests/incremental_parsing.rs
@@ -4,12 +4,10 @@
 
 #![cfg(feature = "native")]
 
-mod test_helpers;
-
 use std::time::Instant;
-use test_helpers::generate_large_wat;
 use tower_lsp::lsp_types::Position;
 use wat_lsp_rust::diagnostics::provide_tree_sitter_diagnostics;
+use wat_lsp_rust::test_utils::generate_large_wat;
 use wat_lsp_rust::tree_sitter_bindings::create_parser;
 use wat_lsp_rust::utils::apply_text_edit;
 

--- a/tests/large_file_performance.rs
+++ b/tests/large_file_performance.rs
@@ -5,12 +5,10 @@
 
 #![cfg(feature = "native")]
 
-mod test_helpers;
-
 use std::time::Instant;
-use test_helpers::generate_large_wat;
 use tower_lsp::lsp_types::Position;
 use wat_lsp_rust::core::types::Position as CorePosition;
+use wat_lsp_rust::test_utils::generate_large_wat;
 use wat_lsp_rust::tree_sitter_bindings::create_parser;
 use wat_lsp_rust::utils::apply_text_edit;
 use wat_lsp_rust::{diagnostics, parser};

--- a/tests/test_helpers.rs
+++ b/tests/test_helpers.rs
@@ -1,5 +1,0 @@
-//! Shared test utilities for WAT LSP integration tests.
-//!
-//! Re-exports the canonical generate_large_wat from the library.
-
-pub use wat_lsp_rust::test_utils::generate_large_wat;


### PR DESCRIPTION
## Summary

- **Optimize `get_word_at_position()`**: eliminate `Vec<char>` allocation by using `char_indices()` iterators directly
- **Optimize `position_to_byte()`**: replace `source.lines().enumerate()` with direct byte scanning for newlines
- **Optimize `parse_wat_nat()`**: fast path for numbers without underscores avoids `String` allocation
- **Optimize `normalize_heap_type()`**: return `&str` instead of `String`, eliminating 13 allocations per call
- **Lazy `determine_context_with_fallback()`**: skip line-based detection when AST gives a definitive context
- **Inline `parse_nat` wrapper** in module_checks.rs: use `parse_wat_nat()` directly
- **Inline `check_heap_type_index` wrapper**: remove trivial forwarding function
- **Extract `check_instruction_diagnostics()`**: consolidate duplicate SIMD/alignment/GC checks
- **Cache `has_inline_import` result**: avoid 3x redundant calls on same node
- **Remove redundant `tests/test_helpers.rs`**: use direct library imports instead