### PR TITLE
defrag: optimize hot paths, reduce cloning, and consolidate lookup patterns

### DIFF
--- a/src/diagnostics_core/local_init.rs
+++ b/src/diagnostics_core/local_init.rs
@@ -41,11 +41,10 @@ pub(crate) fn check_uninitialized_locals(
     }
 
     // Initialize tracking: params are always initialized, defaultable locals are initialized
+    // Use Vec<bool> instead of HashSet<usize> for O(1) clone (memcpy) and O(1) lookups
     let num_params = func.parameters.len();
     let total = num_params + func.locals.len();
-    let mut initialized: HashSet<usize> = (0..total)
-        .filter(|i| !non_defaultable.contains(i))
-        .collect();
+    let mut initialized: Vec<bool> = (0..total).map(|i| !non_defaultable.contains(&i)).collect();
 
     let mut diagnostics = Vec::new();
 
@@ -171,7 +170,7 @@ fn walk_body(
     source: &str,
     func: &Function,
     non_defaultable: &HashSet<usize>,
-    initialized: &mut HashSet<usize>,
+    initialized: &mut Vec<bool>,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
     let mut cursor = node.walk();
@@ -193,7 +192,7 @@ fn walk_node(
     source: &str,
     func: &Function,
     non_defaultable: &HashSet<usize>,
-    initialized: &mut HashSet<usize>,
+    initialized: &mut Vec<bool>,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
     node_kind!(kind = node);
@@ -265,7 +264,7 @@ fn walk_node(
                     diagnostics,
                 );
             }
-            *initialized = saved;
+            initialized.copy_from_slice(&saved);
         }
         "block_block" | "block_loop" | "block_try_table" | "block_try" => {
             let saved = initialized.clone();
@@ -277,7 +276,7 @@ fn walk_node(
                 initialized,
                 diagnostics,
             );
-            *initialized = saved;
+            initialized.copy_from_slice(&saved);
         }
 
         // Folded block/loop
@@ -291,7 +290,7 @@ fn walk_node(
                 initialized,
                 diagnostics,
             );
-            *initialized = saved;
+            initialized.copy_from_slice(&saved);
         }
 
         // If: save/restore same as block (control flow doesn't contribute to init)
@@ -306,7 +305,7 @@ fn walk_node(
                 diagnostics,
                 &saved,
             );
-            *initialized = saved;
+            initialized.copy_from_slice(&saved);
         }
         "block_if" | "if_block" => {
             let saved = initialized.clone();
@@ -319,7 +318,7 @@ fn walk_node(
                 diagnostics,
                 &saved,
             );
-            *initialized = saved;
+            initialized.copy_from_slice(&saved);
         }
 
         // Default: recurse into children in order
