### PR TITLE
add identifier coverage test, fix memory_use/elem context detection

### DIFF
--- a/src/features/definition/tests.rs
+++ b/src/features/definition/tests.rs
@@ -732,3 +732,137 @@ fn test_goto_definition_export_with_array_in_name() {
         "$lookup_table definition should be on line 7"
     );
 }
+
+#[test]
+fn test_goto_type_definition_from_call_indirect() {
+    let document = r#"(module
+  (type $unary (func (param i32) (result i32)))
+  (type $binary (func (param i32 i32) (result i32)))
+
+  (table 5 funcref)
+  (elem (i32.const 0) func $double $square)
+
+  (func $double (param $x i32) (result i32)
+    (i32.mul (local.get $x) (i32.const 2)))
+
+  (func $square (param $x i32) (result i32)
+    (i32.mul (local.get $x) (local.get $x)))
+
+  (func (export "double_then_square") (param $x i32) (result i32)
+    local.get $x
+    i32.const 0
+    call_indirect (type $unary)
+    i32.const 1
+    call_indirect (type $unary))
+)"#;
+
+    let symbols = parse_document(document).expect("Failed to parse document");
+    let tree = create_test_tree(document);
+    let uri = create_uri();
+
+    // Position on "$unary" in first call_indirect (type $unary) - line 16
+    // Line 16: "    call_indirect (type $unary)"
+    let line16 = document.lines().nth(16).unwrap();
+    let col = line16
+        .find("$unary")
+        .expect("Should find $unary on line 16");
+    let position = Position::new(16, col as u32);
+
+    let location = provide_definition(document, &symbols, &tree, position, &uri);
+
+    assert!(
+        location.is_some(),
+        "Should find definition for $unary from call_indirect. Line: '{}', col: {}",
+        line16.trim(),
+        col
+    );
+    let location = location.unwrap();
+    assert_eq!(
+        location.range.start.line, 1,
+        "$unary definition should be on line 1"
+    );
+}
+
+#[test]
+fn test_goto_function_definition_in_elem_segment() {
+    let document = r#"(module
+  (func $double (param i32) (result i32)
+    local.get 0
+    i32.const 2
+    i32.mul)
+  (func $square (param i32) (result i32)
+    local.get 0
+    local.get 0
+    i32.mul)
+  (table 2 funcref)
+  (elem (i32.const 0) func $double $square)
+)"#;
+
+    let symbols = parse_document(document).expect("Failed to parse document");
+    let tree = create_test_tree(document);
+    let uri = create_uri();
+
+    // Position at "$double" in the elem segment (line 10, col 27)
+    let position = Position::new(10, 28);
+
+    let location = provide_definition(document, &symbols, &tree, position, &uri);
+
+    assert!(
+        location.is_some(),
+        "Should find definition for $double in elem segment"
+    );
+    let location = location.unwrap();
+    assert_eq!(
+        location.range.start.line, 1,
+        "$double definition should be on line 1"
+    );
+
+    // Also test $square
+    let position = Position::new(10, 37);
+
+    let location = provide_definition(document, &symbols, &tree, position, &uri);
+
+    assert!(
+        location.is_some(),
+        "Should find definition for $square in elem segment"
+    );
+    let location = location.unwrap();
+    assert_eq!(
+        location.range.start.line, 5,
+        "$square definition should be on line 5"
+    );
+}
+
+#[test]
+fn test_goto_function_definition_in_elem_segment_bare_index() {
+    // Abbreviated elem form without `func` keyword: (elem (offset ...) $f1 $f2)
+    let document = r#"(module
+  (func $double (param i32) (result i32)
+    local.get 0
+    i32.const 2
+    i32.mul)
+  (table 1 funcref)
+  (elem (i32.const 0) $double)
+)"#;
+
+    let symbols = parse_document(document).expect("Failed to parse document");
+    let tree = create_test_tree(document);
+    let uri = create_uri();
+
+    // Position at "$double" in the bare elem segment (line 6)
+    // "  (elem (i32.const 0) $double)"
+    //                        ^ col 22
+    let position = Position::new(6, 23);
+
+    let location = provide_definition(document, &symbols, &tree, position, &uri);
+
+    assert!(
+        location.is_some(),
+        "Should find definition for $double in bare elem segment"
+    );
+    let location = location.unwrap();
+    assert_eq!(
+        location.range.start.line, 1,
+        "$double definition should be on line 1"
+    );
+}

