### PR TITLE
defrag: eliminate hot-path string allocations, deduplicate segment validation, remove dead code

### DIFF
--- a/src/diagnostics_core/alignment_checks.rs
+++ b/src/diagnostics_core/alignment_checks.rs
@@ -21,7 +21,7 @@ use crate::ts_facade::Node;
 /// - `offset=N` where N exceeds u32::MAX for memory32 targets
 pub fn check_alignment(node: &Node, source: &str, symbols: &SymbolTable) -> Vec<Diagnostic> {
     let mut diagnostics = Vec::new();
-    let mut instr_name = None;
+    let mut instr_name: Option<&str> = None;
     let mut align_node = None;
     let mut offset_node = None;
 
@@ -33,7 +33,7 @@ pub fn check_alignment(node: &Node, source: &str, symbols: &SymbolTable) -> Vec<
             "op_index_opt_offset_opt_align_opt"
             | "op_simd_offset_opt_align_opt"
             | "op_simd_lane_memarg" => {
-                instr_name = Some(source[child.byte_range()].to_string());
+                instr_name = Some(&source[child.byte_range()]);
             }
             "align_value" => {
                 align_node = Some(child);
@@ -53,7 +53,7 @@ pub fn check_alignment(node: &Node, source: &str, symbols: &SymbolTable) -> Vec<
                 if offset > u32::MAX as u64 {
                     diagnostics.push(Diagnostic::error(
                         node_to_range(offset_nd),
-                        "offset out of range".to_string(),
+                        "offset out of range",
                     ));
                 }
             }
@@ -75,17 +75,17 @@ pub fn check_alignment(node: &Node, source: &str, symbols: &SymbolTable) -> Vec<
     if align == 0 || (align & (align - 1)) != 0 {
         diagnostics.push(Diagnostic::error(
             node_to_range(&align_nd),
-            "alignment must be a power of 2".to_string(),
+            "alignment must be a power of 2",
         ));
         return diagnostics;
     }
 
     // Check against natural alignment
-    if let Some(natural) = natural_alignment(&instr) {
+    if let Some(natural) = natural_alignment(instr) {
         if align > natural as u64 {
             diagnostics.push(Diagnostic::error(
                 node_to_range(&align_nd),
-                "alignment must not be larger than natural".to_string(),
+                "alignment must not be larger than natural",
             ));
         }
     }

--- a/src/diagnostics_core/folded_checks.rs
+++ b/src/diagnostics_core/folded_checks.rs
@@ -47,16 +47,16 @@ pub fn check_folded_operand_count(
     };
 
     let instr_kind = first_instr_child.kind();
-    let instr_name = match instr_kind.as_ref() {
+    let instr_name: &str = match instr_kind.as_ref() {
         "op_const" => {
             let mut const_cursor = first_instr_child.walk();
             let result = first_instr_child.children(&mut const_cursor).next();
             match result {
-                Some(c) => source[c.byte_range()].trim().to_string(),
+                Some(c) => source[c.byte_range()].trim(),
                 None => return diagnostics,
             }
         }
-        _ => source[first_instr_child.byte_range()].trim().to_string(),
+        _ => source[first_instr_child.byte_range()].trim(),
     };
 
     // Count expr children (these are the operands)
@@ -67,10 +67,10 @@ pub fn check_folded_operand_count(
         .count();
 
     // Resolve arity: try explicit map first, then SIMD pattern fallback
-    let resolved = if let Some(arity) = lookup_instruction_arity(instr_name.as_str()) {
+    let resolved = if let Some(arity) = lookup_instruction_arity(instr_name) {
         Some((arity.operand_mode, true))
     } else {
-        infer_simd_instruction_arity(&instr_name).map(|(c, _)| (OperandMode::Fixed(c), false))
+        infer_simd_instruction_arity(instr_name).map(|(c, _)| (OperandMode::Fixed(c), false))
     };
 
     if let Some((operand_mode, check_dynamic)) = resolved {
@@ -107,7 +107,7 @@ pub fn check_folded_operand_count(
             OperandMode::Dynamic if check_dynamic => {
                 validate_dynamic_operands(
                     node,
-                    &instr_name,
+                    instr_name,
                     operand_count,
                     deficit,
                     symbols,
@@ -141,7 +141,7 @@ fn validate_dynamic_operands(
         "struct.new" => {
             if let Some(type_name) = extract_instruction_index(node, source) {
                 let type_def = if type_name.starts_with('$') {
-                    symbols.get_type_by_name(&type_name)
+                    symbols.get_type_by_name(type_name)
                 } else if let Ok(idx) = type_name.parse::<usize>() {
                     symbols.get_type_by_index(idx)
                 } else {
@@ -150,7 +150,7 @@ fn validate_dynamic_operands(
                 if let Some(type_def) = type_def {
                     if let TypeKind::Struct { fields } = &type_def.kind {
                         let expected = fields.len();
-                        let type_display = type_def.name.as_deref().unwrap_or(&type_name);
+                        let type_display = type_def.name.as_deref().unwrap_or(type_name);
                         emit_operand_diagnostic(
                             node,
                             instr_name,
@@ -168,7 +168,7 @@ fn validate_dynamic_operands(
         "call" | "return_call" => {
             if let Some(func_name) = extract_instruction_index(node, source) {
                 let func = if func_name.starts_with('$') {
-                    symbols.get_function_by_name(&func_name)
+                    symbols.get_function_by_name(func_name)
                 } else if let Ok(idx) = func_name.parse::<usize>() {
                     symbols.get_function_by_index(idx)
                 } else {
@@ -176,7 +176,7 @@ fn validate_dynamic_operands(
                 };
                 if let Some(func) = func {
                     let expected = func.parameters.len();
-                    let func_display = func.name.as_deref().unwrap_or(&func_name);
+                    let func_display = func.name.as_deref().unwrap_or(func_name);
                     emit_operand_diagnostic(
                         node,
                         instr_name,
@@ -193,7 +193,7 @@ fn validate_dynamic_operands(
         "throw" => {
             if let Some(tag_name) = extract_instruction_index(node, source) {
                 let tag = if tag_name.starts_with('$') {
-                    symbols.get_tag_by_name(&tag_name)
+                    symbols.get_tag_by_name(tag_name)
                 } else if let Ok(idx) = tag_name.parse::<usize>() {
                     symbols.get_tag_by_index(idx)
                 } else {
@@ -201,7 +201,7 @@ fn validate_dynamic_operands(
                 };
                 if let Some(tag) = tag {
                     let expected = tag.params.len();
-                    let tag_display = tag.name.as_deref().unwrap_or(&tag_name);
+                    let tag_display = tag.name.as_deref().unwrap_or(tag_name);
                     emit_operand_diagnostic(
                         node,
                         instr_name,
@@ -218,7 +218,7 @@ fn validate_dynamic_operands(
         "call_ref" | "return_call_ref" => {
             if let Some(type_name) = extract_instruction_index(node, source) {
                 let type_def = if type_name.starts_with('$') {
-                    symbols.get_type_by_name(&type_name)
+                    symbols.get_type_by_name(type_name)
                 } else if let Ok(idx) = type_name.parse::<usize>() {
                     symbols.get_type_by_index(idx)
                 } else {
@@ -228,7 +228,7 @@ fn validate_dynamic_operands(
                     if let TypeKind::Func { params, .. } = &type_def.kind {
                         // Expected: params + 1 for the funcref
                         let expected = params.len() + 1;
-                        let type_display = type_def.name.as_deref().unwrap_or(&type_name);
+                        let type_display = type_def.name.as_deref().unwrap_or(type_name);
                         emit_operand_diagnostic(
                             node,
                             instr_name,
@@ -354,31 +354,28 @@ fn compute_child_expr_deficit(node: &Node, source: &str, symbols: &SymbolTable) 
             };
 
             let op_kind = first_op.kind();
-            let inner_name = {
-                let name = match op_kind.as_ref() {
-                    "op_const" => {
-                        let mut cc = first_op.walk();
-                        let child = first_op.children(&mut cc).next();
-                        match child {
-                            Some(c) => source[c.byte_range()].trim().to_string(),
-                            None => continue,
-                        }
+            let inner_name: &str = match op_kind.as_ref() {
+                "op_const" => {
+                    let mut cc = first_op.walk();
+                    let child = first_op.children(&mut cc).next();
+                    match child {
+                        Some(c) => source[c.byte_range()].trim(),
+                        None => continue,
                     }
-                    _ => source[first_op.byte_range()].trim().to_string(),
-                };
-                name
+                }
+                _ => source[first_op.byte_range()].trim(),
             };
 
-            let expected = if let Some(arity) = lookup_instruction_arity(inner_name.as_str()) {
+            let expected = if let Some(arity) = lookup_instruction_arity(inner_name) {
                 match arity.operand_mode {
                     OperandMode::Fixed(n) => n,
                     OperandMode::Dynamic => {
                         // For dynamic, try to resolve actual param count
-                        resolve_dynamic_expected(&expr_child, &inner_name, source, symbols)
+                        resolve_dynamic_expected(&expr_child, inner_name, source, symbols)
                             .unwrap_or(0)
                     }
                 }
-            } else if let Some((c, _)) = infer_simd_instruction_arity(&inner_name) {
+            } else if let Some((c, _)) = infer_simd_instruction_arity(inner_name) {
                 c
             } else {
                 continue;
@@ -404,7 +401,7 @@ fn resolve_dynamic_expected(
     match instr_name {
         "call" | "return_call" => {
             let func = if index_name.starts_with('$') {
-                symbols.get_function_by_name(&index_name)
+                symbols.get_function_by_name(index_name)
             } else if let Ok(idx) = index_name.parse::<usize>() {
                 symbols.get_function_by_index(idx)
             } else {
@@ -414,7 +411,7 @@ fn resolve_dynamic_expected(
         }
         "call_ref" | "return_call_ref" => {
             let type_def = if index_name.starts_with('$') {
-                symbols.get_type_by_name(&index_name)
+                symbols.get_type_by_name(index_name)
             } else if let Ok(idx) = index_name.parse::<usize>() {
                 symbols.get_type_by_index(idx)
             } else {
@@ -430,7 +427,7 @@ fn resolve_dynamic_expected(
         }
         "struct.new" => {
             let type_def = if index_name.starts_with('$') {
-                symbols.get_type_by_name(&index_name)
+                symbols.get_type_by_name(index_name)
             } else if let Ok(idx) = index_name.parse::<usize>() {
                 symbols.get_type_by_index(idx)
             } else {
@@ -446,7 +443,7 @@ fn resolve_dynamic_expected(
         }
         "throw" => {
             let tag = if index_name.starts_with('$') {
-                symbols.get_tag_by_name(&index_name)
+                symbols.get_tag_by_name(index_name)
             } else if let Ok(idx) = index_name.parse::<usize>() {
                 symbols.get_tag_by_index(idx)
             } else {
@@ -461,21 +458,21 @@ fn resolve_dynamic_expected(
 /// Extract the type/function/tag index from a folded expression node.
 ///
 /// Navigates: expr1_plain → instr_plain → (op_... index/identifier)
-fn extract_instruction_index(node: &Node, source: &str) -> Option<String> {
+fn extract_instruction_index<'s>(node: &Node, source: &'s str) -> Option<&'s str> {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         if child.kind() == "instr_plain" {
             let mut instr_cursor = child.walk();
             for instr_child in child.children(&mut instr_cursor) {
                 if instr_child.kind() == "index" || instr_child.kind() == "identifier" {
-                    return Some(source[instr_child.byte_range()].trim().to_string());
+                    return Some(source[instr_child.byte_range()].trim());
                 }
                 // Also check inside op_ nodes
                 if instr_child.kind().starts_with("op_") {
                     let mut op_cursor = instr_child.walk();
                     for op_child in instr_child.children(&mut op_cursor) {
                         if op_child.kind() == "index" || op_child.kind() == "identifier" {
-                            return Some(source[op_child.byte_range()].trim().to_string());
+                            return Some(source[op_child.byte_range()].trim());
                         }
                     }
                 }

--- a/src/diagnostics_core/gc_checks.rs
+++ b/src/diagnostics_core/gc_checks.rs
@@ -48,7 +48,7 @@ pub fn check_struct_field_access(
     };
 
     // Resolve type
-    let type_def = match resolve_type_def(&type_ref, symbols) {
+    let type_def = match resolve_type_def(type_ref, symbols) {
         Some(td) => td,
         None => return Vec::new(), // Undefined type caught by reference checker
     };
@@ -60,7 +60,7 @@ pub fn check_struct_field_access(
                 node_to_range(node),
                 format!(
                     "struct.get/set used on non-struct type {}",
-                    type_ref_display(&type_ref, type_def.index)
+                    type_ref_display(type_ref, type_def.index)
                 ),
             )];
         }
@@ -69,7 +69,7 @@ pub fn check_struct_field_access(
     let mut diagnostics = Vec::new();
 
     // Resolve field index
-    let field_idx = match resolve_field_index(&field_ref, fields) {
+    let field_idx = match resolve_field_index(field_ref, fields) {
         Some(idx) => idx,
         None => {
             if field_ref.starts_with('$') {
@@ -105,10 +105,7 @@ pub fn check_struct_field_access(
     if first_token == "struct.set" {
         let (_, _, mutable) = &fields[field_idx];
         if !mutable {
-            diagnostics.push(Diagnostic::error(
-                node_to_range(node),
-                "immutable field".to_string(),
-            ));
+            diagnostics.push(Diagnostic::error(node_to_range(node), "immutable field"));
         }
     }
 
@@ -119,42 +116,37 @@ pub fn check_struct_field_access(
 ///
 /// struct.get/set instructions have the form: `struct.get $type $field`
 /// where both are `index` nodes in the grammar.
-fn extract_two_indices(node: &Node, source: &str) -> Option<(String, String)> {
-    let mut indices = Vec::new();
+fn extract_two_indices<'s>(node: &Node, source: &'s str) -> Option<(&'s str, &'s str)> {
+    let mut first = None;
     let mut cursor = node.walk();
 
     for child in node.children(&mut cursor) {
         node_kind!(kind_ref = child);
 
         if kind_ref == "index" {
-            // Index node may contain identifier or nat child
-            let index_text = extract_index_value(&child, source);
-            indices.push(index_text);
-            if indices.len() == 2 {
-                break;
+            let text = extract_index_value(&child, source);
+            match first {
+                None => first = Some(text),
+                Some(f) => return Some((f, text)),
             }
         }
     }
 
-    if indices.len() == 2 {
-        Some((indices.remove(0), indices.remove(0)))
-    } else {
-        None
-    }
+    None
 }
 
 /// Extract the value from an index node — either a `$name` identifier or numeric `nat`.
-fn extract_index_value(node: &Node, source: &str) -> String {
+fn extract_index_value<'s>(node: &Node, source: &'s str) -> &'s str {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         node_kind!(kind_ref = child);
 
         if kind_ref == "identifier" || kind_ref == "nat" {
-            return source[child.byte_range()].trim().to_string();
+            return source[child.byte_range()].trim();
         }
     }
     // Fallback: use the node text directly
-    source[node.byte_range()].trim().to_string()
+    source[node.byte_range()].trim()
 }
 
 /// Resolve a type reference (either `$name` or numeric index) to a TypeDef.

--- a/src/diagnostics_core/module_checks.rs
+++ b/src/diagnostics_core/module_checks.rs
@@ -530,7 +530,7 @@ fn check_tag_no_results(node: &Node, _source: &str, diagnostics: &mut Vec<Diagno
             if ck == "func_type_results" {
                 diagnostics.push(Diagnostic::error(
                     node_to_range(&child),
-                    "non-empty tag result type".to_string(),
+                    "non-empty tag result type",
                 ));
                 return true;
             }
@@ -2310,7 +2310,7 @@ fn infer_const_instr_type(
         "ref.null" => {
             // Resolve the heap type from the argument
             let heap_text = resolve_ref_null_heap_type(node, source);
-            match heap_text.as_deref() {
+            match heap_text {
                 Some("func") | Some("funcref") => Some(ValueType::Funcref),
                 Some("extern") | Some("externref") => Some(ValueType::Externref),
                 Some("any") | Some("anyref") => Some(ValueType::Anyref),
@@ -2443,7 +2443,7 @@ fn resolve_ref_func_target<'a>(
 /// Resolve the type of a global.get instruction's target global.
 /// Resolve the heap type argument of a ref.null instruction.
 /// Looks for the heap type text in child nodes of the instruction.
-fn resolve_ref_null_heap_type(node: &Node, source: &str) -> Option<String> {
+fn resolve_ref_null_heap_type<'s>(node: &Node, source: &'s str) -> Option<&'s str> {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         node_kind!(ck = child);
@@ -2452,7 +2452,7 @@ fn resolve_ref_null_heap_type(node: &Node, source: &str) -> Option<String> {
             ck,
             "heap_type" | "_heap_type_or_ref" | "identifier" | "nat" | "index"
         ) {
-            let text = node_text(&child, source).trim().to_string();
+            let text = node_text(&child, source).trim();
             if !text.is_empty() {
                 return Some(text);
             }
@@ -2463,7 +2463,7 @@ fn resolve_ref_null_heap_type(node: &Node, source: &str) -> Option<String> {
             for idx_child in child.children(&mut ic) {
                 node_kind!(ik = idx_child);
                 if matches!(ik, "identifier" | "nat") {
-                    let text = node_text(&idx_child, source).trim().to_string();
+                    let text = node_text(&idx_child, source).trim();
                     if !text.is_empty() {
                         return Some(text);
                     }
@@ -2473,10 +2473,7 @@ fn resolve_ref_null_heap_type(node: &Node, source: &str) -> Option<String> {
     }
     // Fallback: try to extract from text
     let text = node_text(node, source);
-    if let Some(second) = text.split_whitespace().nth(1) {
-        return Some(second.to_string());
-    }
-    None
+    text.split_whitespace().nth(1)
 }
 
 fn resolve_global_get_type(node: &Node, source: &str, symbols: &SymbolTable) -> Option<ValueType> {
@@ -3348,7 +3345,7 @@ fn walk_for_memory_instrs(node: &Node, source: &str, diagnostics: &mut Vec<Diagn
         let first_token = text.split_whitespace().next().unwrap_or("");
         if is_memory_instruction(first_token) {
             diagnostics.push(
-                Diagnostic::error(node_to_range(node), "unknown memory 0".to_string())
+                Diagnostic::error(node_to_range(node), "unknown memory 0")
                     .with_code("unknown-memory"),
             );
         }
@@ -3424,7 +3421,7 @@ fn check_call_indirect_table(
 ) {
     if symbols.tables.is_empty() {
         diagnostics.push(
-            Diagnostic::error(node_to_range(report_node), "unknown table".to_string())
+            Diagnostic::error(node_to_range(report_node), "unknown table")
                 .with_code("unknown-table"),
         );
     } else {
@@ -3432,7 +3429,7 @@ fn check_call_indirect_table(
         if let Some(table) = symbols.tables.get(table_idx) {
             if table.ref_type == ValueType::Externref {
                 diagnostics.push(
-                    Diagnostic::error(node_to_range(report_node), "type mismatch".to_string())
+                    Diagnostic::error(node_to_range(report_node), "type mismatch")
                         .with_code("type-mismatch"),
                 );
             }
@@ -3524,7 +3521,7 @@ fn check_inline_table_elem_refs(
     for child in node.children(&mut cursor) {
         node_kind!(ck = child);
         if ck == "nat" || ck == "index" {
-            let text = node_text(&child, source).trim().to_string();
+            let text = node_text(&child, source).trim();
             if let Ok(idx) = text.parse::<usize>() {
                 if idx >= symbols.functions.len() {
                     diagnostics.push(

--- a/src/diagnostics_core/semantic.rs
+++ b/src/diagnostics_core/semantic.rs
@@ -852,7 +852,7 @@ fn process_instruction(
             };
             if is_immutable {
                 checker.diagnostics.push(
-                    Diagnostic::error(node_to_range(node), "global is immutable".to_string())
+                    Diagnostic::error(node_to_range(node), "global is immutable")
                         .with_code("immutable-global"),
                 );
             }
@@ -1365,13 +1365,13 @@ fn get_branch_depth(node: &Node, source: &str, checker: &mut TypeChecker) -> Opt
 /// Get all branch depths from a br_table instruction (last one is the default).
 /// Emits "unknown label" diagnostics for out-of-range depths.
 fn get_all_branch_depths(node: &Node, source: &str, checker: &mut TypeChecker) -> Vec<usize> {
-    let mut indices = Vec::new();
+    let mut indices: Vec<&str> = Vec::new();
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         node_kind!(kind = child);
 
         if kind == "index" || kind == "identifier" || kind == "nat" {
-            indices.push(source[child.byte_range()].trim().to_string());
+            indices.push(source[child.byte_range()].trim());
         }
         if kind.starts_with("op_") {
             let mut inner_cursor = child.walk();
@@ -1379,7 +1379,7 @@ fn get_all_branch_depths(node: &Node, source: &str, checker: &mut TypeChecker) -
                 node_kind!(inner_kind = inner_child);
 
                 if inner_kind == "index" || inner_kind == "identifier" || inner_kind == "nat" {
-                    indices.push(source[inner_child.byte_range()].trim().to_string());
+                    indices.push(source[inner_child.byte_range()].trim());
                 }
             }
         }
@@ -1914,7 +1914,7 @@ fn resolve_call_indirect_type<'a>(
     symbols: &'a SymbolTable,
 ) -> Option<&'a TypeDef> {
     let mut cursor = node.walk();
-    let mut first_index: Option<String> = None;
+    let mut first_index: Option<&str> = None;
     for child in node.children(&mut cursor) {
         node_kind!(kind = child);
 
@@ -1924,11 +1924,11 @@ fn resolve_call_indirect_type<'a>(
         }
         // Track first index (could be table ref in multi-table or type ref in single-table)
         if kind == "index" && first_index.is_none() {
-            first_index = Some(source[child.byte_range()].trim().to_string());
+            first_index = Some(source[child.byte_range()].trim());
         }
     }
     // No type_use found — try first index as a type reference (single-table mode)
-    if let Some(ref idx_text) = first_index {
+    if let Some(idx_text) = first_index {
         return resolve_type_ref(idx_text, symbols);
     }
     None
@@ -3285,8 +3285,7 @@ fn check_table_init_types(
     if let (Some(table), Some(elem)) = (table, elem) {
         if !ref_types_compatible(elem.ref_type, table.ref_type, symbols) {
             checker.diagnostics.push(
-                Diagnostic::error(node_to_range(node), "type mismatch".to_string())
-                    .with_code("type-mismatch"),
+                Diagnostic::error(node_to_range(node), "type mismatch").with_code("type-mismatch"),
             );
         }
     }
@@ -3317,8 +3316,7 @@ fn check_table_copy_types(
     if let (Some(dst), Some(src)) = (dst, src) {
         if !ref_types_compatible(src.ref_type, dst.ref_type, symbols) {
             checker.diagnostics.push(
-                Diagnostic::error(node_to_range(node), "type mismatch".to_string())
-                    .with_code("type-mismatch"),
+                Diagnostic::error(node_to_range(node), "type mismatch").with_code("type-mismatch"),
             );
         }
     }
@@ -3389,7 +3387,7 @@ fn check_array_operations(
         if let TypeKind::Array { mutable, .. } = &type_def.kind {
             if !mutable {
                 checker.diagnostics.push(
-                    Diagnostic::error(node_to_range(node), "immutable array".to_string())
+                    Diagnostic::error(node_to_range(node), "immutable array")
                         .with_code("immutable-array"),
                 );
                 return; // Don't report additional errors after mutability failure
@@ -3449,7 +3447,7 @@ fn check_array_operations(
                             && *element_type != elem_seg.ref_type
                         {
                             checker.diagnostics.push(
-                                Diagnostic::error(node_to_range(node), "type mismatch".to_string())
+                                Diagnostic::error(node_to_range(node), "type mismatch")
                                     .with_code("type-mismatch"),
                             );
                         }
@@ -3658,8 +3656,7 @@ fn check_br_on_cast_types(
     // Validate rt2 <: rt1: nullable rt2 can't be subtype of non-null rt1
     if *rt2_nullable && !*rt1_nullable {
         checker.diagnostics.push(
-            Diagnostic::error(node_to_range(node), "type mismatch".to_string())
-                .with_code("type-mismatch"),
+            Diagnostic::error(node_to_range(node), "type mismatch").with_code("type-mismatch"),
         );
         has_error = true;
     }
@@ -3669,8 +3666,7 @@ fn check_br_on_cast_types(
         let heap_types = extract_heap_types_from_cast(node, source);
         if heap_types.len() >= 2 && !is_heap_subtype(heap_types[1], heap_types[0]) {
             checker.diagnostics.push(
-                Diagnostic::error(node_to_range(node), "type mismatch".to_string())
-                    .with_code("type-mismatch"),
+                Diagnostic::error(node_to_range(node), "type mismatch").with_code("type-mismatch"),
             );
             has_error = true;
         }
@@ -3703,7 +3699,7 @@ fn check_br_on_cast_types(
                     };
                     if !types_compatible_with_symbols(&branch_vt, label_type, symbols) {
                         checker.diagnostics.push(
-                            Diagnostic::error(node_to_range(node), "type mismatch".to_string())
+                            Diagnostic::error(node_to_range(node), "type mismatch")
                                 .with_code("type-mismatch"),
                         );
                     }
@@ -4014,8 +4010,7 @@ fn check_catch_clause_types(
     // Compare: sent types must match label types in count and type
     if sent_types.len() != label_types.len() {
         checker.diagnostics.push(
-            Diagnostic::error(node_to_range(node), "type mismatch".to_string())
-                .with_code("type-mismatch"),
+            Diagnostic::error(node_to_range(node), "type mismatch").with_code("type-mismatch"),
         );
         return;
     }
@@ -4023,8 +4018,7 @@ fn check_catch_clause_types(
     for (sent, expected) in sent_types.iter().zip(label_types.iter()) {
         if !types_compatible_with_symbols(sent, expected, symbols) {
             checker.diagnostics.push(
-                Diagnostic::error(node_to_range(node), "type mismatch".to_string())
-                    .with_code("type-mismatch"),
+                Diagnostic::error(node_to_range(node), "type mismatch").with_code("type-mismatch"),
             );
             return;
         }

--- a/src/diagnostics_core/simd_checks.rs
+++ b/src/diagnostics_core/simd_checks.rs
@@ -95,14 +95,14 @@ fn validate_lane_value(int_node: &Node, source: &str, max_lane: u32) -> Option<D
     if text.starts_with('-') {
         return Some(Diagnostic::error(
             node_to_range(int_node),
-            "invalid lane index".to_string(),
+            "invalid lane index",
         ));
     }
     if let Ok(value) = text.trim_start_matches('+').parse::<u32>() {
         if value > max_lane {
             return Some(Diagnostic::error(
                 node_to_range(int_node),
-                "invalid lane index".to_string(),
+                "invalid lane index",
             ));
         }
     }

--- a/src/diagnostics_core/subtype.rs
+++ b/src/diagnostics_core/subtype.rs
@@ -163,18 +163,12 @@ fn check_structural_compatibility(
                     ));
                 }
                 if child_mut != parent_mut {
-                    diagnostics.push(Diagnostic::error(
-                        range,
-                        "Array mutability mismatch".to_string(),
-                    ));
+                    diagnostics.push(Diagnostic::error(range, "Array mutability mismatch"));
                 }
             } else {
                 // Immutable array: covariant
                 if *child_mut {
-                    diagnostics.push(Diagnostic::error(
-                        range,
-                        "Array mutability mismatch".to_string(),
-                    ));
+                    diagnostics.push(Diagnostic::error(range, "Array mutability mismatch"));
                 }
                 if !types_compatible_with_symbols(child_elem, parent_elem, symbols) {
                     diagnostics.push(Diagnostic::error(
@@ -214,7 +208,7 @@ fn check_structural_compatibility(
             if !params_ok || !results_ok {
                 diagnostics.push(Diagnostic::error(
                     range,
-                    "Function subtype signature must match parent exactly".to_string(),
+                    "Function subtype signature must match parent exactly",
                 ));
             }
         }


### PR DESCRIPTION
## Summary

- **Eliminate hot-path String allocations**: Convert 6 functions from returning `String`/`Option<String>` to `&str`/`Option<&str>` in folded_checks, alignment_checks, gc_checks, semantic, and module_checks
- **Remove unnecessary `.to_string()` calls**: 15+ string literal allocations removed across 8 diagnostic files (all accept `impl Into<String>`)
- **Deduplicate segment validation**: Consolidate `check_data_segment_memory_indices` + `check_elem_segment_table_indices` into shared `check_segment_indices` (-40 lines)
- **Remove dead code**: Remove 3 unused `TimingResult` fields and `bytes` parameter from 7 benchmark functions
- **Optimize ValueType comparison**: Compare enum values directly instead of roundtripping through Display/to_string
- **format_types() optimization**: Use `write!` directly instead of `Vec<String>.join()`