@@ -343,9 +342,9 @@ fn walk_if_body(
     source: &str,
     func: &Function,
     non_defaultable: &HashSet<usize>,
-    initialized: &mut HashSet<usize>,
+    initialized: &mut Vec<bool>,
     diagnostics: &mut Vec<Diagnostic>,
-    saved: &HashSet<usize>,
+    saved: &[bool],
 ) {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
@@ -354,7 +353,7 @@ fn walk_if_body(
         match ck {
             // Linear format: else branch is in a separate node
             "instr_else" => {
-                *initialized = saved.clone();
+                initialized.copy_from_slice(saved);
                 walk_body(
                     &child,
                     source,
@@ -366,7 +365,7 @@ fn walk_if_body(
             }
             // Folded format: "else" keyword resets state
             "else" => {
-                *initialized = saved.clone();
+                initialized.copy_from_slice(saved);
             }
             // if_block / block_if contain the then/else structure — recurse
             "if_block" | "block_if" => {
@@ -412,7 +411,7 @@ fn check_local_instruction(
     source: &str,
     func: &Function,
     non_defaultable: &HashSet<usize>,
-    initialized: &mut HashSet<usize>,
+    initialized: &mut [bool],
     diagnostics: &mut Vec<Diagnostic>,
 ) {
     let text = &source[node.byte_range()];
@@ -421,7 +420,8 @@ fn check_local_instruction(
     match first_token {
         "local.get" => {
             if let Some(idx) = resolve_local_index_from_node(node, source, func) {
-                if non_defaultable.contains(&idx) && !initialized.contains(&idx) {
+                if non_defaultable.contains(&idx) && !initialized.get(idx).copied().unwrap_or(true)
+                {
                     diagnostics.push(Diagnostic::error(
                         node_to_range(node),
                         "uninitialized local".to_string(),
@@ -431,7 +431,9 @@ fn check_local_instruction(
         }
         "local.set" | "local.tee" => {
             if let Some(idx) = resolve_local_index_from_node(node, source, func) {
-                initialized.insert(idx);
+                if idx < initialized.len() {
+                    initialized[idx] = true;
+                }
             }
         }
         _ => {}

--- a/src/diagnostics_core/module_checks.rs
+++ b/src/diagnostics_core/module_checks.rs
@@ -259,7 +259,7 @@ fn check_duplicate_exports(module: &Node, source: &str, diagnostics: &mut Vec<Di
         match fk {
             // Standalone export: (export "name" (func $idx))
             "module_field_export" => {
-                if let Some(name) = extract_export_name(field, source) {
+                if let Some(name) = extract_name_child(field, source) {
                     check_export_name(name, field, &mut seen_exports, diagnostics);
                 }
             }
@@ -282,10 +282,6 @@ fn check_duplicate_exports(module: &Node, source: &str, diagnostics: &mut Vec<Di
             _ => {}
         }
     });
-}
-
-fn extract_export_name<'a>(node: &Node, source: &'a str) -> Option<&'a str> {
-    extract_name_child(node, source)
 }
 
 fn extract_name_child<'a>(node: &Node, source: &'a str) -> Option<&'a str> {

--- a/src/diagnostics_core/semantic.rs
+++ b/src/diagnostics_core/semantic.rs
@@ -1012,12 +1012,14 @@ fn derive_consumed_types_from_name(
         // Call — consume parameter types
         "call" | "return_call" => {
             if let Some(func_ref) = get_index_from_node(node, source) {
-                if let Some(func) = symbols.get_function_by_name(func_ref) {
-                    return Some(func.parameters.iter().map(|p| p.param_type).collect());
-                } else if let Ok(idx) = func_ref.parse::<usize>() {
-                    if let Some(func) = symbols.get_function_by_index(idx) {
-                        return Some(func.parameters.iter().map(|p| p.param_type).collect());
-                    }
+                let func = symbols.get_function_by_name(func_ref).or_else(|| {
+                    func_ref
+                        .parse::<usize>()
+                        .ok()
+                        .and_then(|idx| symbols.get_function_by_index(idx))
+                });
+                if let Some(f) = func {
+                    return Some(f.parameters.iter().map(|p| p.param_type).collect());
                 }
             }
             None // fall back to untyped
@@ -1026,19 +1028,12 @@ fn derive_consumed_types_from_name(
         // Call_ref — consume param types + typed funcref (ref null $type)
         "call_ref" | "return_call_ref" => {
             if let Some(type_ref) = get_index_from_node(node, source) {
-                if let Some(type_def) = symbols.get_type_by_name(type_ref) {
-                    if let TypeKind::Func { params, .. } = &type_def.kind {
-                        let mut types: Vec<ValueType> = params.clone();
-                        types.push(ValueType::RefNull(type_def.index as u32));
+                if let Some(td) = resolve_type_ref(type_ref, symbols) {
+                    if let TypeKind::Func { params, .. } = &td.kind {
+                        let mut types = Vec::with_capacity(params.len() + 1);
+                        types.extend_from_slice(params);
+                        types.push(ValueType::RefNull(td.index as u32));
                         return Some(types);
-                    }
-                } else if let Some(idx) = parse_wat_nat(type_ref) {
-                    if let Some(type_def) = symbols.get_type_by_index(idx as usize) {
-                        if let TypeKind::Func { params, .. } = &type_def.kind {
-                            let mut types: Vec<ValueType> = params.clone();
-                            types.push(ValueType::RefNull(type_def.index as u32));
-                            return Some(types);
-                        }
                     }
                 }
             }
@@ -1314,7 +1309,8 @@ fn get_call_indirect_consumed_types(
     // First, try to resolve from type_use (handles multi-table where first index is table ref)
     if let Some(td) = resolve_call_indirect_type(node, source, symbols) {
         if let TypeKind::Func { params, .. } = &td.kind {
-            let mut types = params.clone();
+            let mut types = Vec::with_capacity(params.len() + 1);
+            types.extend_from_slice(params);
             types.push(table_idx_type);
             return types;
         }
@@ -1459,27 +1455,23 @@ fn get_dynamic_operand_count(
     match instr_name {
         "call" | "return_call" => {
             if let Some(func_ref) = get_index_from_node(node, source) {
-                if let Some(func) = symbols.get_function_by_name(func_ref) {
-                    return func.parameters.len();
-                } else if let Ok(idx) = func_ref.parse::<usize>() {
-                    if let Some(func) = symbols.get_function_by_index(idx) {
-                        return func.parameters.len();
-                    }
+                let func = symbols.get_function_by_name(func_ref).or_else(|| {
+                    func_ref
+                        .parse::<usize>()
+                        .ok()
+                        .and_then(|idx| symbols.get_function_by_index(idx))
+                });
+                if let Some(f) = func {
+                    return f.parameters.len();
                 }
             }
             0
         }
         "call_ref" | "return_call_ref" => {
             if let Some(type_ref) = get_index_from_node(node, source) {
-                if let Some(type_def) = symbols.get_type_by_name(type_ref) {
-                    if let TypeKind::Func { params, .. } = &type_def.kind {
+                if let Some(td) = resolve_type_ref(type_ref, symbols) {
+                    if let TypeKind::Func { params, .. } = &td.kind {
                         return params.len() + 1;
-                    }
-                } else if let Ok(idx) = type_ref.parse::<usize>() {
-                    if let Some(type_def) = symbols.get_type_by_index(idx) {
-                        if let TypeKind::Func { params, .. } = &type_def.kind {
-                            return params.len() + 1;
-                        }
                     }
                 }
             }
@@ -1487,15 +1479,9 @@ fn get_dynamic_operand_count(
         }
         "call_indirect" | "return_call_indirect" => {
             if let Some(type_ref) = get_index_from_node(node, source) {
-                if let Some(type_def) = symbols.get_type_by_name(type_ref) {
-                    if let TypeKind::Func { params, .. } = &type_def.kind {
+                if let Some(td) = resolve_type_ref(type_ref, symbols) {
+                    if let TypeKind::Func { params, .. } = &td.kind {
                         return params.len() + 1;
-                    }
-                } else if let Ok(idx) = type_ref.parse::<usize>() {
-                    if let Some(type_def) = symbols.get_type_by_index(idx) {
-                        if let TypeKind::Func { params, .. } = &type_def.kind {
-                            return params.len() + 1;
-                        }
                     }
                 }
             }
@@ -1503,15 +1489,9 @@ fn get_dynamic_operand_count(
         }
         "struct.new" => {
             if let Some(type_ref) = get_index_from_node(node, source) {
-                if let Some(type_def) = symbols.get_type_by_name(type_ref) {
-                    if let TypeKind::Struct { fields } = &type_def.kind {
+                if let Some(td) = resolve_type_ref(type_ref, symbols) {
+                    if let TypeKind::Struct { fields } = &td.kind {
                         return fields.len();
-                    }
-                } else if let Ok(idx) = type_ref.parse::<usize>() {
-                    if let Some(type_def) = symbols.get_type_by_index(idx) {
-                        if let TypeKind::Struct { fields } = &type_def.kind {
-                            return fields.len();
-                        }
                     }
                 }
             }
@@ -1520,12 +1500,14 @@ fn get_dynamic_operand_count(
         "array.new_fixed" => get_array_new_fixed_count(node, source),
         "throw" => {
             if let Some(tag_ref) = get_index_from_node(node, source) {
-                if let Some(tag) = symbols.get_tag_by_name(tag_ref) {
-                    return tag.params.len();
-                } else if let Ok(idx) = tag_ref.parse::<usize>() {
-                    if let Some(tag) = symbols.get_tag_by_index(idx) {
-                        return tag.params.len();
-                    }
+                let tag = symbols.get_tag_by_name(tag_ref).or_else(|| {
+                    tag_ref
+                        .parse::<usize>()
+                        .ok()
+                        .and_then(|idx| symbols.get_tag_by_index(idx))
+                });
+                if let Some(t) = tag {
+                    return t.params.len();
                 }
             }
             0
@@ -1899,12 +1881,14 @@ fn get_ref_func_result_type(node: &Node, symbols: &SymbolTable, source: &str) ->
 /// Get result types for a call instruction
 fn get_call_result_types(node: &Node, symbols: &SymbolTable, source: &str) -> Vec<ValueType> {
     if let Some(func_ref) = get_index_from_node(node, source) {
-        if let Some(func) = symbols.get_function_by_name(func_ref) {
-            return func.results.clone();
-        } else if let Ok(idx) = func_ref.parse::<usize>() {
-            if let Some(func) = symbols.get_function_by_index(idx) {
-                return func.results.clone();
-            }
+        let func = symbols.get_function_by_name(func_ref).or_else(|| {
+            func_ref
+                .parse::<usize>()
+                .ok()
+                .and_then(|idx| symbols.get_function_by_index(idx))
+        });
+        if let Some(f) = func {
+            return f.results.clone();
         }
     }
     vec![]
@@ -1913,15 +1897,9 @@ fn get_call_result_types(node: &Node, symbols: &SymbolTable, source: &str) -> Ve
 /// Get result types for a call_ref instruction
 fn get_call_ref_result_types(node: &Node, symbols: &SymbolTable, source: &str) -> Vec<ValueType> {
     if let Some(type_ref) = get_index_from_node(node, source) {
-        if let Some(type_def) = symbols.get_type_by_name(type_ref) {
-            if let TypeKind::Func { results, .. } = &type_def.kind {
+        if let Some(td) = resolve_type_ref(type_ref, symbols) {
+            if let TypeKind::Func { results, .. } = &td.kind {
                 return results.clone();
-            }
-        } else if let Ok(idx) = type_ref.parse::<usize>() {
-            if let Some(type_def) = symbols.get_type_by_index(idx) {
-                if let TypeKind::Func { results, .. } = &type_def.kind {
-                    return results.clone();
-                }
             }
         }
     }
@@ -1951,12 +1929,7 @@ fn resolve_call_indirect_type<'a>(
     }
     // No type_use found — try first index as a type reference (single-table mode)
     if let Some(ref idx_text) = first_index {
-        if let Some(td) = symbols.get_type_by_name(idx_text) {
-            return Some(td);
-        }
-        if let Ok(idx) = idx_text.parse::<usize>() {
-            return symbols.get_type_by_index(idx);
-        }
+        return resolve_type_ref(idx_text, symbols);
     }
     None
 }
@@ -2087,39 +2060,32 @@ fn get_expr1_wrapper_info<'a>(expr1: &Node, source: &'a str) -> Option<(&'a str,
 
 /// Get instruction info from an expr1_* node
 fn get_expr1_info<'a>(expr1: &Node, source: &'a str) -> Option<(&'a str, usize)> {
-    let mut expr_cursor = expr1.walk();
-    let explicit_operands = expr1
-        .children(&mut expr_cursor)
-        .filter(|c| {
-            node_kind!(kind = c);
-            kind == "expr"
-        })
-        .count();
-
     let mut cursor = expr1.walk();
+    let mut explicit_operands = 0usize;
+    let mut instr_name: Option<&'a str> = None;
+
     for child in expr1.children(&mut cursor) {
         node_kind!(kind = child);
 
-        if kind == "instr_plain" {
-            if let Some(name) = get_instruction_name(&child, source) {
-                return Some((name, explicit_operands));
-            }
-        }
-        if kind == "call_indirect" {
-            return Some(("call_indirect", explicit_operands));
-        }
-        if kind == "return_call_indirect" {
-            return Some(("return_call_indirect", explicit_operands));
-        }
-        if kind == "instr_call" {
-            let text = &source[child.byte_range()];
-            let first_token = text.split_whitespace().next().unwrap_or("");
-            if !first_token.is_empty() {
-                return Some((first_token, explicit_operands));
+        if kind == "expr" {
+            explicit_operands += 1;
+        } else if instr_name.is_none() {
+            if kind == "instr_plain" {
+                instr_name = get_instruction_name(&child, source);
+            } else if kind == "call_indirect" {
+                instr_name = Some("call_indirect");
+            } else if kind == "return_call_indirect" {
+                instr_name = Some("return_call_indirect");
+            } else if kind == "instr_call" {
+                let text = &source[child.byte_range()];
+                let first_token = text.split_whitespace().next().unwrap_or("");
+                if !first_token.is_empty() {
+                    instr_name = Some(first_token);
+                }
             }
         }
     }
-    None
+    instr_name.map(|name| (name, explicit_operands))
 }
 
 /// Get the expected operand count for an instruction (fixed or dynamic)
@@ -2610,12 +2576,14 @@ fn get_expr1_result_types(expr1: &Node, source: &str, symbols: &SymbolTable) -> 
                 }
             }
             if let Some(func_ref) = get_index_from_expr1_call(expr1, source) {
-                if let Some(func) = symbols.get_function_by_name(func_ref) {
-                    return func.results.clone();
-                } else if let Ok(idx) = func_ref.parse::<usize>() {
-                    if let Some(func) = symbols.get_function_by_index(idx) {
-                        return func.results.clone();
-                    }
+                let func = symbols.get_function_by_name(func_ref).or_else(|| {
+                    func_ref
+                        .parse::<usize>()
+                        .ok()
+                        .and_then(|idx| symbols.get_function_by_index(idx))
+                });
+                if let Some(f) = func {
+                    return f.results.clone();
                 }
             }
             vec![]
@@ -2671,6 +2639,16 @@ fn resolve_block_type_use<'a>(
     None
 }
 
+/// Resolve a type reference (name or numeric index) to a TypeDef.
+fn resolve_type_ref<'a>(type_ref: &str, symbols: &'a SymbolTable) -> Option<&'a TypeDef> {
+    symbols.get_type_by_name(type_ref).or_else(|| {
+        type_ref
+            .parse::<usize>()
+            .ok()
+            .and_then(|idx| symbols.get_type_by_index(idx))
+    })
+}
+
 /// Resolve a type_use node to a TypeDef via the symbol table.
 fn resolve_type_use_node<'a>(
     type_use_node: &Node,
@@ -2714,12 +2692,14 @@ fn resolve_type_index_to_func_sig(
     }
 
     // Build implicit type table: explicit type sigs + unique function sigs
-    let mut sigs: Vec<(Vec<ValueType>, Vec<ValueType>)> = Vec::new();
-    let mut seen = std::collections::HashSet::new();
+    let capacity = symbols.types.len() + symbols.functions.len();
+    let mut sigs: Vec<(Vec<ValueType>, Vec<ValueType>)> = Vec::with_capacity(capacity);
+    let mut seen = std::collections::HashSet::with_capacity(capacity);
     for type_def in &symbols.types {
         if let TypeKind::Func { params, results } = &type_def.kind {
-            seen.insert((params.clone(), results.clone()));
-            sigs.push((params.clone(), results.clone()));
+            let sig = (params.clone(), results.clone());
+            seen.insert(sig.clone());
+            sigs.push(sig);
         }
     }
     for func in &symbols.functions {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1058,8 +1058,9 @@ fn resolve_implicit_type(
     idx: usize,
     symbol_table: &SymbolTable,
 ) -> Option<(Vec<ValueType>, Vec<ValueType>)> {
-    let mut sigs: Vec<(Vec<ValueType>, Vec<ValueType>)> = Vec::new();
-    let mut seen = std::collections::HashSet::new();
+    let capacity = symbol_table.types.len() + symbol_table.functions.len();
+    let mut sigs: Vec<(Vec<ValueType>, Vec<ValueType>)> = Vec::with_capacity(capacity);
+    let mut seen = std::collections::HashSet::with_capacity(capacity);
     for type_def in &symbol_table.types {
         if let TypeKind::Func { params, results } = &type_def.kind {
             let sig = (params.clone(), results.clone());


### PR DESCRIPTION
## Summary
- **local_init.rs**: Replace `HashSet<usize>` with `Vec<bool>` for initialization tracking — clone becomes memcpy, lookups become array indexing
- **semantic.rs**: Extract `resolve_type_ref()` helper to consolidate 6+ repeated name-or-index lookup chains
- **semantic.rs**: Use `extend_from_slice` instead of `clone() + push` for call_ref/call_indirect type resolution
- **semantic.rs**: Merge double tree walk in `get_expr1_info()` into single pass
- **semantic.rs**: Use `.or_else()` chains for function/tag lookups replacing nested if-let chains
- **parser.rs + semantic.rs**: Add `Vec::with_capacity` for implicit type resolution tables
- **module_checks.rs**: Remove trivial `extract_export_name` wrapper