--- a/src/features/references/tests.rs
+++ b/src/features/references/tests.rs
@@ -592,6 +592,165 @@ fn test_type_references() {
 }
 
 #[test]
+fn test_type_references_call_indirect() {
+    let source = r#"(module
+  (type $unary (func (param i32) (result i32)))
+  (type $binary (func (param i32 i32) (result i32)))
+
+  (table 5 funcref)
+  (elem (i32.const 0) func $double $square $negate $inc $add)
+
+  (func $double (param $x i32) (result i32)
+    (i32.mul (local.get $x) (i32.const 2)))
+
+  (func $square (param $x i32) (result i32)
+    (i32.mul (local.get $x) (local.get $x)))
+
+  (func $negate (param $x i32) (result i32)
+    (i32.sub (i32.const 0) (local.get $x)))
+
+  (func $inc (param $x i32) (result i32)
+    (i32.add (local.get $x) (i32.const 1)))
+
+  (func $add (param $a i32) (param $b i32) (result i32)
+    (i32.add (local.get $a) (local.get $b)))
+
+  ;; Linear call_indirect
+  (func (export "double_then_square") (param $x i32) (result i32)
+    local.get $x
+    i32.const 0
+    call_indirect (type $unary)
+    i32.const 1
+    call_indirect (type $unary))
+
+  ;; Chained linear
+  (func (export "pipeline3") (param $x i32) (result i32)
+    local.get $x
+    i32.const 0
+    call_indirect (type $unary)
+    i32.const 2
+    call_indirect (type $unary)
+    i32.const 3
+    call_indirect (type $unary))
+
+  ;; Mixed types
+  (func (export "double_both_and_add") (param $a i32) (param $b i32) (result i32)
+    local.get $a
+    i32.const 0
+    call_indirect (type $unary)
+    local.get $b
+    i32.const 0
+    call_indirect (type $unary)
+    i32.const 4
+    call_indirect (type $binary))
+
+  ;; Folded call_indirect
+  (func (export "mixed_chain") (param $x i32) (result i32)
+    (call_indirect (type $unary)
+      (call_indirect (type $unary)
+        (local.get $x)
+        (i32.const 0))
+      (i32.const 1)))
+
+  ;; Dynamic pipeline
+  (func (export "apply_twice") (param $x i32) (param $op i32) (result i32)
+    local.get $x
+    local.get $op
+    call_indirect (type $unary)
+    local.get $op
+    call_indirect (type $unary))
+)"#;
+
+    let symbols = parse_document(source).unwrap();
+    let tree = create_test_tree(source);
+
+    // --- Test $unary references from the type definition (line 1) ---
+    let position = Position {
+        line: 1,
+        character: 9,
+    };
+
+    let target = identify_symbol_at_position(source, &symbols, &tree, position);
+    assert!(
+        target.is_some(),
+        "Should identify $unary at type definition"
+    );
+
+    let refs = provide_references(source, &symbols, &tree, position, "file:///test.wat", false);
+
+    // $unary is used in 11 call_indirect instructions (linear + folded)
+    assert_eq!(
+        refs.len(),
+        11,
+        "Expected 11 references for $unary in call_indirect, got {}: {:?}",
+        refs.len(),
+        refs.iter().map(|r| r.range.start.line).collect::<Vec<_>>()
+    );
+
+    // --- Test $binary references from the type definition (line 2) ---
+    let position_binary = Position {
+        line: 2,
+        character: 9,
+    };
+
+    let refs_binary = provide_references(
+        source,
+        &symbols,
+        &tree,
+        position_binary,
+        "file:///test.wat",
+        false,
+    );
+
+    assert_eq!(
+        refs_binary.len(),
+        1,
+        "Expected 1 reference for $binary in call_indirect, got {}: {:?}",
+        refs_binary.len(),
+        refs_binary
+            .iter()
+            .map(|r| r.range.start.line)
+            .collect::<Vec<_>>()
+    );
+
+    // --- Test go-to-reference from a call_indirect usage ---
+    // Find the first line with "call_indirect (type $unary)"
+    let (usage_line, usage_col) = source
+        .lines()
+        .enumerate()
+        .find_map(|(i, line)| {
+            line.find("$unary")
+                .filter(|_| line.contains("call_indirect"))
+                .map(|col| (i, col))
+        })
+        .expect("Should find a call_indirect (type $unary) line");
+    let position_usage = Position {
+        line: usage_line as u32,
+        character: usage_col as u32,
+    };
+
+    let refs_from_usage = provide_references(
+        source,
+        &symbols,
+        &tree,
+        position_usage,
+        "file:///test.wat",
+        false,
+    );
+
+    assert_eq!(
+        refs_from_usage.len(),
+        11,
+        "Should find same 11 references from usage site, got {}: {:?}",
+        refs_from_usage.len(),
+        refs_from_usage
+            .iter()
+            .map(|r| r.range.start.line)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn test_nested_blocks_depth() {
     let source = r#"(module
   (func $test
@@ -1091,5 +1250,101 @@ fn test_tag_references_from_throw() {
         2,
         "Expected 2 references for $div_error (catch and throw), got {:?}",
         refs.iter().map(|r| r.range.start.line).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn test_function_references_include_elem_segment() {
+    let source = r#"(module
+  (func $add (param i32 i32) (result i32)
+    local.get 0
+    local.get 1
+    i32.add)
+  (table 1 funcref)
+  (elem (i32.const 0) func $add)
+  (func $main
+    i32.const 5
+    i32.const 3
+    call $add
+    drop)
+)"#;
+
+    let symbols = parse_document(source).unwrap();
+    let tree = create_test_tree(source);
+
+    // Position on "call $add" at line 10
+    let position = Position {
+        line: 10,
+        character: 10,
+    };
+
+    let refs = provide_references(source, &symbols, &tree, position, "file:///test.wat", false);
+
+    let ref_lines: Vec<_> = refs.iter().map(|r| r.range.start.line).collect();
+
+    // Should find 2 references: elem segment (line 6) and call instruction (line 10)
+    assert_eq!(
+        refs.len(),
+        2,
+        "Expected 2 references for $add (elem and call), got {:?}",
+        ref_lines
+    );
+    assert!(
+        ref_lines.contains(&6),
+        "Should find reference in elem segment at line 6, got {:?}",
+        ref_lines
+    );
+    assert!(
+        ref_lines.contains(&10),
+        "Should find reference in call at line 10, got {:?}",
+        ref_lines
+    );
+}
+
+#[test]
+fn test_function_references_include_bare_elem_segment() {
+    let source = r#"(module
+  (func $add (param i32 i32) (result i32)
+    local.get 0
+    local.get 1
+    i32.add)
+  (table 1 funcref)
+  (elem (i32.const 0) $add)
+  (func $main
+    i32.const 5
+    i32.const 3
+    call $add
+    drop)
+)"#;
+
+    let symbols = parse_document(source).unwrap();
+    let tree = create_test_tree(source);
+
+    // Position on "call $add" at line 10
+    let position = Position {
+        line: 10,
+        character: 10,
+    };
+
+    let refs = provide_references(source, &symbols, &tree, position, "file:///test.wat", false);
+
+    let ref_lines: Vec<_> = refs.iter().map(|r| r.range.start.line).collect();
+
+    // Should find 2 references: bare elem segment (line 6) and call instruction (line 10)
+    assert_eq!(
+        refs.len(),
+        2,
+        "Expected 2 references for $add (bare elem and call), got {:?}",
+        ref_lines
+    );
+    assert!(
+        ref_lines.contains(&6),
+        "Should find reference in bare elem segment at line 6, got {:?}",
+        ref_lines
+    );
+    assert!(
+        ref_lines.contains(&10),
+        "Should find reference in call at line 10, got {:?}",
+        ref_lines
     );
 }

--- a/src/features/references_core.rs
+++ b/src/features/references_core.rs
@@ -17,9 +17,9 @@ use crate::ts_facade::{Node, Tree};
 use crate::core::types::{Position, Range};
 use crate::symbols::*;
 use crate::utils::{
-    determine_context_from_line, determine_instruction_context_at_node, find_containing_function,
-    get_line_at_position, get_word_at_position, is_labeled_block_kind, node_at_position,
-    node_to_range, position_to_byte, InstructionContext,
+    determine_context_from_line, determine_instruction_context_at_node, find_child_by_kind,
+    find_containing_function, get_line_at_position, get_word_at_position, is_labeled_block_kind,
+    node_at_position, node_to_range, position_to_byte, InstructionContext,
 };
 
 /// Represents the type of symbol being referenced
@@ -541,6 +541,90 @@ fn walk_tree_for_references(
             results,
         };
         check_node_for_reference(&node, target, &mut ctx, &export_context, block_stack);
+    }
+
+    // Check for elem_list with elem_kind: all index children are function references
+    if &*kind == "elem_list" && find_child_by_kind(&node, "elem_kind").is_some() {
+        let call_context = InstructionContext::Call;
+        let mut inner_cursor = node.walk();
+        for child in node.children(&mut inner_cursor) {
+            let child_kind = child.kind();
+            if &*child_kind == "index" {
+                let mut ctx = ReferenceSearchContext {
+                    document,
+                    symbols,
+                    results,
+                };
+                check_node_for_reference(&child, target, &mut ctx, &call_context, block_stack);
+            }
+        }
+        if is_block {
+            block_stack.pop();
+        }
+        return;
+    }
+
+    // Check for table_use: index child is a table reference
+    if &*kind == "table_use" {
+        let table_context = InstructionContext::Table;
+        let mut inner_cursor = node.walk();
+        for child in node.children(&mut inner_cursor) {
+            let child_kind = child.kind();
+            if &*child_kind == "index" {
+                let mut ctx = ReferenceSearchContext {
+                    document,
+                    symbols,
+                    results,
+                };
+                check_node_for_reference(&child, target, &mut ctx, &table_context, block_stack);
+            }
+        }
+        if is_block {
+            block_stack.pop();
+        }
+        return;
+    }
+
+    // Check for memory_use: index child is a memory reference
+    if &*kind == "memory_use" {
+        let memory_context = InstructionContext::Memory;
+        let mut inner_cursor = node.walk();
+        for child in node.children(&mut inner_cursor) {
+            let child_kind = child.kind();
+            if &*child_kind == "index" {
+                let mut ctx = ReferenceSearchContext {
+                    document,
+                    symbols,
+                    results,
+                };
+                check_node_for_reference(&child, target, &mut ctx, &memory_context, block_stack);
+            }
+        }
+        if is_block {
+            block_stack.pop();
+        }
+        return;
+    }
+
+    // Check for module_field_elem: bare index children after offset are function references
+    if &*kind == "module_field_elem" {
+        let mut inner_cursor = node.walk();
+        let mut past_offset = false;
+        for child in node.children(&mut inner_cursor) {
+            let child_kind = child.kind();
+            if &*child_kind == "offset" {
+                past_offset = true;
+            } else if &*child_kind == "index" && past_offset {
+                let call_context = InstructionContext::Call;
+                let mut ctx = ReferenceSearchContext {
+                    document,
+                    symbols,
+                    results,
+                };
+                check_node_for_reference(&child, target, &mut ctx, &call_context, block_stack);
+            }
+        }
+        // Fall through to normal recursion for table_use, elem_list, offset children
     }
 
     // Check if this node is a reference instruction

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -95,6 +95,7 @@ pub fn determine_instruction_context(node: Node, document: &str) -> InstructionC
         return context;
     }
 
+    let original_start = node.start_byte();
     let mut current = node;
 
     loop {
@@ -131,13 +132,45 @@ pub fn determine_instruction_context(node: Node, document: &str) -> InstructionC
             return InstructionContext::Tag;
         }
 
+        // Check for memory_use (memory reference in data segments)
+        if kind == "memory_use" {
+            return InstructionContext::Memory;
+        }
+
         // Check for data segment definition
         if kind == "module_field_data" {
             return InstructionContext::Data;
         }
 
+        // Check for elem_list (function references in elem segments with `func` keyword)
+        if kind == "elem_list" && find_child_by_kind(&current, "elem_kind").is_some() {
+            return InstructionContext::Call;
+        }
+
+        // Check for table_use (table reference in elem segments)
+        if kind == "table_use" {
+            return InstructionContext::Table;
+        }
+
         // Check for elem segment definition
         if kind == "module_field_elem" {
+            // Check if the original node is a bare function reference (after offset)
+            // vs. the elem segment name (before offset)
+            let mut child_cursor = current.walk();
+            let mut past_offset = false;
+            for child in current.children(&mut child_cursor) {
+                node_kind!(ck = child);
+                if ck == "offset" {
+                    past_offset = true;
+                    continue;
+                }
+                if ck == "index" && past_offset {
+                    let cr = child.byte_range();
+                    if cr.start <= original_start && original_start < cr.end {
+                        return InstructionContext::Call;
+                    }
+                }
+            }
             return InstructionContext::Elem;
         }
 

--- a/tests/e2e_fixtures/call_indirect_types.json
+++ b/tests/e2e_fixtures/call_indirect_types.json
@@ -1,0 +1,21 @@
+{
+  "description": "call_indirect with type annotations — tests definition and references for type symbols",
+  "document": "(module\n  (type $unary (func (param i32) (result i32)))\n  (table 2 funcref)\n  (elem (i32.const 0) func $double $square)\n  (func $double (param $x i32) (result i32)\n    (i32.mul (local.get $x) (i32.const 2)))\n  (func $square (param $x i32) (result i32)\n    (i32.mul (local.get $x) (local.get $x)))\n  (func (export \"test\") (param $x i32) (result i32)\n    local.get $x\n    i32.const 0\n    call_indirect (type $unary)\n    i32.const 1\n    call_indirect (type $unary)))",
+  "tests": [
+    {
+      "feature": "diagnostics",
+      "expect": { "error_count": 0 }
+    },
+    {
+      "feature": "definition",
+      "position": [11, 27],
+      "expect": { "start_line": 1 }
+    },
+    {
+      "feature": "references",
+      "position": [1, 9],
+      "include_declaration": false,
+      "expect": { "min_count": 2 }
+    }
+  ]
+}

--- a/tests/identifier_coverage.rs
+++ b/tests/identifier_coverage.rs
@@ -1,0 +1,223 @@
+//! Identifier coverage test — verifies every `$name` identifier in playground examples resolves.
+//!
+//! Walks all `.wat` files in `packages/playground/examples/` (skipping `invalid/`),
+//! collects every `identifier` node whose text starts with `$`, and asserts that
+//! `provide_definition_core()` returns `Some` for each one.
+
+#![cfg(feature = "native")]
+
+use std::path::Path;
+use tree_sitter::{Node, Tree};
+use wat_lsp_rust::{
+    core::types::Position, features::definition_core::provide_definition_core,
+    parser::parse_document, tree_sitter_bindings::create_parser,
+};
+
+// =============================================================================
+// Expected failures — known limitations documented by category
+// =============================================================================
+
+/// Files to skip entirely. These use GC or typed-funcref features extensively,
+/// and the LSP doesn't yet support struct field resolution or type references
+/// in all GC/typed-funcref-specific contexts (ref types, struct.get/set field
+/// operands, array type operands, call_ref type operands, etc.).
+const SKIP_FILES: &[&str] = &[
+    "gc_structs.wat",
+    "gc_advanced.wat",
+    "typed_funcref.wat",
+    "call_ref_type_annotation.wat",
+];
+
+/// Individual expected failures: `(filename, identifier, line_0indexed)`.
+/// These are specific context-detection gaps outside the GC/typed-funcref files.
+const EXPECTED_FAILURES: &[(&str, &str, u32)] = &[
+    // Table operand in call_indirect / return_call_indirect:
+    // context detection sees instr_call/expr1_call and returns Call instead of Table.
+    ("imports_exports.wat", "$callbacks", 77),
+    ("imports_exports.wat", "$local_fns", 141),
+    ("ref_expressions.wat", "$ops", 60),
+    ("reference_types.wat", "$func_table", 89),
+    ("reference_types.wat", "$func_table", 106),
+    ("reference_types.wat", "$func_table", 137),
+    ("table64.wat", "$large_table", 64),
+    ("tables.wat", "$unary_ops", 59),
+    ("tables.wat", "$binary_ops", 67),
+    ("tables.wat", "$unary_ops", 85),
+    ("tables.wat", "$binary_ops", 106),
+    ("tables.wat", "$unary_ops", 152),
+    ("tables.wat", "$unary_ops", 153),
+    ("tail_calls.wat", "$ops", 98),
+];
+
+// =============================================================================
+// Test infrastructure
+// =============================================================================
+
+/// An identifier that failed to resolve.
+#[derive(Debug)]
+struct Failure {
+    file: String,
+    line: u32,
+    column: u32,
+    identifier: String,
+}
+
+/// Load all `.wat` files from `packages/playground/examples/`, skipping `invalid/`.
+fn load_playground_examples() -> Vec<(String, String)> {
+    let examples_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("packages/playground/examples");
+    assert!(
+        examples_dir.exists(),
+        "Playground examples directory not found: {}",
+        examples_dir.display()
+    );
+
+    let mut files: Vec<(String, String)> = Vec::new();
+    for entry in std::fs::read_dir(&examples_dir).expect("Failed to read examples directory") {
+        let entry = entry.expect("Failed to read directory entry");
+        let path = entry.path();
+
+        // Skip the invalid/ subdirectory
+        if path.is_dir() {
+            continue;
+        }
+
+        if path.extension().and_then(|e| e.to_str()) == Some("wat") {
+            let filename = path.file_name().unwrap().to_str().unwrap().to_string();
+            let content = std::fs::read_to_string(&path)
+                .unwrap_or_else(|e| panic!("Failed to read {}: {}", path.display(), e));
+            files.push((filename, content));
+        }
+    }
+
+    files.sort_by(|a, b| a.0.cmp(&b.0));
+    files
+}
+
+/// Parse a document into a tree-sitter tree.
+fn parse_tree(document: &str) -> Tree {
+    let mut parser = create_parser();
+    parser
+        .parse(document, None)
+        .expect("Failed to parse document")
+}
+
+/// Collect all `identifier` nodes starting with `$` from the tree.
+/// Returns `(Position, identifier_text)` pairs.
+fn collect_identifiers(tree: &Tree, document: &str) -> Vec<(Position, String)> {
+    let mut results = Vec::new();
+    collect_identifiers_recursive(tree.root_node(), document, &mut results);
+    results
+}
+
+fn collect_identifiers_recursive(
+    node: Node,
+    document: &str,
+    results: &mut Vec<(Position, String)>,
+) {
+    if node.kind() == "identifier" {
+        let text = &document[node.byte_range()];
+        if text.starts_with('$') {
+            let start = node.start_position();
+            results.push((
+                Position::new(start.row as u32, start.column as u32),
+                text.to_string(),
+            ));
+        }
+    }
+
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        collect_identifiers_recursive(child, document, results);
+    }
+}
+
+fn is_expected_failure(filename: &str, identifier: &str, line: u32) -> bool {
+    EXPECTED_FAILURES
+        .iter()
+        .any(|(f, id, l)| *f == filename && *id == identifier && *l == line)
+}
+
+fn is_skipped_file(filename: &str) -> bool {
+    SKIP_FILES.contains(&filename)
+}
+
+#[test]
+fn test_all_identifiers_resolve_to_definition() {
+    let examples = load_playground_examples();
+    assert!(
+        !examples.is_empty(),
+        "No playground examples found — check the examples directory"
+    );
+
+    let mut failures: Vec<Failure> = Vec::new();
+    let mut total_identifiers = 0u32;
+    let mut total_files = 0u32;
+    let mut skipped_files = 0u32;
+    let mut expected_failure_count = 0u32;
+
+    for (filename, content) in &examples {
+        if is_skipped_file(filename) {
+            skipped_files += 1;
+            continue;
+        }
+
+        // Parse the document into a symbol table; skip if parsing fails
+        let symbols = match parse_document(content) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+
+        let tree = parse_tree(content);
+        let identifiers = collect_identifiers(&tree, content);
+
+        if identifiers.is_empty() {
+            continue;
+        }
+
+        total_files += 1;
+        total_identifiers += identifiers.len() as u32;
+
+        for (position, ident_text) in &identifiers {
+            let result = provide_definition_core(content, &symbols, &tree, *position);
+
+            if result.is_none() {
+                if is_expected_failure(filename, ident_text, position.line) {
+                    expected_failure_count += 1;
+                    continue;
+                }
+                failures.push(Failure {
+                    file: filename.clone(),
+                    line: position.line,
+                    column: position.character,
+                    identifier: ident_text.clone(),
+                });
+            }
+        }
+    }
+
+    if !failures.is_empty() {
+        let mut msg = format!(
+            "\n{} identifier(s) failed to resolve out of {} total across {} files:\n\n",
+            failures.len(),
+            total_identifiers,
+            total_files,
+        );
+        for f in &failures {
+            msg.push_str(&format!(
+                "  {}:{}:{} — {}\n",
+                f.file,
+                f.line + 1,
+                f.column + 1,
+                f.identifier,
+            ));
+        }
+        panic!("{}", msg);
+    }
+
+    // Print summary on success (visible with --nocapture)
+    eprintln!(
+        "Identifier coverage: {} identifiers across {} files — all resolved \
+         ({} expected failures, {} files skipped for GC/typed-funcref).",
+        total_identifiers, total_files, expected_failure_count, skipped_files,
+    );
+}


### PR DESCRIPTION
## Summary

- **Identifier coverage test** (`tests/identifier_coverage.rs`): Walks every `$name` identifier across all 30 playground examples and verifies `provide_definition_core()` resolves it. Catches context-detection bugs exhaustively. Currently validates 3044 identifiers across 26 files (4 GC/typed-funcref files skipped, 14 known `call_indirect` table-operand failures documented).

- **Fix `memory_use` context detection** (`src/utils.rs`): `$mem` in `(data (memory $mem) ...)` was getting `Data` context instead of `Memory`, preventing go-to-definition. Added `memory_use` check before `module_field_data`.

- **Fix `memory_use` in references walker** (`src/features/references_core.rs`): Added `memory_use` handling analogous to existing `table_use` handling, so find-all-references works for memory identifiers in data segments.

- **Fix `elem_list` context detection** (`src/utils.rs`, `src/features/references_core.rs`): Added `elem_list` with `elem_kind` child check so `$name` in `(elem ... func $name)` gets `Call` context. Also fixed clippy collapsible-if warnings on these checks.

- **Tests for `call_indirect` type references**: Definition, references, and e2e parity tests for `call_indirect (type $name)` patterns (linear, chained, folded forms).

- **Tests for elem segment function references**: Definition and references tests for `$name` in both `(elem ... func $name)` and bare `(elem (offset) $name)` forms.