### PR TITLE
Add doc sample validation system with hidden context lines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
               - 'build.rs'
               - 'packages/docs/instructions.md'
               - 'packages/docs/annotations.md'
+              - 'packages/docs/src/content/docs/**'
               - 'packages/playground/examples/**'
               - 'grammars/tree-sitter-wat/**'
               - 'tests/**'

--- a/packages/docs/astro.config.mjs
+++ b/packages/docs/astro.config.mjs
@@ -4,12 +4,16 @@ import starlight from '@astrojs/starlight';
 import starlightThemeFlexoki from 'starlight-theme-flexoki';
 import fs from 'node:fs';
 import react from '@astrojs/react';
+import { remarkStripHiddenLines } from './src/plugins/remark-strip-hidden-lines.mjs';
 const watGrammar = JSON.parse(
   fs.readFileSync(new URL('./src/grammars/wat.tmLanguage.json', import.meta.url), 'utf-8'),
 );
 
 // https://astro.build/config
 export default defineConfig({
+  markdown: {
+    remarkPlugins: [remarkStripHiddenLines],
+  },
   vite: {
     optimizeDeps: {
       include: ['monaco-editor', 'vscode-textmate', 'vscode-oniguruma'],

--- a/packages/docs/src/content/docs/control/try-table.md
+++ b/packages/docs/src/content/docs/control/try-table.md
@@ -36,7 +36,9 @@ sidebar:
 Tags declare exception types with their payload signatures:
 
 ```wat
+# (module
 (tag $my-error (param i32 i32))
+# )
 ```
 
 When a `catch` clause matches, the tag's parameter types are delivered to the branch target label.

--- a/packages/docs/src/content/docs/instructions/atomic.md
+++ b/packages/docs/src/content/docs/instructions/atomic.md
@@ -14,8 +14,12 @@ Atomically load a 32-bit integer from memory. Requires shared memory. The addres
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i32)
 ;; Atomically load i32 from address
 (i32.atomic.load (i32.const 0))
+# ))
 ```
 
 ---
@@ -29,8 +33,12 @@ Atomically load a 64-bit integer from memory. Requires shared memory. The addres
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i64)
 ;; Atomically load i64 from address
 (i64.atomic.load (i32.const 0))
+# ))
 ```
 
 ---
@@ -44,8 +52,12 @@ Atomically load an 8-bit value from memory and zero-extend to i32. Requires shar
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i32)
 ;; Atomically load byte and zero-extend to i32
 (i32.atomic.load8_u (i32.const 0))
+# ))
 ```
 
 ---
@@ -59,8 +71,12 @@ Atomically load a 16-bit value from memory and zero-extend to i32. Requires shar
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i32)
 ;; Atomically load 16-bit value and zero-extend to i32
 (i32.atomic.load16_u (i32.const 0))
+# ))
 ```
 
 ---
@@ -74,8 +90,12 @@ Atomically load an 8-bit value from memory and zero-extend to i64. Requires shar
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i64)
 ;; Atomically load byte and zero-extend to i64
 (i64.atomic.load8_u (i32.const 0))
+# ))
 ```
 
 ---
@@ -89,8 +109,12 @@ Atomically load a 16-bit value from memory and zero-extend to i64. Requires shar
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i64)
 ;; Atomically load 16-bit value and zero-extend to i64
 (i64.atomic.load16_u (i32.const 0))
+# ))
 ```
 
 ---
@@ -104,8 +128,12 @@ Atomically load a 32-bit value from memory and zero-extend to i64. Requires shar
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i64)
 ;; Atomically load 32-bit value and zero-extend to i64
 (i64.atomic.load32_u (i32.const 0))
+# ))
 ```
 
 ---
@@ -119,8 +147,12 @@ Atomically store a 32-bit integer to memory. Requires shared memory. The address
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func
 ;; Atomically store i32 value at address
 (i32.atomic.store (i32.const 0) (i32.const 42))
+# ))
 ```
 
 ---
@@ -134,8 +166,12 @@ Atomically store a 64-bit integer to memory. Requires shared memory. The address
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func
 ;; Atomically store i64 value at address
 (i64.atomic.store (i32.const 0) (i64.const 42))
+# ))
 ```
 
 ---
@@ -149,8 +185,12 @@ Atomically store the low 8 bits of an i32 to memory. Requires shared memory.
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func
 ;; Atomically store low byte of i32 at address
 (i32.atomic.store8 (i32.const 0) (i32.const 255))
+# ))
 ```
 
 ---
@@ -164,8 +204,12 @@ Atomically store the low 16 bits of an i32 to memory. Requires shared memory. Th
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func
 ;; Atomically store low 16 bits of i32 at address
 (i32.atomic.store16 (i32.const 0) (i32.const 1000))
+# ))
 ```
 
 ---
@@ -179,8 +223,12 @@ Atomically store the low 8 bits of an i64 to memory. Requires shared memory.
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func
 ;; Atomically store low byte of i64 at address
 (i64.atomic.store8 (i32.const 0) (i64.const 255))
+# ))
 ```
 
 ---
@@ -194,8 +242,12 @@ Atomically store the low 16 bits of an i64 to memory. Requires shared memory. Th
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func
 ;; Atomically store low 16 bits of i64 at address
 (i64.atomic.store16 (i32.const 0) (i64.const 1000))
+# ))
 ```
 
 ---
@@ -209,8 +261,12 @@ Atomically store the low 32 bits of an i64 to memory. Requires shared memory. Th
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func
 ;; Atomically store low 32 bits of i64 at address
 (i64.atomic.store32 (i32.const 0) (i64.const 100000))
+# ))
 ```
 
 ---
@@ -224,8 +280,12 @@ Atomically read a 32-bit value, add to it, and store the result. Returns the ori
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i32)
 ;; Atomically add 10 to value at address, return old value
 (i32.atomic.rmw.add (i32.const 0) (i32.const 10))
+# ))
 ```
 
 ---
@@ -239,8 +299,12 @@ Atomically read a 32-bit value, subtract from it, and store the result. Returns 
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i32)
 ;; Atomically subtract 5 from value at address, return old value
 (i32.atomic.rmw.sub (i32.const 0) (i32.const 5))
+# ))
 ```
 
 ---
@@ -254,8 +318,12 @@ Atomically read a 32-bit value, perform bitwise AND, and store the result. Retur
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i32)
 ;; Atomically AND with mask, return old value
 (i32.atomic.rmw.and (i32.const 0) (i32.const 0xFF))
+# ))
 ```
 
 ---
@@ -269,8 +337,12 @@ Atomically read a 32-bit value, perform bitwise OR, and store the result. Return
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i32)
 ;; Atomically OR with flags, return old value
 (i32.atomic.rmw.or (i32.const 0) (i32.const 0x80))
+# ))
 ```
 
 ---
@@ -284,8 +356,12 @@ Atomically read a 32-bit value, perform bitwise XOR, and store the result. Retur
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i32)
 ;; Atomically XOR with value, return old value
 (i32.atomic.rmw.xor (i32.const 0) (i32.const 0xFF))
+# ))
 ```
 
 ---
@@ -299,8 +375,12 @@ Atomically exchange (swap) a 32-bit value in memory. Returns the original value.
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i32)
 ;; Atomically swap value at address, return old value
 (i32.atomic.rmw.xchg (i32.const 0) (i32.const 100))
+# ))
 ```
 
 ---
@@ -314,8 +394,12 @@ Atomically read a 64-bit value, add to it, and store the result. Returns the ori
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i64)
 ;; Atomically add 10 to i64 value at address, return old value
 (i64.atomic.rmw.add (i32.const 0) (i64.const 10))
+# ))
 ```
 
 ---
@@ -329,8 +413,12 @@ Atomically read a 64-bit value, subtract from it, and store the result. Returns 
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i64)
 ;; Atomically subtract 5 from i64 value at address, return old value
 (i64.atomic.rmw.sub (i32.const 0) (i64.const 5))
+# ))
 ```
 
 ---
@@ -344,8 +432,12 @@ Atomically read a 64-bit value, perform bitwise AND, and store the result. Retur
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i64)
 ;; Atomically AND with mask, return old value
 (i64.atomic.rmw.and (i32.const 0) (i64.const 0xFF))
+# ))
 ```
 
 ---
@@ -359,8 +451,12 @@ Atomically read a 64-bit value, perform bitwise OR, and store the result. Return
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i64)
 ;; Atomically OR with flags, return old value
 (i64.atomic.rmw.or (i32.const 0) (i64.const 0x80))
+# ))
 ```
 
 ---
@@ -374,8 +470,12 @@ Atomically read a 64-bit value, perform bitwise XOR, and store the result. Retur
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i64)
 ;; Atomically XOR with value, return old value
 (i64.atomic.rmw.xor (i32.const 0) (i64.const 0xFF))
+# ))
 ```
 
 ---
@@ -389,8 +489,12 @@ Atomically exchange (swap) a 64-bit value in memory. Returns the original value.
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i64)
 ;; Atomically swap i64 value at address, return old value
 (i64.atomic.rmw.xchg (i32.const 0) (i64.const 100))
+# ))
 ```
 
 ---
@@ -404,8 +508,12 @@ Atomically read an 8-bit value, add to it, and store the result. Returns the ori
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i32)
 ;; Atomically add to byte at address, return old value
 (i32.atomic.rmw8.add_u (i32.const 0) (i32.const 1))
+# ))
 ```
 
 ---
@@ -419,8 +527,12 @@ Atomically read an 8-bit value, subtract from it, and store the result. Returns 
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i32)
 ;; Atomically subtract from byte at address, return old value
 (i32.atomic.rmw8.sub_u (i32.const 0) (i32.const 1))
+# ))
 ```
 
 ---
@@ -434,8 +546,12 @@ Atomically read an 8-bit value, perform bitwise AND, and store the result. Retur
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i32)
 ;; Atomically AND byte at address with mask, return old value
 (i32.atomic.rmw8.and_u (i32.const 0) (i32.const 0x0F))
+# ))
 ```
 
 ---
@@ -449,8 +565,12 @@ Atomically read an 8-bit value, perform bitwise OR, and store the result. Return
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i32)
 ;; Atomically OR byte at address with flags, return old value
 (i32.atomic.rmw8.or_u (i32.const 0) (i32.const 0x80))
+# ))
 ```
 
 ---
@@ -464,8 +584,12 @@ Atomically read an 8-bit value, perform bitwise XOR, and store the result. Retur
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i32)
 ;; Atomically XOR byte at address, return old value
 (i32.atomic.rmw8.xor_u (i32.const 0) (i32.const 0xFF))
+# ))
 ```
 
 ---
@@ -479,8 +603,12 @@ Atomically exchange an 8-bit value in memory. Returns the original value zero-ex
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i32)
 ;; Atomically swap byte at address, return old value
 (i32.atomic.rmw8.xchg_u (i32.const 0) (i32.const 42))
+# ))
 ```
 
 ---
@@ -494,8 +622,12 @@ Atomically read a 16-bit value, add to it, and store the result. Returns the ori
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i32)
 ;; Atomically add to 16-bit value at address, return old value
 (i32.atomic.rmw16.add_u (i32.const 0) (i32.const 100))
+# ))
 ```
 
 ---
@@ -509,8 +641,12 @@ Atomically read a 16-bit value, subtract from it, and store the result. Returns 
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i32)
 ;; Atomically subtract from 16-bit value at address, return old value
 (i32.atomic.rmw16.sub_u (i32.const 0) (i32.const 100))
+# ))
 ```
 
 ---
@@ -524,8 +660,12 @@ Atomically read a 16-bit value, perform bitwise AND, and store the result. Retur
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i32)
 ;; Atomically AND 16-bit value at address with mask, return old value
 (i32.atomic.rmw16.and_u (i32.const 0) (i32.const 0x00FF))
+# ))
 ```
 
 ---
@@ -539,8 +679,12 @@ Atomically read a 16-bit value, perform bitwise OR, and store the result. Return
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i32)
 ;; Atomically OR 16-bit value at address with flags, return old value
 (i32.atomic.rmw16.or_u (i32.const 0) (i32.const 0x8000))
+# ))
 ```
 
 ---
@@ -554,8 +698,12 @@ Atomically read a 16-bit value, perform bitwise XOR, and store the result. Retur
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i32)
 ;; Atomically XOR 16-bit value at address, return old value
 (i32.atomic.rmw16.xor_u (i32.const 0) (i32.const 0xFFFF))
+# ))
 ```
 
 ---
@@ -569,8 +717,12 @@ Atomically exchange a 16-bit value in memory. Returns the original value zero-ex
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i32)
 ;; Atomically swap 16-bit value at address, return old value
 (i32.atomic.rmw16.xchg_u (i32.const 0) (i32.const 1000))
+# ))
 ```
 
 ---
@@ -584,8 +736,12 @@ Atomically read an 8-bit value, add to it, and store the result. Returns the ori
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i64)
 ;; Atomically add to byte at address, return old value as i64
 (i64.atomic.rmw8.add_u (i32.const 0) (i64.const 1))
+# ))
 ```
 
 ---
@@ -599,8 +755,12 @@ Atomically read an 8-bit value, subtract from it, and store the result. Returns 
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i64)
 ;; Atomically subtract from byte at address, return old value as i64
 (i64.atomic.rmw8.sub_u (i32.const 0) (i64.const 1))
+# ))
 ```
 
 ---
@@ -614,8 +774,12 @@ Atomically read an 8-bit value, perform bitwise AND, and store the result. Retur
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i64)
 ;; Atomically AND byte at address with mask, return old value as i64
 (i64.atomic.rmw8.and_u (i32.const 0) (i64.const 0x0F))
+# ))
 ```
 
 ---
@@ -629,8 +793,12 @@ Atomically read an 8-bit value, perform bitwise OR, and store the result. Return
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i64)
 ;; Atomically OR byte at address with flags, return old value as i64
 (i64.atomic.rmw8.or_u (i32.const 0) (i64.const 0x80))
+# ))
 ```
 
 ---
@@ -644,8 +812,12 @@ Atomically read an 8-bit value, perform bitwise XOR, and store the result. Retur
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i64)
 ;; Atomically XOR byte at address, return old value as i64
 (i64.atomic.rmw8.xor_u (i32.const 0) (i64.const 0xFF))
+# ))
 ```
 
 ---
@@ -659,8 +831,12 @@ Atomically exchange an 8-bit value in memory. Returns the original value zero-ex
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i64)
 ;; Atomically swap byte at address, return old value as i64
 (i64.atomic.rmw8.xchg_u (i32.const 0) (i64.const 42))
+# ))
 ```
 
 ---
@@ -674,8 +850,12 @@ Atomically read a 16-bit value, add to it, and store the result. Returns the ori
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i64)
 ;; Atomically add to 16-bit value at address, return old value as i64
 (i64.atomic.rmw16.add_u (i32.const 0) (i64.const 100))
+# ))
 ```
 
 ---
@@ -689,8 +869,12 @@ Atomically read a 16-bit value, subtract from it, and store the result. Returns 
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i64)
 ;; Atomically subtract from 16-bit value at address, return old value as i64
 (i64.atomic.rmw16.sub_u (i32.const 0) (i64.const 100))
+# ))
 ```
 
 ---
@@ -704,8 +888,12 @@ Atomically read a 16-bit value, perform bitwise AND, and store the result. Retur
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i64)
 ;; Atomically AND 16-bit value at address with mask, return old value as i64
 (i64.atomic.rmw16.and_u (i32.const 0) (i64.const 0x00FF))
+# ))
 ```
 
 ---
@@ -719,8 +907,12 @@ Atomically read a 16-bit value, perform bitwise OR, and store the result. Return
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i64)
 ;; Atomically OR 16-bit value at address with flags, return old value as i64
 (i64.atomic.rmw16.or_u (i32.const 0) (i64.const 0x8000))
+# ))
 ```
 
 ---
@@ -734,8 +926,12 @@ Atomically read a 16-bit value, perform bitwise XOR, and store the result. Retur
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i64)
 ;; Atomically XOR 16-bit value at address, return old value as i64
 (i64.atomic.rmw16.xor_u (i32.const 0) (i64.const 0xFFFF))
+# ))
 ```
 
 ---
@@ -749,8 +945,12 @@ Atomically exchange a 16-bit value in memory. Returns the original value zero-ex
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i64)
 ;; Atomically swap 16-bit value at address, return old value as i64
 (i64.atomic.rmw16.xchg_u (i32.const 0) (i64.const 1000))
+# ))
 ```
 
 ---
@@ -764,8 +964,12 @@ Atomically read a 32-bit value, add to it, and store the result. Returns the ori
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i64)
 ;; Atomically add to 32-bit value at address, return old value as i64
 (i64.atomic.rmw32.add_u (i32.const 0) (i64.const 1000))
+# ))
 ```
 
 ---
@@ -779,8 +983,12 @@ Atomically read a 32-bit value, subtract from it, and store the result. Returns 
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i64)
 ;; Atomically subtract from 32-bit value at address, return old value as i64
 (i64.atomic.rmw32.sub_u (i32.const 0) (i64.const 1000))
+# ))
 ```
 
 ---
@@ -794,8 +1002,12 @@ Atomically read a 32-bit value, perform bitwise AND, and store the result. Retur
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i64)
 ;; Atomically AND 32-bit value at address with mask, return old value as i64
 (i64.atomic.rmw32.and_u (i32.const 0) (i64.const 0xFFFF0000))
+# ))
 ```
 
 ---
@@ -809,8 +1021,12 @@ Atomically read a 32-bit value, perform bitwise OR, and store the result. Return
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i64)
 ;; Atomically OR 32-bit value at address with flags, return old value as i64
 (i64.atomic.rmw32.or_u (i32.const 0) (i64.const 0x80000000))
+# ))
 ```
 
 ---
@@ -824,8 +1040,12 @@ Atomically read a 32-bit value, perform bitwise XOR, and store the result. Retur
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i64)
 ;; Atomically XOR 32-bit value at address, return old value as i64
 (i64.atomic.rmw32.xor_u (i32.const 0) (i64.const 0xFFFFFFFF))
+# ))
 ```
 
 ---
@@ -839,8 +1059,12 @@ Atomically exchange a 32-bit value in memory. Returns the original value zero-ex
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i64)
 ;; Atomically swap 32-bit value at address, return old value as i64
 (i64.atomic.rmw32.xchg_u (i32.const 0) (i64.const 100000))
+# ))
 ```
 
 ---
@@ -854,12 +1078,16 @@ Atomically compare and exchange a 32-bit value. If the value at the address equa
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i32)
 ;; Compare and exchange: if [addr] == expected, set to replacement
 ;; Returns original value at address
 (i32.atomic.rmw.cmpxchg
   (i32.const 0)       ;; address
   (i32.const 0)       ;; expected value
   (i32.const 1))      ;; replacement value
+# ))
 ```
 
 ---
@@ -873,12 +1101,16 @@ Atomically compare and exchange a 64-bit value. If the value at the address equa
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i64)
 ;; Compare and exchange: if [addr] == expected, set to replacement
 ;; Returns original value at address
 (i64.atomic.rmw.cmpxchg
   (i32.const 0)       ;; address
   (i64.const 0)       ;; expected value
   (i64.const 1))      ;; replacement value
+# ))
 ```
 
 ---
@@ -892,11 +1124,15 @@ Atomically compare and exchange an 8-bit value. If the value at the address equa
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i32)
 ;; Compare and exchange byte: if [addr] == expected, set to replacement
 (i32.atomic.rmw8.cmpxchg_u
   (i32.const 0)       ;; address
   (i32.const 0)       ;; expected value
   (i32.const 1))      ;; replacement value
+# ))
 ```
 
 ---
@@ -910,11 +1146,15 @@ Atomically compare and exchange a 16-bit value. If the value at the address equa
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i32)
 ;; Compare and exchange 16-bit: if [addr] == expected, set to replacement
 (i32.atomic.rmw16.cmpxchg_u
   (i32.const 0)       ;; address
   (i32.const 0)       ;; expected value
   (i32.const 1))      ;; replacement value
+# ))
 ```
 
 ---
@@ -928,11 +1168,15 @@ Atomically compare and exchange an 8-bit value. If the value at the address equa
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i64)
 ;; Compare and exchange byte: if [addr] == expected, set to replacement
 (i64.atomic.rmw8.cmpxchg_u
   (i32.const 0)       ;; address
   (i64.const 0)       ;; expected value
   (i64.const 1))      ;; replacement value
+# ))
 ```
 
 ---
@@ -946,11 +1190,15 @@ Atomically compare and exchange a 16-bit value. If the value at the address equa
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i64)
 ;; Compare and exchange 16-bit: if [addr] == expected, set to replacement
 (i64.atomic.rmw16.cmpxchg_u
   (i32.const 0)       ;; address
   (i64.const 0)       ;; expected value
   (i64.const 1))      ;; replacement value
+# ))
 ```
 
 ---
@@ -964,11 +1212,15 @@ Atomically compare and exchange a 32-bit value. If the value at the address equa
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i64)
 ;; Compare and exchange 32-bit: if [addr] == expected, set to replacement
 (i64.atomic.rmw32.cmpxchg_u
   (i32.const 0)       ;; address
   (i64.const 0)       ;; expected value
   (i64.const 1))      ;; replacement value
+# ))
 ```
 
 ---
@@ -982,12 +1234,16 @@ Suspend the current thread until notified or timeout. The thread waits if the 32
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i32)
 ;; Wait on address until value changes or timeout
 ;; Returns: 0 = woken, 1 = not equal, 2 = timed out
 (memory.atomic.wait32
   (i32.const 0)       ;; address
   (i32.const 0)       ;; expected value
   (i64.const -1))     ;; timeout (-1 = infinite)
+# ))
 ```
 
 ---
@@ -1001,12 +1257,16 @@ Suspend the current thread until notified or timeout. The thread waits if the 64
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i32)
 ;; Wait on address until 64-bit value changes or timeout
 ;; Returns: 0 = woken, 1 = not equal, 2 = timed out
 (memory.atomic.wait64
   (i32.const 0)       ;; address
   (i64.const 0)       ;; expected value
   (i64.const 1000000000)) ;; timeout in nanoseconds (1 second)
+# ))
 ```
 
 ---
@@ -1020,10 +1280,14 @@ Wake up threads waiting on an address. Returns the number of threads that were w
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i32)
 ;; Wake up to 1 waiter at address
 (memory.atomic.notify
   (i32.const 0)       ;; address
   (i32.const 1))      ;; max waiters to wake
+# ))
 ```
 
 ---
@@ -1037,8 +1301,12 @@ Ensure memory ordering between atomic and non-atomic operations. This is a seque
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func
 ;; Memory fence for ordering guarantees
 (atomic.fence)
+# ))
 ```
 
 ---

--- a/packages/docs/src/content/docs/instructions/control.md
+++ b/packages/docs/src/content/docs/instructions/control.md
@@ -12,12 +12,14 @@ Define a block with a label at the end. Branching to this label exits the block.
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (block $exit (result i32)
   (i32.const 10)
-  (br_if $exit (i32.const 1))  ;; Exit early
-  (i32.const 20)  ;; This won't execute
+  (br $exit)  ;; Exit with 10
+  (unreachable)  ;; This won't execute
 )
 ;; Returns 10
+# ))
 ```
 
 ---
@@ -29,6 +31,7 @@ Define a loop with a label at the start. Branching to this label restarts the lo
 **Example:**
 
 ```wat
+# (module (func
 (local $i i32)
 (local.set $i (i32.const 0))
 (loop $continue
@@ -36,6 +39,7 @@ Define a loop with a label at the start. Branching to this label restarts the lo
   (br_if $continue (i32.lt_s (local.get $i) (i32.const 10)))
 )
 ;; $i is now 10
+# ))
 ```
 
 ---
@@ -47,16 +51,22 @@ Conditional execution based on stack value. Execute 'then' if non-zero, 'else' i
 **Example:**
 
 ```wat
+# (module
+# (func $handle_zero)
+# (func (param $x i32)
+# (drop
 (if (result i32) (i32.const 1)
   (then (i32.const 42))
   (else (i32.const 0))
 )
 ;; Returns 42
-
+# )
+#
 ;; Without else
 (if (i32.eq (local.get $x) (i32.const 0))
   (then (call $handle_zero))
 )
+# ))
 ```
 
 ---
@@ -68,15 +78,21 @@ Marks the branch of an `if` statement that executes when the condition is non-ze
 **Example:**
 
 ```wat
+# (module
+# (func $log (param i32))
+# (func (param $x i32) (param $condition i32)
+# (local $positive i32)
 (if (i32.gt_s (local.get $x) (i32.const 0))
   (then
     (call $log (i32.const 1))
     (local.set $positive (i32.const 1))))
 
 ;; With result type
+# (drop
 (if (result i32) (local.get $condition)
   (then (i32.const 100))
   (else (i32.const 0)))
+# )))
 ```
 
 ---
@@ -88,16 +104,24 @@ Marks the branch of an `if` statement that executes when the condition is zero (
 **Example:**
 
 ```wat
+# (module
+# (func $handle_zero)
+# (func $handle_nonzero)
+# (func (param $flag i32) (param $x i32)
+# (local $processed i32)
+# (drop
 (if (result i32) (local.get $flag)
   (then (i32.const 1))
   (else (i32.const 0)))
-
+# )
+#
 ;; Multi-statement else
 (if (i32.eqz (local.get $x))
   (then (call $handle_zero))
   (else
     (call $handle_nonzero)
     (local.set $processed (i32.const 1))))
+# ))
 ```
 
 ---
@@ -109,12 +133,14 @@ Unconditional branch to a label. Exits blocks/loops.
 **Example:**
 
 ```wat
+# (module (func
 (block $outer
   (block $inner
     (br $outer)  ;; Jump to end of $outer
     (unreachable)  ;; Never executed
   )
 )
+# ))
 ```
 
 ---
@@ -128,10 +154,13 @@ Conditional branch to a label if top stack value is non-zero.
 **Example:**
 
 ```wat
+# (module
+# (func (param $x i32)
 (block $exit
   (br_if $exit (i32.eq (local.get $x) (i32.const 0)))
   ;; Code here runs if $x != 0
 )
+# ))
 ```
 
 ---
@@ -145,6 +174,8 @@ Table-based branch. Jumps to label based on index.
 **Example:**
 
 ```wat
+# (module
+# (func (param $selector i32)
 (block $case0
   (block $case1
     (block $case2
@@ -162,6 +193,7 @@ Table-based branch. Jumps to label based on index.
   (return)
 )
 ;; case 0
+# ))
 ```
 
 ---
@@ -173,13 +205,19 @@ Call a function by name or index.
 **Example:**
 
 ```wat
+# (module
 (func $add (param i32 i32) (result i32)
   (i32.add (local.get 0) (local.get 1)))
 
 (func $main
+# (drop
   (call $add (i32.const 5) (i32.const 3))  ;; Returns 8
+# )
+# (drop
   (call 0 (i32.const 1) (i32.const 2))     ;; Call by index
+# )
 )
+# )
 ```
 
 ---
@@ -191,6 +229,7 @@ Call a function from a table using a dynamic index.
 **Example:**
 
 ```wat
+# (module
 (type $binop (func (param i32 i32) (result i32)))
 (table 2 funcref)
 (elem (i32.const 0) $add $mul)
@@ -207,6 +246,7 @@ Call a function from a table using a dynamic index.
     (i32.const 3)
     (local.get $fn_index))
 )
+# )
 ```
 
 ---
@@ -218,12 +258,14 @@ Return from the current function immediately.
 **Example:**
 
 ```wat
+# (module
 (func $early_return (param $x i32) (result i32)
   (if (i32.eqz (local.get $x))
     (then (return (i32.const 0))))
   ;; More code here
   (i32.const 1)
 )
+# )
 ```
 
 ---
@@ -235,12 +277,14 @@ Tail call: calls a function and returns its result directly. The current functio
 **Example:**
 
 ```wat
+# (module
 (func $factorial_tail (param $n i32) (param $acc i32) (result i32)
   (if (result i32) (i32.le_s (local.get $n) (i32.const 1))
     (then (local.get $acc))
     (else (return_call $factorial_tail
       (i32.sub (local.get $n) (i32.const 1))
       (i32.mul (local.get $n) (local.get $acc))))))
+# )
 ```
 
 ---
@@ -252,11 +296,13 @@ Trap unconditionally. Used for code that should never be reached.
 **Example:**
 
 ```wat
+# (module
 (func $divide (param $x i32) (param $y i32) (result i32)
   (if (i32.eqz (local.get $y))
     (then (unreachable)))  ;; Trap on division by zero
   (i32.div_s (local.get $x) (local.get $y))
 )
+# )
 ```
 
 ---
@@ -268,7 +314,9 @@ No operation. Does nothing.
 **Example:**
 
 ```wat
+# (module (func
 (nop)  ;; Useful for debugging or as placeholder
+# ))
 ```
 
 ---
@@ -281,7 +329,7 @@ Call a function through a typed function reference. The reference type determine
 
 **Example:**
 
-```wat
+```wat-snippet
 (type $sig (func (param i32) (result i32)))
 (call_ref $sig (i32.const 42) (local.get $func_ref))
 ```
@@ -296,7 +344,7 @@ Tail call a function through a typed function reference. Immediately returns the
 
 **Example:**
 
-```wat
+```wat-snippet
 (type $sig (func (param i32) (result i32)))
 (return_call_ref $sig (i32.const 42) (local.get $func_ref))
 ```
@@ -311,7 +359,7 @@ Branch to a label if the reference is null. If not null, the non-null reference 
 
 **Example:**
 
-```wat
+```wat-snippet
 (block $is_null
   (br_on_null $is_null (local.get $maybe_null_ref))
   ;; Reference is not null here, use it
@@ -330,7 +378,7 @@ Branch to a label if the reference is not null. The non-null reference is passed
 
 **Example:**
 
-```wat
+```wat-snippet
 (block $not_null (param (ref $type))
   (br_on_non_null $not_null (local.get $maybe_null_ref))
   ;; Reference was null, handle null case

--- a/packages/docs/src/content/docs/instructions/exceptions.md
+++ b/packages/docs/src/content/docs/instructions/exceptions.md
@@ -14,7 +14,11 @@ Throw an exception with a tag.
 **Example:**
 
 ```wat
+# (module
+# (tag $error_tag (param i32))
+# (func
 (throw $error_tag (i32.const 500))
+# ))
 ```
 
 ---
@@ -28,7 +32,9 @@ Throw an existing exception reference.
 **Example:**
 
 ```wat
+# (module (func (param $exn exnref)
 (throw_ref (local.get $exn))
+# ))
 ```
 
 ---
@@ -41,7 +47,7 @@ Rethrow an exception from a catch block.
 
 **Example:**
 
-```wat
+```wat-snippet
 (rethrow $label)
 ```
 
@@ -54,8 +60,10 @@ Declare an exception tag with a type signature for exception handling.
 **Example:**
 
 ```wat
+# (module
 (tag $error (param i32))
 (tag $complex_error (param i32 i32 f64))
+# )
 ```
 
 ---
@@ -67,9 +75,14 @@ Define a block that catches exceptions using a jump table.
 **Example:**
 
 ```wat
+# (module
+# (tag $tag (param i32))
+# (func
+# (block $handler_label (result i32)
 (try_table (catch $tag $handler_label)
   (throw $tag (i32.const 1))
 )
+# (unreachable))))
 ```
 
 ---
@@ -80,7 +93,7 @@ Catches exceptions with a specific tag in a `try_table` block. Branches to a lab
 
 **Example:**
 
-```wat
+```wat-snippet
 (block $handler (result i32)
   (try_table (catch $error_tag $handler)
     (call $may_throw)
@@ -105,7 +118,7 @@ Catches any exception in a `try_table` block, regardless of tag.
 
 **Example:**
 
-```wat
+```wat-snippet
 (block $fallback
   (try_table (catch_all $fallback)
     (call $may_throw_anything)
@@ -122,7 +135,7 @@ Catches exceptions with a specific tag and provides the exception reference.
 
 **Example:**
 
-```wat
+```wat-snippet
 (block $handler (result i32 exnref)
   (try_table (catch_ref $error_tag $handler)
     (call $may_throw)
@@ -140,7 +153,7 @@ Catches any exception and provides the exception reference.
 
 **Example:**
 
-```wat
+```wat-snippet
 (block $handler (result exnref)
   (try_table (catch_all_ref $handler)
     (call $may_throw)

--- a/packages/docs/src/content/docs/instructions/f32.md
+++ b/packages/docs/src/content/docs/instructions/f32.md
@@ -14,7 +14,9 @@ Convert signed i32 to f32.
 **Example:**
 
 ```wat
+# (module (func (result f32)
 (f32.convert_i32_s (i32.const -5))  ;; Returns -5.0
+# ))
 ```
 
 ---
@@ -28,7 +30,9 @@ Convert unsigned i32 to f32.
 **Example:**
 
 ```wat
+# (module (func (result f32)
 (f32.convert_i32_u (i32.const 5))  ;; Returns 5.0
+# ))
 ```
 
 ---
@@ -42,7 +46,9 @@ Convert signed i64 to f32.
 **Example:**
 
 ```wat
+# (module (func (result f32)
 (f32.convert_i64_s (i64.const -5))  ;; Returns -5.0
+# ))
 ```
 
 ---
@@ -56,7 +62,9 @@ Convert unsigned i64 to f32.
 **Example:**
 
 ```wat
+# (module (func (result f32)
 (f32.convert_i64_u (i64.const 5))  ;; Returns 5.0
+# ))
 ```
 
 ---
@@ -70,7 +78,9 @@ Convert f64 to f32 (may lose precision).
 **Example:**
 
 ```wat
+# (module (func (result f32)
 (f32.demote_f64 (f64.const 3.141592653589793))  ;; Returns ~3.1415927
+# ))
 ```
 
 ---
@@ -84,7 +94,9 @@ Reinterpret i32 bits as f32.
 **Example:**
 
 ```wat
+# (module (func (result f32)
 (f32.reinterpret_i32 (i32.const 0x3F800000))  ;; Returns 1.0
+# ))
 ```
 
 ---
@@ -98,7 +110,9 @@ Add two f32 values.
 **Example:**
 
 ```wat
+# (module (func (result f32)
 (f32.add (f32.const 3.14) (f32.const 2.86))
+# ))
 ```
 
 ---
@@ -112,7 +126,9 @@ Subtract two f32 values.
 **Example:**
 
 ```wat
+# (module (func (result f32)
 (f32.sub (f32.const 10.5) (f32.const 3.2))
+# ))
 ```
 
 ---
@@ -126,7 +142,9 @@ Multiply two f32 values.
 **Example:**
 
 ```wat
+# (module (func (result f32)
 (f32.mul (f32.const 3.5) (f32.const 2.0))
+# ))
 ```
 
 ---
@@ -140,7 +158,9 @@ Divide two f32 values.
 **Example:**
 
 ```wat
+# (module (func (result f32)
 (f32.div (f32.const 10.0) (f32.const 3.0))
+# ))
 ```
 
 ---
@@ -154,7 +174,9 @@ Calculate square root.
 **Example:**
 
 ```wat
+# (module (func (result f32)
 (f32.sqrt (f32.const 16.0))  ;; Returns 4.0
+# ))
 ```
 
 ---
@@ -168,7 +190,9 @@ Return minimum of two f32 values.
 **Example:**
 
 ```wat
+# (module (func (result f32)
 (f32.min (f32.const 3.5) (f32.const 2.1))  ;; Returns 2.1
+# ))
 ```
 
 ---
@@ -182,7 +206,9 @@ Return maximum of two f32 values.
 **Example:**
 
 ```wat
+# (module (func (result f32)
 (f32.max (f32.const 3.5) (f32.const 2.1))  ;; Returns 3.5
+# ))
 ```
 
 ---
@@ -196,7 +222,9 @@ Absolute value.
 **Example:**
 
 ```wat
+# (module (func (result f32)
 (f32.abs (f32.const -3.14))  ;; Returns 3.14
+# ))
 ```
 
 ---
@@ -210,7 +238,9 @@ Negate value.
 **Example:**
 
 ```wat
+# (module (func (result f32)
 (f32.neg (f32.const 3.14))  ;; Returns -3.14
+# ))
 ```
 
 ---
@@ -224,7 +254,9 @@ Round up to nearest integer.
 **Example:**
 
 ```wat
+# (module (func (result f32)
 (f32.ceil (f32.const 3.2))  ;; Returns 4.0
+# ))
 ```
 
 ---
@@ -238,7 +270,9 @@ Round down to nearest integer.
 **Example:**
 
 ```wat
+# (module (func (result f32)
 (f32.floor (f32.const 3.8))  ;; Returns 3.0
+# ))
 ```
 
 ---
@@ -252,8 +286,13 @@ Round toward zero.
 **Example:**
 
 ```wat
+# (module (func
+# (drop
 (f32.trunc (f32.const 3.8))   ;; Returns 3.0
+# )
+# (drop
 (f32.trunc (f32.const -3.8))  ;; Returns -3.0
+# )))
 ```
 
 ---
@@ -267,8 +306,13 @@ Round to nearest integer, ties to even.
 **Example:**
 
 ```wat
+# (module (func
+# (drop
 (f32.nearest (f32.const 3.5))  ;; Returns 4.0
+# )
+# (drop
 (f32.nearest (f32.const 2.5))  ;; Returns 2.0 (ties to even)
+# )))
 ```
 
 ---
@@ -282,7 +326,9 @@ Copy sign of second argument to first argument.
 **Example:**
 
 ```wat
+# (module (func (result f32)
 (f32.copysign (f32.const 5.0) (f32.const -1.0))  ;; Returns -5.0
+# ))
 ```
 
 ---
@@ -296,7 +342,9 @@ Check if two f32 values are equal.
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (f32.eq (f32.const 3.14) (f32.const 3.14))  ;; Returns 1 (true)
+# ))
 ```
 
 ---
@@ -310,7 +358,9 @@ Check if two f32 values are not equal.
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (f32.ne (f32.const 3.14) (f32.const 2.71))  ;; Returns 1 (true)
+# ))
 ```
 
 ---
@@ -324,7 +374,9 @@ Check if first f32 is less than second.
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (f32.lt (f32.const 2.0) (f32.const 3.0))  ;; Returns 1 (true)
+# ))
 ```
 
 ---
@@ -338,7 +390,9 @@ Check if first f32 is greater than second.
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (f32.gt (f32.const 3.0) (f32.const 2.0))  ;; Returns 1 (true)
+# ))
 ```
 
 ---
@@ -352,7 +406,9 @@ Check if first f32 is less than or equal to second.
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (f32.le (f32.const 3.0) (f32.const 3.0))  ;; Returns 1 (true)
+# ))
 ```
 
 ---
@@ -366,7 +422,9 @@ Check if first f32 is greater than or equal to second.
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (f32.ge (f32.const 3.0) (f32.const 3.0))  ;; Returns 1 (true)
+# ))
 ```
 
 ---
@@ -380,8 +438,15 @@ Load f32 from memory at the given address.
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func
+# (drop
 (f32.load (i32.const 0))
+# )
+# (drop
 (f32.load offset=4 align=4 (i32.const 0))
+# )))
 ```
 
 ---
@@ -395,7 +460,11 @@ Store f32 value to memory.
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func
 (f32.store (i32.const 0) (f32.const 3.14))
+# ))
 ```
 
 ---
@@ -409,10 +478,19 @@ Create a constant f32 value.
 **Example:**
 
 ```wat
+# (module (func
+# (drop
 (f32.const 3.14159)
+# )
+# (drop
 (f32.const -0.0)
+# )
+# (drop
 (f32.const inf)
+# )
+# (drop
 (f32.const nan)
+# )))
 ```
 
 ---

--- a/packages/docs/src/content/docs/instructions/f64.md
+++ b/packages/docs/src/content/docs/instructions/f64.md
@@ -14,7 +14,9 @@ Convert signed i32 to f64.
 **Example:**
 
 ```wat
+# (module (func (result f64)
 (f64.convert_i32_s (i32.const -5))  ;; Returns -5.0
+# ))
 ```
 
 ---
@@ -28,7 +30,9 @@ Convert unsigned i32 to f64.
 **Example:**
 
 ```wat
+# (module (func (result f64)
 (f64.convert_i32_u (i32.const 5))  ;; Returns 5.0
+# ))
 ```
 
 ---
@@ -42,7 +46,9 @@ Convert signed i64 to f64.
 **Example:**
 
 ```wat
+# (module (func (result f64)
 (f64.convert_i64_s (i64.const -5))  ;; Returns -5.0
+# ))
 ```
 
 ---
@@ -56,7 +62,9 @@ Convert unsigned i64 to f64.
 **Example:**
 
 ```wat
+# (module (func (result f64)
 (f64.convert_i64_u (i64.const 5))  ;; Returns 5.0
+# ))
 ```
 
 ---
@@ -70,7 +78,9 @@ Convert f32 to f64 (lossless).
 **Example:**
 
 ```wat
+# (module (func (result f64)
 (f64.promote_f32 (f32.const 3.14))  ;; Returns 3.14 (as f64)
+# ))
 ```
 
 ---
@@ -84,7 +94,9 @@ Reinterpret i64 bits as f64.
 **Example:**
 
 ```wat
+# (module (func (result f64)
 (f64.reinterpret_i64 (i64.const 0x3FF0000000000000))  ;; Returns 1.0
+# ))
 ```
 
 ---
@@ -98,7 +110,9 @@ Add two f64 values.
 **Example:**
 
 ```wat
+# (module (func (result f64)
 (f64.add (f64.const 3.14159) (f64.const 2.71828))
+# ))
 ```
 
 ---
@@ -112,7 +126,9 @@ Subtract two f64 values.
 **Example:**
 
 ```wat
+# (module (func (result f64)
 (f64.sub (f64.const 10.5) (f64.const 3.2))
+# ))
 ```
 
 ---
@@ -126,7 +142,9 @@ Multiply two f64 values.
 **Example:**
 
 ```wat
+# (module (func (result f64)
 (f64.mul (f64.const 3.5) (f64.const 2.0))
+# ))
 ```
 
 ---
@@ -140,7 +158,9 @@ Divide two f64 values.
 **Example:**
 
 ```wat
+# (module (func (result f64)
 (f64.div (f64.const 10.0) (f64.const 3.0))
+# ))
 ```
 
 ---
@@ -154,7 +174,9 @@ Calculate square root with double precision.
 **Example:**
 
 ```wat
+# (module (func (result f64)
 (f64.sqrt (f64.const 2.0))  ;; Returns 1.4142135623730951
+# ))
 ```
 
 ---
@@ -168,7 +190,9 @@ Return minimum of two f64 values.
 **Example:**
 
 ```wat
+# (module (func (result f64)
 (f64.min (f64.const 3.5) (f64.const 2.1))  ;; Returns 2.1
+# ))
 ```
 
 ---
@@ -182,7 +206,9 @@ Return maximum of two f64 values.
 **Example:**
 
 ```wat
+# (module (func (result f64)
 (f64.max (f64.const 3.5) (f64.const 2.1))  ;; Returns 3.5
+# ))
 ```
 
 ---
@@ -196,7 +222,9 @@ Absolute value.
 **Example:**
 
 ```wat
+# (module (func (result f64)
 (f64.abs (f64.const -3.14))  ;; Returns 3.14
+# ))
 ```
 
 ---
@@ -210,7 +238,9 @@ Negate value.
 **Example:**
 
 ```wat
+# (module (func (result f64)
 (f64.neg (f64.const 3.14))  ;; Returns -3.14
+# ))
 ```
 
 ---
@@ -224,7 +254,9 @@ Round up to nearest integer.
 **Example:**
 
 ```wat
+# (module (func (result f64)
 (f64.ceil (f64.const 3.2))  ;; Returns 4.0
+# ))
 ```
 
 ---
@@ -238,7 +270,9 @@ Round down to nearest integer.
 **Example:**
 
 ```wat
+# (module (func (result f64)
 (f64.floor (f64.const 3.8))  ;; Returns 3.0
+# ))
 ```
 
 ---
@@ -252,8 +286,13 @@ Round toward zero.
 **Example:**
 
 ```wat
+# (module (func
+# (drop
 (f64.trunc (f64.const 3.8))   ;; Returns 3.0
+# )
+# (drop
 (f64.trunc (f64.const -3.8))  ;; Returns -3.0
+# )))
 ```
 
 ---
@@ -267,8 +306,13 @@ Round to nearest integer, ties to even.
 **Example:**
 
 ```wat
+# (module (func
+# (drop
 (f64.nearest (f64.const 3.5))  ;; Returns 4.0
+# )
+# (drop
 (f64.nearest (f64.const 2.5))  ;; Returns 2.0 (ties to even)
+# )))
 ```
 
 ---
@@ -282,7 +326,9 @@ Copy sign of second argument to first argument.
 **Example:**
 
 ```wat
+# (module (func (result f64)
 (f64.copysign (f64.const 5.0) (f64.const -1.0))  ;; Returns -5.0
+# ))
 ```
 
 ---
@@ -296,7 +342,9 @@ Check if two f64 values are equal.
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (f64.eq (f64.const 3.14) (f64.const 3.14))  ;; Returns 1 (true)
+# ))
 ```
 
 ---
@@ -310,7 +358,9 @@ Check if two f64 values are not equal.
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (f64.ne (f64.const 3.14) (f64.const 2.71))  ;; Returns 1 (true)
+# ))
 ```
 
 ---
@@ -324,7 +374,9 @@ Check if first f64 is less than second.
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (f64.lt (f64.const 2.0) (f64.const 3.0))  ;; Returns 1 (true)
+# ))
 ```
 
 ---
@@ -338,7 +390,9 @@ Check if first f64 is greater than second.
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (f64.gt (f64.const 3.0) (f64.const 2.0))  ;; Returns 1 (true)
+# ))
 ```
 
 ---
@@ -352,7 +406,9 @@ Check if first f64 is less than or equal to second.
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (f64.le (f64.const 3.0) (f64.const 3.0))  ;; Returns 1 (true)
+# ))
 ```
 
 ---
@@ -366,7 +422,9 @@ Check if first f64 is greater than or equal to second.
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (f64.ge (f64.const 3.0) (f64.const 3.0))  ;; Returns 1 (true)
+# ))
 ```
 
 ---
@@ -380,8 +438,15 @@ Load f64 from memory at the given address.
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func
+# (drop
 (f64.load (i32.const 0))
+# )
+# (drop
 (f64.load offset=8 align=8 (i32.const 0))
+# )))
 ```
 
 ---
@@ -395,7 +460,11 @@ Store f64 value to memory.
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func
 (f64.store (i32.const 0) (f64.const 3.14159))
+# ))
 ```
 
 ---
@@ -409,8 +478,13 @@ Create a constant f64 value.
 **Example:**
 
 ```wat
+# (module (func
+# (drop
 (f64.const 3.141592653589793)
+# )
+# (drop
 (f64.const 1.7976931348623157e+308)  ;; Max f64
+# )))
 ```
 
 ---

--- a/packages/docs/src/content/docs/instructions/gc-array.md
+++ b/packages/docs/src/content/docs/instructions/gc-array.md
@@ -14,7 +14,11 @@ Create a new array on the heap.
 **Example:**
 
 ```wat
+# (module
+# (type $my_array (array (mut i32)))
+# (func (result (ref $my_array))
 (array.new $my_array (i32.const 0) (i32.const 10)) ;; Create size 10 array filled with 0
+# ))
 ```
 
 ---
@@ -28,7 +32,11 @@ Create a new array with default values.
 **Example:**
 
 ```wat
+# (module
+# (type $my_array (array (mut i32)))
+# (func (result (ref $my_array))
 (array.new_default $my_array (i32.const 10))
+# ))
 ```
 
 ---
@@ -42,7 +50,11 @@ Create a new array from a fixed set of arguments.
 **Example:**
 
 ```wat
+# (module
+# (type $my_array (array (mut i32)))
+# (func (result (ref $my_array))
 (array.new_fixed $my_array 3 (i32.const 1) (i32.const 2) (i32.const 3))
+# ))
 ```
 
 ---
@@ -56,7 +68,13 @@ Create a new array from a data segment.
 **Example:**
 
 ```wat
+# (module
+# (type $my_array (array (mut i8)))
+# (memory 1)
+# (data $data_index "0123456789")
+# (func (result (ref $my_array))
 (array.new_data $my_array $data_index (i32.const 0) (i32.const 10))
+# ))
 ```
 
 ---
@@ -69,7 +87,7 @@ Create a new array from an element segment.
 
 **Example:**
 
-```wat
+```wat-snippet
 (array.new_elem $my_array $elem_index (i32.const 0) (i32.const 10))
 ```
 
@@ -84,7 +102,11 @@ Get an element from an array.
 **Example:**
 
 ```wat
+# (module
+# (type $my_array (array (mut i32)))
+# (func (param $arr (ref $my_array)) (result i32)
 (array.get $my_array (local.get $arr) (i32.const 5))
+# ))
 ```
 
 ---
@@ -98,7 +120,11 @@ Get a signed element from an array.
 **Example:**
 
 ```wat
+# (module
+# (type $my_array (array (mut i8)))
+# (func (param $arr (ref $my_array)) (result i32)
 (array.get_s $my_array (local.get $arr) (i32.const 5))
+# ))
 ```
 
 ---
@@ -112,7 +138,11 @@ Get an unsigned element from an array.
 **Example:**
 
 ```wat
+# (module
+# (type $my_array (array (mut i8)))
+# (func (param $arr (ref $my_array)) (result i32)
 (array.get_u $my_array (local.get $arr) (i32.const 5))
+# ))
 ```
 
 ---
@@ -126,7 +156,11 @@ Set an element in an array.
 **Example:**
 
 ```wat
+# (module
+# (type $my_array (array (mut i32)))
+# (func (param $arr (ref $my_array))
 (array.set $my_array (local.get $arr) (i32.const 5) (i32.const 42))
+# ))
 ```
 
 ---
@@ -140,7 +174,11 @@ Get the length of an array.
 **Example:**
 
 ```wat
+# (module
+# (type $my_array (array (mut i32)))
+# (func (param $arr (ref $my_array)) (result i32)
 (array.len (local.get $arr))
+# ))
 ```
 
 ---
@@ -154,7 +192,11 @@ Fill a range of an array with a value.
 **Example:**
 
 ```wat
-(array.fill (local.get $arr) (i32.const 0) (i32.const 42) (i32.const 10))
+# (module
+# (type $my_array (array (mut i32)))
+# (func (param $arr (ref $my_array))
+(array.fill $my_array (local.get $arr) (i32.const 0) (i32.const 42) (i32.const 10))
+# ))
 ```
 
 ---
@@ -168,7 +210,12 @@ Copy a range from one array to another.
 **Example:**
 
 ```wat
+# (module
+# (type $dst_type (array (mut i32)))
+# (type $src_type (array (mut i32)))
+# (func (param $dst (ref $dst_type)) (param $src (ref $src_type))
 (array.copy $dst_type $src_type (local.get $dst) (i32.const 0) (local.get $src) (i32.const 0) (i32.const 10))
+# ))
 ```
 
 ---
@@ -182,11 +229,17 @@ Initialize a portion of an array from a passive data segment. Takes the array, d
 **Example:**
 
 ```wat
+# (module
+# (type $byte_array (array (mut i8)))
+# (memory 1)
+# (data $data_segment "0123456789")
+# (func (param $arr (ref $byte_array))
 (array.init_data $byte_array $data_segment
   (local.get $arr)     ;; array reference
   (i32.const 0)        ;; destination offset in array
   (i32.const 0)        ;; source offset in data segment
   (i32.const 100))     ;; number of elements to copy
+# ))
 ```
 
 ---
@@ -199,7 +252,7 @@ Initialize a portion of an array from a passive element segment. Takes the array
 
 **Example:**
 
-```wat
+```wat-snippet
 (array.init_elem $funcref_array $elem_segment
   (local.get $arr)     ;; array reference
   (i32.const 0)        ;; destination offset in array

--- a/packages/docs/src/content/docs/instructions/gc-casts.md
+++ b/packages/docs/src/content/docs/instructions/gc-casts.md
@@ -14,7 +14,11 @@ Test if a reference is null or of a specific type.
 **Example:**
 
 ```wat
+# (module
+# (type $type (struct (field i32)))
+# (func (param $ref (ref null $type)) (result i32)
 (ref.test (ref null $type) (local.get $ref))
+# ))
 ```
 
 ---
@@ -28,7 +32,11 @@ Cast a reference to a specific type (traps on failure).
 **Example:**
 
 ```wat
+# (module
+# (type $type (struct (field i32)))
+# (func (param $ref (ref null $type)) (result (ref null $type))
 (ref.cast (ref null $type) (local.get $ref))
+# ))
 ```
 
 ---
@@ -41,7 +49,7 @@ Cast a reference to a specific type (returns null on failure).
 
 **Example:**
 
-```wat
+```wat-snippet
 (ref.cast_null (ref null $type) (local.get $ref))
 ```
 
@@ -55,7 +63,7 @@ Branch if a reference can be cast to a type.
 
 **Example:**
 
-```wat
+```wat-snippet
 (br_on_cast $label (ref null $target_type) (local.get $ref))
 ```
 
@@ -69,7 +77,7 @@ Branch if a reference cannot be cast to a type.
 
 **Example:**
 
-```wat
+```wat-snippet
 (br_on_cast_fail $label (ref null $target_type) (local.get $ref))
 ```
 
@@ -84,7 +92,9 @@ Compare two references for equality. Both references must be of type eqref or a 
 **Example:**
 
 ```wat
+# (module (func (param $ref1 eqref) (param $ref2 eqref) (result i32)
 (ref.eq (local.get $ref1) (local.get $ref2))  ;; Returns 1 if equal, 0 otherwise
+# ))
 ```
 
 ---

--- a/packages/docs/src/content/docs/instructions/gc-i31.md
+++ b/packages/docs/src/content/docs/instructions/gc-i31.md
@@ -14,7 +14,9 @@ Create a 31-bit integer reference from an i32.
 **Example:**
 
 ```wat
+# (module (func (result i31ref)
 (ref.i31 (i32.const 42))
+# ))
 ```
 
 ---
@@ -28,7 +30,9 @@ Get the signed i32 value from an i31 reference.
 **Example:**
 
 ```wat
+# (module (func (param $i31 i31ref) (result i32)
 (i31.get_s (local.get $i31))
+# ))
 ```
 
 ---
@@ -42,7 +46,9 @@ Get the unsigned i32 value from an i31 reference.
 **Example:**
 
 ```wat
+# (module (func (param $i31 i31ref) (result i32)
 (i31.get_u (local.get $i31))
+# ))
 ```
 
 ---

--- a/packages/docs/src/content/docs/instructions/gc-struct.md
+++ b/packages/docs/src/content/docs/instructions/gc-struct.md
@@ -14,7 +14,11 @@ Create a new structure on the heap.
 **Example:**
 
 ```wat
+# (module
+# (type $my_struct (struct (field $a i32) (field $b f32)))
+# (func (result (ref $my_struct))
 (struct.new $my_struct (i32.const 1) (f32.const 2.0))
+# ))
 ```
 
 ---
@@ -28,7 +32,11 @@ Create a new structure with default values.
 **Example:**
 
 ```wat
+# (module
+# (type $my_struct (struct (field $a i32) (field $b f32)))
+# (func (result (ref $my_struct))
 (struct.new_default $my_struct)
+# ))
 ```
 
 ---
@@ -41,7 +49,7 @@ Get a field from a structure.
 
 **Example:**
 
-```wat
+```wat-snippet
 (struct.get $my_struct $field_name (local.get $s))
 ```
 
@@ -55,7 +63,7 @@ Get a signed field from a structure (sign-extending).
 
 **Example:**
 
-```wat
+```wat-snippet
 (struct.get_s $my_struct $field_index (local.get $s))
 ```
 
@@ -69,7 +77,7 @@ Get an unsigned field from a structure (zero-extending).
 
 **Example:**
 
-```wat
+```wat-snippet
 (struct.get_u $my_struct $field_index (local.get $s))
 ```
 
@@ -83,7 +91,7 @@ Set a field in a structure.
 
 **Example:**
 
-```wat
+```wat-snippet
 (struct.set $my_struct $field_index (local.get $s) (i32.const 42))
 ```
 

--- a/packages/docs/src/content/docs/instructions/gc-types.md
+++ b/packages/docs/src/content/docs/instructions/gc-types.md
@@ -12,10 +12,11 @@ Declares a subtype that extends another type, enabling type hierarchies. The sub
 **Example:**
 
 ```wat
+# (module
 ;; Base type
-(type $shape (struct
+(type $shape (sub (struct
   (field $x f32)
-  (field $y f32)))
+  (field $y f32))))
 
 ;; Subtype extending $shape with additional fields
 (type $rectangle (sub $shape (struct
@@ -33,6 +34,7 @@ Declares a subtype that extends another type, enabling type hierarchies. The sub
 
 ;; Subtype without explicit parent (subtypes the top type)
 (type $any_struct (sub (struct (field i32))))
+# )
 ```
 
 ---
@@ -43,7 +45,7 @@ Modifier for subtypes that prevents further subtyping. A final type is sealed an
 
 **Example:**
 
-```wat
+```wat-snippet
 ;; This type cannot be subtyped
 (type $sealed (sub final (struct
   (field $value i32))))
@@ -65,6 +67,7 @@ Declares a recursive type group, allowing mutually recursive type definitions.
 **Example:**
 
 ```wat
+# (module
 ;; Mutually recursive types
 (rec
   (type $tree (struct
@@ -83,6 +86,7 @@ Declares a recursive type group, allowing mutually recursive type definitions.
 (rec
   (type $node (struct
     (field $next (ref null $node)))))
+# )
 ```
 
 ---
@@ -94,6 +98,7 @@ Declares a mutable global variable or struct/array field. Without `mut`, the val
 **Example:**
 
 ```wat
+# (module
 ;; Mutable global
 (global $counter (mut i32) (i32.const 0))
 
@@ -102,6 +107,7 @@ Declares a mutable global variable or struct/array field. Without `mut`, the val
 
 ;; Mutable array elements
 (type $buffer (array (mut i32)))
+# )
 ```
 
 ---
@@ -112,7 +118,7 @@ Declares shared memory that can be accessed by multiple threads (threads proposa
 
 **Example:**
 
-```wat
+```wat-snippet
 ;; Shared memory with initial 1 page, max 4 pages
 (memory $mem 1 4 shared)
 
@@ -128,7 +134,7 @@ Heap type representing the null reference. Used in type annotations to indicate 
 
 **Example:**
 
-```wat
+```wat-snippet
 ;; Nullable reference to a function type
 (local $callback (ref null func))
 
@@ -149,7 +155,7 @@ Declares a reference type, optionally nullable. Used in type annotations for par
 
 **Example:**
 
-```wat
+```wat-snippet
 ;; Non-nullable reference to a struct type
 (param $p (ref $my_struct))
 
@@ -174,7 +180,7 @@ Declares a field within a struct type definition. Fields can be mutable or immut
 
 **Example:**
 
-```wat
+```wat-snippet
 ;; Struct with named fields
 (type $point (struct
   (field $x f32)
@@ -204,7 +210,7 @@ Declares a struct type with zero or more fields. Structs are heap-allocated refe
 
 **Example:**
 
-```wat
+```wat-snippet
 ;; Simple struct type
 (type $point (struct
   (field $x f32)
@@ -234,7 +240,7 @@ Declares an array type with elements of a specified type. Arrays are heap-alloca
 
 **Example:**
 
-```wat
+```wat-snippet
 ;; Simple array of i32
 (type $int_array (array i32))
 

--- a/packages/docs/src/content/docs/instructions/i32.md
+++ b/packages/docs/src/content/docs/instructions/i32.md
@@ -14,7 +14,9 @@ Add two i32 values.
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (i32.add (i32.const 5) (i32.const 3))  ;; Returns 8
+# ))
 ```
 
 ---
@@ -28,7 +30,9 @@ Subtract the second i32 value from the first.
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (i32.sub (i32.const 10) (i32.const 3))  ;; Returns 7
+# ))
 ```
 
 ---
@@ -42,7 +46,9 @@ Multiply two i32 values.
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (i32.mul (i32.const 4) (i32.const 5))  ;; Returns 20
+# ))
 ```
 
 ---
@@ -56,7 +62,9 @@ Signed division of two i32 values. Traps if divisor is zero.
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (i32.div_s (i32.const -10) (i32.const 3))  ;; Returns -3
+# ))
 ```
 
 ---
@@ -70,7 +78,9 @@ Unsigned division of two i32 values. Traps if divisor is zero.
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (i32.div_u (i32.const 10) (i32.const 3))  ;; Returns 3
+# ))
 ```
 
 ---
@@ -84,7 +94,9 @@ Signed remainder of division.
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (i32.rem_s (i32.const 10) (i32.const 3))  ;; Returns 1
+# ))
 ```
 
 ---
@@ -98,7 +110,9 @@ Unsigned remainder of division.
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (i32.rem_u (i32.const 10) (i32.const 3))  ;; Returns 1
+# ))
 ```
 
 ---
@@ -112,7 +126,9 @@ Bitwise AND of two i32 values.
 **Example:**
 
 ```wat
-(i32.and (i32.const 0b1100) (i32.const 0b1010))  ;; Returns 0b1000 (8)
+# (module (func (result i32)
+(i32.and (i32.const 0x0C) (i32.const 0x0A))  ;; 0b1100 AND 0b1010 = 8
+# ))
 ```
 
 ---
@@ -126,7 +142,9 @@ Bitwise OR of two i32 values.
 **Example:**
 
 ```wat
-(i32.or (i32.const 0b1100) (i32.const 0b1010))  ;; Returns 0b1110 (14)
+# (module (func (result i32)
+(i32.or (i32.const 0x0C) (i32.const 0x0A))  ;; 0b1100 OR 0b1010 = 14
+# ))
 ```
 
 ---
@@ -140,7 +158,9 @@ Bitwise XOR of two i32 values.
 **Example:**
 
 ```wat
-(i32.xor (i32.const 0b1100) (i32.const 0b1010))  ;; Returns 0b0110 (6)
+# (module (func (result i32)
+(i32.xor (i32.const 0x0C) (i32.const 0x0A))  ;; 0b1100 XOR 0b1010 = 6
+# ))
 ```
 
 ---
@@ -154,7 +174,9 @@ Shift left.
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (i32.shl (i32.const 5) (i32.const 2))  ;; Returns 20 (5 << 2)
+# ))
 ```
 
 ---
@@ -168,7 +190,9 @@ Signed shift right (arithmetic shift).
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (i32.shr_s (i32.const -8) (i32.const 2))  ;; Returns -2 (preserves sign)
+# ))
 ```
 
 ---
@@ -182,7 +206,9 @@ Unsigned shift right (logical shift).
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (i32.shr_u (i32.const 20) (i32.const 2))  ;; Returns 5
+# ))
 ```
 
 ---
@@ -196,7 +222,9 @@ Rotate left.
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (i32.rotl (i32.const 0x12345678) (i32.const 4))
+# ))
 ```
 
 ---
@@ -210,7 +238,9 @@ Rotate right.
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (i32.rotr (i32.const 0x12345678) (i32.const 4))
+# ))
 ```
 
 ---
@@ -224,7 +254,9 @@ Count leading zeros.
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (i32.clz (i32.const 0x00FF0000))  ;; Returns 8
+# ))
 ```
 
 ---
@@ -238,7 +270,9 @@ Count trailing zeros.
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (i32.ctz (i32.const 0xFF000000))  ;; Returns 24
+# ))
 ```
 
 ---
@@ -252,7 +286,9 @@ Count number of 1 bits (population count).
 **Example:**
 
 ```wat
-(i32.popcnt (i32.const 0b1101))  ;; Returns 3
+# (module (func (result i32)
+(i32.popcnt (i32.const 0x0D))  ;; 0b1101 = 3 bits set
+# ))
 ```
 
 ---
@@ -266,8 +302,13 @@ Check if two i32 values are equal.
 **Example:**
 
 ```wat
+# (module (func
+# (drop
 (i32.eq (i32.const 5) (i32.const 5))  ;; Returns 1 (true)
+# )
+# (drop
 (i32.eq (i32.const 5) (i32.const 3))  ;; Returns 0 (false)
+# )))
 ```
 
 ---
@@ -281,7 +322,9 @@ Check if two i32 values are not equal.
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (i32.ne (i32.const 5) (i32.const 3))  ;; Returns 1 (true)
+# ))
 ```
 
 ---
@@ -295,8 +338,13 @@ Check if i32 value equals zero.
 **Example:**
 
 ```wat
+# (module (func
+# (drop
 (i32.eqz (i32.const 0))  ;; Returns 1 (true)
+# )
+# (drop
 (i32.eqz (i32.const 5))  ;; Returns 0 (false)
+# )))
 ```
 
 ---
@@ -310,7 +358,9 @@ Signed less than comparison.
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (i32.lt_s (i32.const -5) (i32.const 3))  ;; Returns 1 (true)
+# ))
 ```
 
 ---
@@ -324,7 +374,9 @@ Unsigned less than comparison.
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (i32.lt_u (i32.const 3) (i32.const 5))  ;; Returns 1 (true)
+# ))
 ```
 
 ---
@@ -338,7 +390,9 @@ Signed greater than comparison.
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (i32.gt_s (i32.const 5) (i32.const 3))  ;; Returns 1 (true)
+# ))
 ```
 
 ---
@@ -352,7 +406,9 @@ Unsigned greater than comparison.
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (i32.gt_u (i32.const 5) (i32.const 3))  ;; Returns 1 (true)
+# ))
 ```
 
 ---
@@ -366,7 +422,9 @@ Signed less than or equal comparison.
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (i32.le_s (i32.const 5) (i32.const 5))  ;; Returns 1 (true)
+# ))
 ```
 
 ---
@@ -380,7 +438,9 @@ Unsigned less than or equal comparison.
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (i32.le_u (i32.const 5) (i32.const 5))  ;; Returns 1 (true)
+# ))
 ```
 
 ---
@@ -394,7 +454,9 @@ Signed greater than or equal comparison.
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (i32.ge_s (i32.const 5) (i32.const 5))  ;; Returns 1 (true)
+# ))
 ```
 
 ---
@@ -408,7 +470,9 @@ Unsigned greater than or equal comparison.
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (i32.ge_u (i32.const 5) (i32.const 3))  ;; Returns 1 (true)
+# ))
 ```
 
 ---
@@ -422,9 +486,16 @@ Create a constant i32 value.
 **Example:**
 
 ```wat
+# (module (func
+# (drop
 (i32.const 42)
+# )
+# (drop
 (i32.const -10)
+# )
+# (drop
 (i32.const 0xFF)  ;; Hexadecimal
+# )))
 ```
 
 ---
@@ -438,11 +509,18 @@ Load i32 from memory at the given address.
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func
+# (drop
 ;; Load from memory at offset 0
 (i32.load (i32.const 0))
-
+# )
+#
+# (drop
 ;; Load with alignment hint
 (i32.load offset=4 align=4 (i32.const 0))
+# )))
 ```
 
 ---
@@ -456,7 +534,11 @@ Load signed 8-bit value from memory and sign-extend to i32.
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i32)
 (i32.load8_s (i32.const 100))  ;; Load byte at address 100
+# ))
 ```
 
 ---
@@ -470,7 +552,11 @@ Load unsigned 8-bit value from memory and zero-extend to i32.
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i32)
 (i32.load8_u (i32.const 100))
+# ))
 ```
 
 ---
@@ -484,7 +570,11 @@ Load signed 16-bit value from memory and sign-extend to i32.
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i32)
 (i32.load16_s (i32.const 100))
+# ))
 ```
 
 ---
@@ -498,7 +588,11 @@ Load unsigned 16-bit value from memory and zero-extend to i32.
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i32)
 (i32.load16_u (i32.const 100))
+# ))
 ```
 
 ---
@@ -512,11 +606,15 @@ Store i32 value to memory.
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func
 ;; Store 42 at memory address 0
 (i32.store (i32.const 0) (i32.const 42))
 
 ;; Store with offset
 (i32.store offset=8 (i32.const 0) (i32.const 100))
+# ))
 ```
 
 ---
@@ -530,7 +628,11 @@ Store low 8 bits of i32 to memory.
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func
 (i32.store8 (i32.const 100) (i32.const 0xFF))
+# ))
 ```
 
 ---
@@ -544,7 +646,11 @@ Store low 16 bits of i32 to memory.
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func
 (i32.store16 (i32.const 100) (i32.const 0xFFFF))
+# ))
 ```
 
 ---
@@ -558,7 +664,9 @@ Wrap i64 to i32 (keep low 32 bits).
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (i32.wrap_i64 (i64.const 0x123456789ABCDEF0))  ;; Returns 0x9ABCDEF0
+# ))
 ```
 
 ---
@@ -572,7 +680,9 @@ Truncate f32 to signed i32. Traps on overflow or NaN.
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (i32.trunc_f32_s (f32.const -3.7))  ;; Returns -3
+# ))
 ```
 
 ---
@@ -586,7 +696,9 @@ Truncate f32 to unsigned i32. Traps on overflow or NaN.
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (i32.trunc_f32_u (f32.const 3.7))  ;; Returns 3
+# ))
 ```
 
 ---
@@ -600,7 +712,9 @@ Truncate f64 to signed i32. Traps on overflow or NaN.
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (i32.trunc_f64_s (f64.const -3.7))  ;; Returns -3
+# ))
 ```
 
 ---
@@ -614,7 +728,9 @@ Truncate f64 to unsigned i32. Traps on overflow or NaN.
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (i32.trunc_f64_u (f64.const 3.7))  ;; Returns 3
+# ))
 ```
 
 ---
@@ -628,7 +744,9 @@ Saturating truncate f32 to signed i32 (no trap).
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (i32.trunc_sat_f32_s (f32.const inf))  ;; Returns i32.max
+# ))
 ```
 
 ---
@@ -642,7 +760,9 @@ Saturating truncate f32 to unsigned i32 (no trap).
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (i32.trunc_sat_f32_u (f32.const -1.0))  ;; Returns 0
+# ))
 ```
 
 ---
@@ -656,7 +776,9 @@ Saturating truncate f64 to signed i32 (no trap).
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (i32.trunc_sat_f64_s (f64.const inf))  ;; Returns i32.max
+# ))
 ```
 
 ---
@@ -670,7 +792,9 @@ Saturating truncate f64 to unsigned i32 (no trap).
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (i32.trunc_sat_f64_u (f64.const -1.0))  ;; Returns 0
+# ))
 ```
 
 ---
@@ -684,7 +808,9 @@ Sign-extend 8-bit value to i32.
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (i32.extend8_s (i32.const 0x80))  ;; Returns -128
+# ))
 ```
 
 ---
@@ -698,7 +824,9 @@ Sign-extend 16-bit value to i32.
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (i32.extend16_s (i32.const 0x8000))  ;; Returns -32768
+# ))
 ```
 
 ---
@@ -712,7 +840,9 @@ Reinterpret f32 bits as i32.
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (i32.reinterpret_f32 (f32.const 1.0))  ;; Returns 0x3F800000
+# ))
 ```
 
 ---

--- a/packages/docs/src/content/docs/instructions/i64.md
+++ b/packages/docs/src/content/docs/instructions/i64.md
@@ -14,7 +14,9 @@ Add two i64 values.
 **Example:**
 
 ```wat
+# (module (func (result i64)
 (i64.add (i64.const 5000000000) (i64.const 3000000000))
+# ))
 ```
 
 ---
@@ -28,7 +30,9 @@ Subtract two i64 values.
 **Example:**
 
 ```wat
+# (module (func (result i64)
 (i64.sub (i64.const 10) (i64.const 3))
+# ))
 ```
 
 ---
@@ -42,7 +46,9 @@ Multiply two i64 values.
 **Example:**
 
 ```wat
+# (module (func (result i64)
 (i64.mul (i64.const 1000) (i64.const 1000))
+# ))
 ```
 
 ---
@@ -56,8 +62,13 @@ Create a constant i64 value.
 **Example:**
 
 ```wat
+# (module (func
+# (drop
 (i64.const 9223372036854775807)  ;; Max i64
+# )
+# (drop
 (i64.const -1)
+# )))
 ```
 
 ---
@@ -71,7 +82,9 @@ Check if i64 value equals zero.
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (i64.eqz (i64.const 0))  ;; Returns 1
+# ))
 ```
 
 ---
@@ -85,7 +98,9 @@ Signed division of two i64 values. Traps if divisor is zero.
 **Example:**
 
 ```wat
+# (module (func (result i64)
 (i64.div_s (i64.const -10) (i64.const 3))  ;; Returns -3
+# ))
 ```
 
 ---
@@ -99,7 +114,9 @@ Unsigned division of two i64 values. Traps if divisor is zero.
 **Example:**
 
 ```wat
+# (module (func (result i64)
 (i64.div_u (i64.const 10) (i64.const 3))  ;; Returns 3
+# ))
 ```
 
 ---
@@ -113,7 +130,9 @@ Signed remainder of division.
 **Example:**
 
 ```wat
+# (module (func (result i64)
 (i64.rem_s (i64.const 10) (i64.const 3))  ;; Returns 1
+# ))
 ```
 
 ---
@@ -127,7 +146,9 @@ Unsigned remainder of division.
 **Example:**
 
 ```wat
+# (module (func (result i64)
 (i64.rem_u (i64.const 10) (i64.const 3))  ;; Returns 1
+# ))
 ```
 
 ---
@@ -141,7 +162,9 @@ Bitwise AND of two i64 values.
 **Example:**
 
 ```wat
-(i64.and (i64.const 0b1100) (i64.const 0b1010))  ;; Returns 0b1000 (8)
+# (module (func (result i64)
+(i64.and (i64.const 12) (i64.const 10))  ;; Returns 0b1000 (8)
+# ))
 ```
 
 ---
@@ -155,7 +178,9 @@ Bitwise OR of two i64 values.
 **Example:**
 
 ```wat
-(i64.or (i64.const 0b1100) (i64.const 0b1010))  ;; Returns 0b1110 (14)
+# (module (func (result i64)
+(i64.or (i64.const 12) (i64.const 10))  ;; Returns 0b1110 (14)
+# ))
 ```
 
 ---
@@ -169,7 +194,9 @@ Bitwise XOR of two i64 values.
 **Example:**
 
 ```wat
-(i64.xor (i64.const 0b1100) (i64.const 0b1010))  ;; Returns 0b0110 (6)
+# (module (func (result i64)
+(i64.xor (i64.const 12) (i64.const 10))  ;; Returns 0b0110 (6)
+# ))
 ```
 
 ---
@@ -183,7 +210,9 @@ Shift left.
 **Example:**
 
 ```wat
+# (module (func (result i64)
 (i64.shl (i64.const 5) (i64.const 2))  ;; Returns 20 (5 << 2)
+# ))
 ```
 
 ---
@@ -197,7 +226,9 @@ Signed shift right (arithmetic shift).
 **Example:**
 
 ```wat
+# (module (func (result i64)
 (i64.shr_s (i64.const -8) (i64.const 2))  ;; Returns -2 (preserves sign)
+# ))
 ```
 
 ---
@@ -211,7 +242,9 @@ Unsigned shift right (logical shift).
 **Example:**
 
 ```wat
+# (module (func (result i64)
 (i64.shr_u (i64.const 20) (i64.const 2))  ;; Returns 5
+# ))
 ```
 
 ---
@@ -225,7 +258,9 @@ Rotate left.
 **Example:**
 
 ```wat
+# (module (func (result i64)
 (i64.rotl (i64.const 0x123456789ABCDEF0) (i64.const 4))
+# ))
 ```
 
 ---
@@ -239,7 +274,9 @@ Rotate right.
 **Example:**
 
 ```wat
+# (module (func (result i64)
 (i64.rotr (i64.const 0x123456789ABCDEF0) (i64.const 4))
+# ))
 ```
 
 ---
@@ -253,7 +290,9 @@ Count leading zeros.
 **Example:**
 
 ```wat
+# (module (func (result i64)
 (i64.clz (i64.const 0x00FF000000000000))  ;; Returns 8
+# ))
 ```
 
 ---
@@ -267,7 +306,9 @@ Count trailing zeros.
 **Example:**
 
 ```wat
+# (module (func (result i64)
 (i64.ctz (i64.const 0xFF00000000000000))  ;; Returns 56
+# ))
 ```
 
 ---
@@ -281,7 +322,9 @@ Count number of 1 bits (population count).
 **Example:**
 
 ```wat
-(i64.popcnt (i64.const 0b1101))  ;; Returns 3
+# (module (func (result i64)
+(i64.popcnt (i64.const 13))  ;; Returns 3
+# ))
 ```
 
 ---
@@ -295,7 +338,9 @@ Check if two i64 values are equal.
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (i64.eq (i64.const 5) (i64.const 5))  ;; Returns 1 (true)
+# ))
 ```
 
 ---
@@ -309,7 +354,9 @@ Check if two i64 values are not equal.
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (i64.ne (i64.const 5) (i64.const 3))  ;; Returns 1 (true)
+# ))
 ```
 
 ---
@@ -323,7 +370,9 @@ Signed less than comparison.
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (i64.lt_s (i64.const -5) (i64.const 3))  ;; Returns 1 (true)
+# ))
 ```
 
 ---
@@ -337,7 +386,9 @@ Unsigned less than comparison.
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (i64.lt_u (i64.const 3) (i64.const 5))  ;; Returns 1 (true)
+# ))
 ```
 
 ---
@@ -351,7 +402,9 @@ Signed greater than comparison.
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (i64.gt_s (i64.const 5) (i64.const 3))  ;; Returns 1 (true)
+# ))
 ```
 
 ---
@@ -365,7 +418,9 @@ Unsigned greater than comparison.
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (i64.gt_u (i64.const 5) (i64.const 3))  ;; Returns 1 (true)
+# ))
 ```
 
 ---
@@ -379,7 +434,9 @@ Signed less than or equal comparison.
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (i64.le_s (i64.const 5) (i64.const 5))  ;; Returns 1 (true)
+# ))
 ```
 
 ---
@@ -393,7 +450,9 @@ Unsigned less than or equal comparison.
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (i64.le_u (i64.const 5) (i64.const 5))  ;; Returns 1 (true)
+# ))
 ```
 
 ---
@@ -407,7 +466,9 @@ Signed greater than or equal comparison.
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (i64.ge_s (i64.const 5) (i64.const 5))  ;; Returns 1 (true)
+# ))
 ```
 
 ---
@@ -421,7 +482,9 @@ Unsigned greater than or equal comparison.
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (i64.ge_u (i64.const 5) (i64.const 3))  ;; Returns 1 (true)
+# ))
 ```
 
 ---
@@ -435,8 +498,15 @@ Load i64 from memory at the given address.
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func
+# (drop
 (i64.load (i32.const 0))
+# )
+# (drop
 (i64.load offset=8 align=8 (i32.const 0))
+# )))
 ```
 
 ---
@@ -450,7 +520,11 @@ Load signed 8-bit value from memory and sign-extend to i64.
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i64)
 (i64.load8_s (i32.const 100))
+# ))
 ```
 
 ---
@@ -464,7 +538,11 @@ Load unsigned 8-bit value from memory and zero-extend to i64.
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i64)
 (i64.load8_u (i32.const 100))
+# ))
 ```
 
 ---
@@ -478,7 +556,11 @@ Load signed 16-bit value from memory and sign-extend to i64.
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i64)
 (i64.load16_s (i32.const 100))
+# ))
 ```
 
 ---
@@ -492,7 +574,11 @@ Load unsigned 16-bit value from memory and zero-extend to i64.
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i64)
 (i64.load16_u (i32.const 100))
+# ))
 ```
 
 ---
@@ -506,7 +592,11 @@ Load signed 32-bit value from memory and sign-extend to i64.
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i64)
 (i64.load32_s (i32.const 100))
+# ))
 ```
 
 ---
@@ -520,7 +610,11 @@ Load unsigned 32-bit value from memory and zero-extend to i64.
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i64)
 (i64.load32_u (i32.const 100))
+# ))
 ```
 
 ---
@@ -534,8 +628,12 @@ Store i64 value to memory.
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func
 (i64.store (i32.const 0) (i64.const 42))
 (i64.store offset=8 (i32.const 0) (i64.const 100))
+# ))
 ```
 
 ---
@@ -549,7 +647,11 @@ Store low 8 bits of i64 to memory.
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func
 (i64.store8 (i32.const 100) (i64.const 0xFF))
+# ))
 ```
 
 ---
@@ -563,7 +665,11 @@ Store low 16 bits of i64 to memory.
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func
 (i64.store16 (i32.const 100) (i64.const 0xFFFF))
+# ))
 ```
 
 ---
@@ -577,7 +683,11 @@ Store low 32 bits of i64 to memory.
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func
 (i64.store32 (i32.const 100) (i64.const 0xFFFFFFFF))
+# ))
 ```
 
 ---
@@ -591,7 +701,9 @@ Sign-extend i32 to i64.
 **Example:**
 
 ```wat
+# (module (func (result i64)
 (i64.extend_i32_s (i32.const -1))  ;; Returns -1 (as i64)
+# ))
 ```
 
 ---
@@ -605,7 +717,9 @@ Zero-extend i32 to i64.
 **Example:**
 
 ```wat
+# (module (func (result i64)
 (i64.extend_i32_u (i32.const -1))  ;; Returns 0xFFFFFFFF
+# ))
 ```
 
 ---
@@ -619,7 +733,9 @@ Truncate f32 to signed i64. Traps on overflow or NaN.
 **Example:**
 
 ```wat
+# (module (func (result i64)
 (i64.trunc_f32_s (f32.const -3.7))  ;; Returns -3
+# ))
 ```
 
 ---
@@ -633,7 +749,9 @@ Truncate f32 to unsigned i64. Traps on overflow or NaN.
 **Example:**
 
 ```wat
+# (module (func (result i64)
 (i64.trunc_f32_u (f32.const 3.7))  ;; Returns 3
+# ))
 ```
 
 ---
@@ -647,7 +765,9 @@ Truncate f64 to signed i64. Traps on overflow or NaN.
 **Example:**
 
 ```wat
+# (module (func (result i64)
 (i64.trunc_f64_s (f64.const -3.7))  ;; Returns -3
+# ))
 ```
 
 ---
@@ -661,7 +781,9 @@ Truncate f64 to unsigned i64. Traps on overflow or NaN.
 **Example:**
 
 ```wat
+# (module (func (result i64)
 (i64.trunc_f64_u (f64.const 3.7))  ;; Returns 3
+# ))
 ```
 
 ---
@@ -675,7 +797,9 @@ Saturating truncate f32 to signed i64 (no trap).
 **Example:**
 
 ```wat
+# (module (func (result i64)
 (i64.trunc_sat_f32_s (f32.const inf))  ;; Returns i64.max
+# ))
 ```
 
 ---
@@ -689,7 +813,9 @@ Saturating truncate f32 to unsigned i64 (no trap).
 **Example:**
 
 ```wat
+# (module (func (result i64)
 (i64.trunc_sat_f32_u (f32.const -1.0))  ;; Returns 0
+# ))
 ```
 
 ---
@@ -703,7 +829,9 @@ Saturating truncate f64 to signed i64 (no trap).
 **Example:**
 
 ```wat
+# (module (func (result i64)
 (i64.trunc_sat_f64_s (f64.const inf))  ;; Returns i64.max
+# ))
 ```
 
 ---
@@ -717,7 +845,9 @@ Saturating truncate f64 to unsigned i64 (no trap).
 **Example:**
 
 ```wat
+# (module (func (result i64)
 (i64.trunc_sat_f64_u (f64.const -1.0))  ;; Returns 0
+# ))
 ```
 
 ---
@@ -731,7 +861,9 @@ Sign-extend 8-bit value to i64.
 **Example:**
 
 ```wat
+# (module (func (result i64)
 (i64.extend8_s (i64.const 0x80))  ;; Returns -128
+# ))
 ```
 
 ---
@@ -745,7 +877,9 @@ Sign-extend 16-bit value to i64.
 **Example:**
 
 ```wat
+# (module (func (result i64)
 (i64.extend16_s (i64.const 0x8000))  ;; Returns -32768
+# ))
 ```
 
 ---
@@ -759,7 +893,9 @@ Sign-extend 32-bit value to i64.
 **Example:**
 
 ```wat
+# (module (func (result i64)
 (i64.extend32_s (i64.const 0x80000000))  ;; Returns -2147483648
+# ))
 ```
 
 ---
@@ -773,7 +909,9 @@ Reinterpret f64 bits as i64.
 **Example:**
 
 ```wat
+# (module (func (result i64)
 (i64.reinterpret_f64 (f64.const 1.0))  ;; Returns 0x3FF0000000000000
+# ))
 ```
 
 ---

--- a/packages/docs/src/content/docs/instructions/local-global.md
+++ b/packages/docs/src/content/docs/instructions/local-global.md
@@ -12,12 +12,18 @@ Get the value of a local variable by name or index.
 **Example:**
 
 ```wat
-(func $example (param $x i32) (result i32)
-  (local $temp i32)
+# (module
+# (func $example (param $x i32) (result i32)
+#   (local $temp i32)
+#   (drop
   (local.get $x)      ;; Get parameter
+#   )
+#   (drop
   (local.get $temp)   ;; Get local
+#   )
   (local.get 0)       ;; Get by index
-)
+# )
+# )
 ```
 
 ---
@@ -29,11 +35,13 @@ Set the value of a local variable by name or index.
 **Example:**
 
 ```wat
+# (module
 (func $example (param $x i32)
   (local $result i32)
   (local.set $result (i32.const 42))
   (local.set 1 (i32.const 100))  ;; Set by index
 )
+# )
 ```
 
 ---
@@ -45,11 +53,13 @@ Set the value of a local variable and return it (combination of set and get).
 **Example:**
 
 ```wat
+# (module
 (func $example (result i32)
   (local $x i32)
   ;; Set $x to 42 and also return it
   (local.tee $x (i32.const 42))
 )
+# )
 ```
 
 ---
@@ -61,11 +71,13 @@ Get the value of a global variable by name or index.
 **Example:**
 
 ```wat
+# (module
 (global $counter (mut i32) (i32.const 0))
 
 (func $read_counter (result i32)
   (global.get $counter)
 )
+# )
 ```
 
 ---
@@ -77,12 +89,14 @@ Set the value of a global variable by name or index. Only works on mutable globa
 **Example:**
 
 ```wat
+# (module
 (global $counter (mut i32) (i32.const 0))
 
 (func $increment
   (global.set $counter
     (i32.add (global.get $counter) (i32.const 1)))
 )
+# )
 ```
 
 ---

--- a/packages/docs/src/content/docs/instructions/memory.md
+++ b/packages/docs/src/content/docs/instructions/memory.md
@@ -14,7 +14,11 @@ Get current memory size in pages (1 page = 64KB).
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i32)
 (memory.size)  ;; Returns current number of pages
+# ))
 ```
 
 ---
@@ -28,9 +32,13 @@ Grow memory by delta pages. Returns previous size, or -1 on failure.
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result i32)
 ;; Grow memory by 1 page
 (memory.grow (i32.const 1))
 ;; Returns old size (e.g., 1) or -1 if failed
+# ))
 ```
 
 ---
@@ -44,11 +52,15 @@ Fill a region of memory with a byte value.
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func
 ;; Fill 100 bytes starting at address 0 with value 0xFF
 (memory.fill
   (i32.const 0)    ;; destination
   (i32.const 0xFF) ;; value
   (i32.const 100)) ;; size
+# ))
 ```
 
 ---
@@ -62,11 +74,15 @@ Copy a region of memory to another location.
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func
 ;; Copy 50 bytes from address 100 to address 200
 (memory.copy
   (i32.const 200)  ;; destination
   (i32.const 100)  ;; source
   (i32.const 50))  ;; size
+# ))
 ```
 
 ---
@@ -80,12 +96,16 @@ Initialize memory region from a passive data segment.
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
 (data $my_data "Hello")
+# (func
 ;; Copy 5 bytes from data segment offset 0 to memory address 0
 (memory.init $my_data
   (i32.const 0)   ;; memory destination
   (i32.const 0)   ;; data segment offset
   (i32.const 5))  ;; size
+# ))
 ```
 
 ---
@@ -97,8 +117,12 @@ Drop a passive data segment, freeing its memory.
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
 (data $my_data "Hello")
+# (func
 (data.drop $my_data)  ;; Data segment can no longer be used
+# ))
 ```
 
 ---

--- a/packages/docs/src/content/docs/instructions/module.md
+++ b/packages/docs/src/content/docs/instructions/module.md
@@ -29,6 +29,7 @@ Declares a function with optional name, parameters, results, and locals.
 **Example:**
 
 ```wat
+# (module
 ;; Named function with params and result
 (func $add (param $a i32) (param $b i32) (result i32)
   (i32.add (local.get $a) (local.get $b)))
@@ -40,6 +41,7 @@ Declares a function with optional name, parameters, results, and locals.
 ;; Multiple params of same type
 (func $multi (param i32 i32 i32) (result i32)
   (local.get 0))
+# )
 ```
 
 ---
@@ -51,12 +53,14 @@ Declares a function parameter with optional name and type.
 **Example:**
 
 ```wat
+# (module
 (func $example
   (param $x i32)
   (param $y i32)
   (param i64)  ;; Unnamed param
   ;; ...
 )
+# )
 ```
 
 ---
@@ -68,6 +72,7 @@ Declares function result type(s).
 **Example:**
 
 ```wat
+# (module
 (func $single (result i32)
   (i32.const 42))
 
@@ -75,6 +80,7 @@ Declares function result type(s).
 (func $multi (result i32 i32)
   (i32.const 1)
   (i32.const 2))
+# )
 ```
 
 ---
@@ -86,12 +92,14 @@ Declares a local variable with optional name and type.
 **Example:**
 
 ```wat
+# (module
 (func $example
   (local $counter i32)
   (local $temp i64)
   (local i32 i32)  ;; Two unnamed locals
   ;; ...
 )
+# )
 ```
 
 ---
@@ -102,7 +110,7 @@ Declares a global variable with type, mutability, and initial value.
 
 **Example:**
 
-```wat
+```wat-snippet
 ;; Immutable global
 (global $pi f64 (f64.const 3.14159))
 
@@ -121,7 +129,7 @@ Declares a table for storing references.
 
 **Example:**
 
-```wat
+```wat-snippet
 ;; Table with size 10
 (table $funcs 10 funcref)
 
@@ -140,7 +148,7 @@ Declares linear memory for the module.
 
 **Example:**
 
-```wat
+```wat-snippet
 ;; 1 page minimum
 (memory $mem 1)
 
@@ -160,6 +168,7 @@ Imports an external resource (function, global, table, or memory).
 **Example:**
 
 ```wat
+# (module
 ;; Import function
 (import "env" "log" (func $log (param i32)))
 
@@ -171,6 +180,7 @@ Imports an external resource (function, global, table, or memory).
 
 ;; Import table
 (import "env" "table" (table 10 funcref))
+# )
 ```
 
 ---
@@ -181,7 +191,7 @@ Exports a resource for use by the host.
 
 **Example:**
 
-```wat
+```wat-snippet
 ;; Export function
 (export "add" (func $add))
 
@@ -232,7 +242,7 @@ Form 3 is useful when you need both a type index (for `call_indirect`) and named
 
 **Example:**
 
-```wat
+```wat-snippet
 ;; Define a binary operation type
 (type $binop (func (param i32 i32) (result i32)))
 
@@ -255,7 +265,7 @@ Declares elements for a table.
 
 **Example:**
 
-```wat
+```wat-snippet
 (table $funcs 10 funcref)
 
 ;; Passive element (for table.init)
@@ -277,6 +287,7 @@ Declares data to be loaded into memory.
 **Example:**
 
 ```wat
+# (module
 (memory 1)
 
 ;; Active data (auto-initialized)
@@ -287,6 +298,7 @@ Declares data to be loaded into memory.
 
 ;; Multiple segments
 (data (i32.const 100) "\00\01\02\03")
+# )
 ```
 
 ---

--- a/packages/docs/src/content/docs/instructions/parametric.md
+++ b/packages/docs/src/content/docs/instructions/parametric.md
@@ -12,8 +12,10 @@ Remove the top value from the stack.
 **Example:**
 
 ```wat
+# (module (func
 (i32.const 42)
 (drop)  ;; Remove 42 from stack
+# ))
 ```
 
 ---
@@ -27,17 +29,21 @@ Select one of two values based on a condition.
 **Example:**
 
 ```wat
+# (module (func (param $x i32)
+# (drop
 ;; Returns first value if condition is non-zero, else second
 (select
   (i32.const 10)
   (i32.const 20)
   (i32.const 1))  ;; Returns 10
-
+# )
+# (drop
 ;; Can specify type
 (select (result i32)
   (i32.const 42)
   (i32.const 0)
   (i32.eqz (local.get $x)))
+# )))
 ```
 
 ---

--- a/packages/docs/src/content/docs/instructions/reference.md
+++ b/packages/docs/src/content/docs/instructions/reference.md
@@ -14,8 +14,13 @@ Create a null reference.
 **Example:**
 
 ```wat
+# (module (func
+# (drop
 (ref.null func)
+# )
+# (drop
 (ref.null extern)
+# )))
 ```
 
 ---
@@ -29,8 +34,13 @@ Create a function reference.
 **Example:**
 
 ```wat
+# (module
 (func $my_func (result i32) (i32.const 42))
+# (elem declare func $my_func)
+# (func
+# (drop
 (ref.func $my_func)
+# )))
 ```
 
 ---
@@ -44,7 +54,9 @@ Check if reference is null.
 **Example:**
 
 ```wat
+# (module (func (result i32)
 (ref.is_null (ref.null func))  ;; Returns 1
+# ))
 ```
 
 ---
@@ -58,7 +70,9 @@ Assert that a reference is not null and convert it to a non-nullable type. Traps
 **Example:**
 
 ```wat
+# (module (func (param $nullable_ref (ref null func)) (result (ref func))
 (ref.as_non_null (local.get $nullable_ref))  ;; Traps if null, otherwise returns non-null ref
+# ))
 ```
 
 ---
@@ -72,7 +86,9 @@ Convert an externref to anyref. This allows external references to be used with 
 **Example:**
 
 ```wat
+# (module (func (param $ext_ref externref) (result anyref)
 (any.convert_extern (local.get $ext_ref))
+# ))
 ```
 
 ---
@@ -86,7 +102,9 @@ Convert an anyref to externref. This allows any GC reference to be passed out as
 **Example:**
 
 ```wat
+# (module (func (param $any_ref anyref) (result externref)
 (extern.convert_any (local.get $any_ref))
+# ))
 ```
 
 ---

--- a/packages/docs/src/content/docs/instructions/simd.md
+++ b/packages/docs/src/content/docs/instructions/simd.md
@@ -14,9 +14,16 @@ Create a constant 128-bit vector value.
 **Example:**
 
 ```wat
+# (module (func
+# (drop
 (v128.const i32x4 1 2 3 4)
+# )
+# (drop
 (v128.const f32x4 1.0 2.0 3.0 4.0)
+# )
+# (drop
 (v128.const i8x16 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15)
+# )))
 ```
 
 ---
@@ -30,8 +37,15 @@ Load 128-bit vector from memory.
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func
+# (drop
 (v128.load (i32.const 0))
+# )
+# (drop
 (v128.load offset=16 align=16 (i32.const 0))
+# )))
 ```
 
 ---
@@ -45,7 +59,11 @@ Store 128-bit vector to memory.
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (local $vec v128)
 (v128.store (i32.const 0) (local.get $vec))
+# ))
 ```
 
 ---
@@ -59,7 +77,11 @@ Load 8 signed 8-bit integers and extend to 16-bit.
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result v128)
 (v128.load8x8_s (i32.const 0))
+# ))
 ```
 
 ---
@@ -73,7 +95,11 @@ Load 8 unsigned 8-bit integers and extend to 16-bit.
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result v128)
 (v128.load8x8_u (i32.const 0))
+# ))
 ```
 
 ---
@@ -87,7 +113,11 @@ Load 4 signed 16-bit integers and extend to 32-bit.
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result v128)
 (v128.load16x4_s (i32.const 0))
+# ))
 ```
 
 ---
@@ -101,7 +131,11 @@ Load 4 unsigned 16-bit integers and extend to 32-bit.
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result v128)
 (v128.load16x4_u (i32.const 0))
+# ))
 ```
 
 ---
@@ -115,7 +149,11 @@ Load 2 signed 32-bit integers and extend to 64-bit.
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result v128)
 (v128.load32x2_s (i32.const 0))
+# ))
 ```
 
 ---
@@ -129,7 +167,11 @@ Load 2 unsigned 32-bit integers and extend to 64-bit.
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result v128)
 (v128.load32x2_u (i32.const 0))
+# ))
 ```
 
 ---
@@ -143,7 +185,11 @@ Load 8-bit value and replicate to all lanes.
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result v128)
 (v128.load8_splat (i32.const 0))  ;; Loads byte and replicates 16 times
+# ))
 ```
 
 ---
@@ -157,7 +203,11 @@ Load 16-bit value and replicate to all lanes.
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result v128)
 (v128.load16_splat (i32.const 0))  ;; Loads i16 and replicates 8 times
+# ))
 ```
 
 ---
@@ -171,7 +221,11 @@ Load 32-bit value and replicate to all lanes.
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result v128)
 (v128.load32_splat (i32.const 0))  ;; Loads i32 and replicates 4 times
+# ))
 ```
 
 ---
@@ -185,7 +239,11 @@ Load 64-bit value and replicate to all lanes.
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result v128)
 (v128.load64_splat (i32.const 0))  ;; Loads i64 and replicates 2 times
+# ))
 ```
 
 ---
@@ -199,7 +257,11 @@ Load 32-bit value into the lowest lane and zero all other lanes.
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result v128)
 (v128.load32_zero (i32.const 0))  ;; Loads i32 into lane 0, zeros lanes 1-3
+# ))
 ```
 
 ---
@@ -213,7 +275,11 @@ Load 64-bit value into the lowest lane and zero all other lanes.
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result v128)
 (v128.load64_zero (i32.const 0))  ;; Loads i64 into lane 0, zeros lane 1
+# ))
 ```
 
 ---
@@ -227,8 +293,15 @@ Load 8-bit value into a specific lane of an existing vector.
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (local $vec v128)
+# (drop
 (v128.load8_lane 0 (i32.const 0) (local.get $vec))  ;; Load byte into lane 0
+# )
+# (drop
 (v128.load8_lane offset=4 5 (i32.const 0) (local.get $vec))  ;; With offset, lane 5
+# )))
 ```
 
 ---
@@ -242,7 +315,11 @@ Load 16-bit value into a specific lane of an existing vector.
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result v128) (local $vec v128)
 (v128.load16_lane 0 (i32.const 0) (local.get $vec))  ;; Load i16 into lane 0
+# ))
 ```
 
 ---
@@ -256,7 +333,11 @@ Load 32-bit value into a specific lane of an existing vector.
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (result v128) (local $vec v128)
 (v128.load32_lane 0 (i32.const 0) (local.get $vec))  ;; Load i32 into lane 0
+# ))
 ```
 
 ---
@@ -270,8 +351,15 @@ Load 64-bit value into a specific lane of an existing vector.
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (local $vec v128)
+# (drop
 (v128.load64_lane 0 (i32.const 0) (local.get $vec))  ;; Load i64 into lane 0
+# )
+# (drop
 (v128.load64_lane offset=8 1 (i32.const 0) (local.get $vec))  ;; With offset, lane 1
+# )))
 ```
 
 ---
@@ -285,7 +373,11 @@ Store 8-bit value from a specific lane to memory.
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (local $vec v128)
 (v128.store8_lane 0 (i32.const 0) (local.get $vec))  ;; Store lane 0 as byte
+# ))
 ```
 
 ---
@@ -299,7 +391,11 @@ Store 16-bit value from a specific lane to memory.
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (local $vec v128)
 (v128.store16_lane 0 (i32.const 0) (local.get $vec))  ;; Store lane 0 as i16
+# ))
 ```
 
 ---
@@ -313,7 +409,11 @@ Store 32-bit value from a specific lane to memory.
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (local $vec v128)
 (v128.store32_lane 0 (i32.const 0) (local.get $vec))  ;; Store lane 0 as i32
+# ))
 ```
 
 ---
@@ -327,8 +427,12 @@ Store 64-bit value from a specific lane to memory.
 **Example:**
 
 ```wat
+# (module
+# (memory 1)
+# (func (local $vec v128)
 (v128.store64_lane 0 (i32.const 0) (local.get $vec))  ;; Store lane 0 as i64
 (v128.store64_lane offset=8 1 (i32.const 0) (local.get $vec))  ;; With offset, lane 1
+# ))
 ```
 
 ---
@@ -342,7 +446,9 @@ Check if any bit in the vector is non-zero.
 **Example:**
 
 ```wat
+# (module (func (result i32) (local $vec v128)
 (v128.any_true (local.get $vec))  ;; Returns 1 if any bit is set
+# ))
 ```
 
 ---
@@ -356,7 +462,9 @@ Compute bitwise AND of two v128 vectors.
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (v128.and (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -370,7 +478,9 @@ Compute bitwise OR of two v128 vectors.
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (v128.or (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -384,7 +494,9 @@ Compute bitwise XOR of two v128 vectors.
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (v128.xor (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -398,7 +510,9 @@ Compute bitwise NOT of a v128 vector.
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128)
 (v128.not (local.get $a))
+# ))
 ```
 
 ---
@@ -412,7 +526,9 @@ Add two i8x16 vectors lane-wise.
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i8x16.add (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -426,7 +542,9 @@ Add two i16x8 vectors lane-wise.
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i16x8.add (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -440,7 +558,9 @@ Add two i32x4 vectors lane-wise.
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i32x4.add (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -454,7 +574,9 @@ Add two i64x2 vectors lane-wise.
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i64x2.add (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -468,7 +590,9 @@ Add two f32x4 vectors lane-wise.
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (f32x4.add (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -482,7 +606,9 @@ Multiply two f32x4 vectors lane-wise.
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (f32x4.mul (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -496,7 +622,9 @@ Subtract two f32x4 vectors lane-wise (first minus second).
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (f32x4.sub (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -510,7 +638,9 @@ Divide two f32x4 vectors lane-wise (first divided by second).
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (f32x4.div (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -524,7 +654,9 @@ Compute square root of each lane in an f32x4 vector.
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128)
 (f32x4.sqrt (local.get $a))
+# ))
 ```
 
 ---
@@ -538,7 +670,9 @@ Negate each lane in an f32x4 vector.
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128)
 (f32x4.neg (local.get $a))
+# ))
 ```
 
 ---
@@ -552,7 +686,9 @@ Compute absolute value of each lane in an f32x4 vector.
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128)
 (f32x4.abs (local.get $a))
+# ))
 ```
 
 ---
@@ -566,7 +702,9 @@ Compute lane-wise minimum of two f32x4 vectors. Returns NaN if either operand is
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (f32x4.min (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -580,7 +718,9 @@ Compute lane-wise maximum of two f32x4 vectors. Returns NaN if either operand is
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (f32x4.max (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -594,7 +734,9 @@ Pseudo-minimum: lane-wise `a < b ? a : b`. Unlike f32x4.min, returns second oper
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (f32x4.pmin (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -608,7 +750,9 @@ Pseudo-maximum: lane-wise `a > b ? a : b`. Unlike f32x4.max, returns second oper
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (f32x4.pmax (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -622,7 +766,9 @@ Round each lane to the nearest integer towards positive infinity.
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128)
 (f32x4.ceil (local.get $a))
+# ))
 ```
 
 ---
@@ -636,7 +782,9 @@ Round each lane to the nearest integer towards negative infinity.
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128)
 (f32x4.floor (local.get $a))
+# ))
 ```
 
 ---
@@ -650,7 +798,9 @@ Round each lane to the nearest integer towards zero.
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128)
 (f32x4.trunc (local.get $a))
+# ))
 ```
 
 ---
@@ -664,7 +814,9 @@ Round each lane to the nearest integer, with ties to even.
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128)
 (f32x4.nearest (local.get $a))
+# ))
 ```
 
 ---
@@ -678,7 +830,9 @@ Compare two f32x4 vectors for equality lane-wise. Returns all 1s for true, all 0
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (f32x4.eq (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -692,7 +846,9 @@ Compare two f32x4 vectors for inequality lane-wise. Returns all 1s for true, all
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (f32x4.ne (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -706,7 +862,9 @@ Compare two f32x4 vectors for less-than lane-wise. Returns all 1s for true, all 
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (f32x4.lt (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -720,7 +878,9 @@ Compare two f32x4 vectors for greater-than lane-wise. Returns all 1s for true, a
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (f32x4.gt (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -734,7 +894,9 @@ Compare two f32x4 vectors for less-than-or-equal lane-wise. Returns all 1s for t
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (f32x4.le (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -748,7 +910,9 @@ Compare two f32x4 vectors for greater-than-or-equal lane-wise. Returns all 1s fo
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (f32x4.ge (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -762,7 +926,9 @@ Create an i32x4 vector with all lanes set to the same i32 value.
 **Example:**
 
 ```wat
+# (module (func (result v128)
 (i32x4.splat (i32.const 42))
+# ))
 ```
 
 ---
@@ -776,7 +942,9 @@ Create an f32x4 vector with all lanes set to the same f32 value.
 **Example:**
 
 ```wat
+# (module (func (result v128)
 (f32x4.splat (f32.const 1.0))
+# ))
 ```
 
 ---
@@ -790,7 +958,9 @@ Add two f64x2 vectors lane-wise.
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (f64x2.add (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -804,7 +974,9 @@ Subtract two f64x2 vectors lane-wise (first minus second).
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (f64x2.sub (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -818,7 +990,9 @@ Multiply two f64x2 vectors lane-wise.
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (f64x2.mul (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -832,7 +1006,9 @@ Divide two f64x2 vectors lane-wise (first divided by second).
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (f64x2.div (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -846,7 +1022,9 @@ Compute square root of each lane in an f64x2 vector.
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128)
 (f64x2.sqrt (local.get $a))
+# ))
 ```
 
 ---
@@ -860,7 +1038,9 @@ Negate each lane in an f64x2 vector.
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128)
 (f64x2.neg (local.get $a))
+# ))
 ```
 
 ---
@@ -874,7 +1054,9 @@ Compute absolute value of each lane in an f64x2 vector.
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128)
 (f64x2.abs (local.get $a))
+# ))
 ```
 
 ---
@@ -888,7 +1070,9 @@ Compute lane-wise minimum of two f64x2 vectors. Returns NaN if either operand is
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (f64x2.min (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -902,7 +1086,9 @@ Compute lane-wise maximum of two f64x2 vectors. Returns NaN if either operand is
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (f64x2.max (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -916,7 +1102,9 @@ Pseudo-minimum: lane-wise `a < b ? a : b`. Unlike f64x2.min, returns second oper
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (f64x2.pmin (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -930,7 +1118,9 @@ Pseudo-maximum: lane-wise `a > b ? a : b`. Unlike f64x2.max, returns second oper
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (f64x2.pmax (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -944,7 +1134,9 @@ Round each lane to the nearest integer towards positive infinity.
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128)
 (f64x2.ceil (local.get $a))
+# ))
 ```
 
 ---
@@ -958,7 +1150,9 @@ Round each lane to the nearest integer towards negative infinity.
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128)
 (f64x2.floor (local.get $a))
+# ))
 ```
 
 ---
@@ -972,7 +1166,9 @@ Round each lane to the nearest integer towards zero.
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128)
 (f64x2.trunc (local.get $a))
+# ))
 ```
 
 ---
@@ -986,7 +1182,9 @@ Round each lane to the nearest integer, with ties to even.
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128)
 (f64x2.nearest (local.get $a))
+# ))
 ```
 
 ---
@@ -1000,7 +1198,9 @@ Compare two f64x2 vectors for equality lane-wise. Returns all 1s for true, all 0
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (f64x2.eq (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -1014,7 +1214,9 @@ Compare two f64x2 vectors for inequality lane-wise. Returns all 1s for true, all
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (f64x2.ne (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -1028,7 +1230,9 @@ Compare two f64x2 vectors for less-than lane-wise. Returns all 1s for true, all 
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (f64x2.lt (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -1042,7 +1246,9 @@ Compare two f64x2 vectors for greater-than lane-wise. Returns all 1s for true, a
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (f64x2.gt (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -1056,7 +1262,9 @@ Compare two f64x2 vectors for less-than-or-equal lane-wise. Returns all 1s for t
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (f64x2.le (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -1070,7 +1278,9 @@ Compare two f64x2 vectors for greater-than-or-equal lane-wise. Returns all 1s fo
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (f64x2.ge (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -1084,7 +1294,9 @@ Create an f64x2 vector with all lanes set to the same f64 value.
 **Example:**
 
 ```wat
+# (module (func (result v128)
 (f64x2.splat (f64.const 1.0))
+# ))
 ```
 
 ---
@@ -1098,7 +1310,9 @@ Convert an f32x4 vector to i32x4 with signed saturation. Values outside the sign
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $floats v128)
 (i32x4.trunc_sat_f32x4_s (local.get $floats))
+# ))
 ```
 
 ---
@@ -1112,7 +1326,9 @@ Convert an f32x4 vector to i32x4 with unsigned saturation. Values outside the un
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $floats v128)
 (i32x4.trunc_sat_f32x4_u (local.get $floats))
+# ))
 ```
 
 ---
@@ -1126,7 +1342,9 @@ Convert an i32x4 vector to f32x4, interpreting each lane as a signed integer.
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $ints v128)
 (f32x4.convert_i32x4_s (local.get $ints))
+# ))
 ```
 
 ---
@@ -1140,7 +1358,9 @@ Convert an i32x4 vector to f32x4, interpreting each lane as an unsigned integer.
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $ints v128)
 (f32x4.convert_i32x4_u (local.get $ints))
+# ))
 ```
 
 ---
@@ -1154,7 +1374,9 @@ Compare two i32x4 vectors for equality lane-wise.
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i32x4.eq (local.get $a) (local.get $b))  ;; Returns -1 for equal lanes, 0 otherwise
+# ))
 ```
 
 ---
@@ -1168,7 +1390,9 @@ Signed greater-than comparison for i32x4 vectors lane-wise.
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i32x4.gt_s (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -1182,7 +1406,9 @@ Unsigned greater-than comparison for i32x4 vectors lane-wise.
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i32x4.gt_u (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -1196,7 +1422,9 @@ Signed less-than-or-equal comparison for i32x4 vectors lane-wise.
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i32x4.le_s (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -1210,7 +1438,9 @@ Signed less-than comparison for i32x4 vectors lane-wise. Returns all 1s for true
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i32x4.lt_s (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -1224,7 +1454,9 @@ Shift each lane in an i32x4 vector left by a scalar amount. The shift count is t
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $vec v128)
 (i32x4.shl (local.get $vec) (i32.const 2))  ;; Shift all lanes left by 2
+# ))
 ```
 
 ---
@@ -1238,7 +1470,9 @@ Shift each lane in an i32x4 vector right by a scalar amount (signed/arithmetic).
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $vec v128)
 (i32x4.shr_s (local.get $vec) (i32.const 2))  ;; Arithmetic shift right by 2
+# ))
 ```
 
 ---
@@ -1252,7 +1486,9 @@ Check if all lanes in an i8x16 vector are non-zero.
 **Example:**
 
 ```wat
+# (module (func (result i32) (local $vec v128)
 (i8x16.all_true (local.get $vec))  ;; Returns 1 if all 16 lanes are non-zero
+# ))
 ```
 
 ---
@@ -1266,7 +1502,9 @@ Check if all lanes in an i32x4 vector are non-zero.
 **Example:**
 
 ```wat
+# (module (func (result i32) (local $vec v128)
 (i32x4.all_true (local.get $vec))  ;; Returns 1 if all 4 lanes are non-zero
+# ))
 ```
 
 ---
@@ -1280,7 +1518,9 @@ Absolute value of each lane in an i32x4 vector.
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $vec v128)
 (i32x4.abs (local.get $vec))
+# ))
 ```
 
 ---
@@ -1294,8 +1534,10 @@ Extract the high bit of each lane and combine into an i32 bitmask.
 **Example:**
 
 ```wat
+# (module (func (result i32) (local $vec v128)
 ;; Returns i32 where bit N is the high bit of lane N (0-3)
 (i32x4.bitmask (local.get $vec))
+# ))
 ```
 
 ---
@@ -1309,8 +1551,10 @@ Extract a signed 8-bit lane from an i8x16 vector and sign-extend to i32.
 **Example:**
 
 ```wat
+# (module (func (result i32) (local $vec v128)
 ;; Extract lane 5 (0-15) as signed i32
 (i8x16.extract_lane_s 5 (local.get $vec))
+# ))
 ```
 
 ---
@@ -1324,8 +1568,10 @@ Extract an unsigned 8-bit lane from an i8x16 vector and zero-extend to i32.
 **Example:**
 
 ```wat
+# (module (func (result i32) (local $vec v128)
 ;; Extract lane 5 (0-15) as unsigned i32
 (i8x16.extract_lane_u 5 (local.get $vec))
+# ))
 ```
 
 ---
@@ -1339,8 +1585,10 @@ Extract a signed 16-bit lane from an i16x8 vector and sign-extend to i32.
 **Example:**
 
 ```wat
+# (module (func (result i32) (local $vec v128)
 ;; Extract lane 3 (0-7) as signed i32
 (i16x8.extract_lane_s 3 (local.get $vec))
+# ))
 ```
 
 ---
@@ -1354,8 +1602,10 @@ Extract an unsigned 16-bit lane from an i16x8 vector and zero-extend to i32.
 **Example:**
 
 ```wat
+# (module (func (result i32) (local $vec v128)
 ;; Extract lane 3 (0-7) as unsigned i32
 (i16x8.extract_lane_u 3 (local.get $vec))
+# ))
 ```
 
 ---
@@ -1369,8 +1619,10 @@ Extract a 32-bit lane from an i32x4 vector.
 **Example:**
 
 ```wat
+# (module (func (result i32) (local $vec v128)
 ;; Extract lane 2 (0-3)
 (i32x4.extract_lane 2 (local.get $vec))
+# ))
 ```
 
 ---
@@ -1384,8 +1636,10 @@ Extract a 64-bit lane from an i64x2 vector.
 **Example:**
 
 ```wat
+# (module (func (result i64) (local $vec v128)
 ;; Extract lane 1 (0-1)
 (i64x2.extract_lane 1 (local.get $vec))
+# ))
 ```
 
 ---
@@ -1399,8 +1653,10 @@ Extract a 32-bit float lane from an f32x4 vector.
 **Example:**
 
 ```wat
+# (module (func (result f32) (local $vec v128)
 ;; Extract lane 0 (0-3)
 (f32x4.extract_lane 0 (local.get $vec))
+# ))
 ```
 
 ---
@@ -1414,8 +1670,10 @@ Extract a 64-bit float lane from an f64x2 vector.
 **Example:**
 
 ```wat
+# (module (func (result f64) (local $vec v128)
 ;; Extract lane 0 (0-1)
 (f64x2.extract_lane 0 (local.get $vec))
+# ))
 ```
 
 ---
@@ -1429,8 +1687,10 @@ Replace an 8-bit lane in an i8x16 vector.
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $vec v128)
 ;; Replace lane 5 (0-15) with value 42
 (i8x16.replace_lane 5 (local.get $vec) (i32.const 42))
+# ))
 ```
 
 ---
@@ -1444,8 +1704,10 @@ Replace a 16-bit lane in an i16x8 vector.
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $vec v128)
 ;; Replace lane 3 (0-7) with value 1000
 (i16x8.replace_lane 3 (local.get $vec) (i32.const 1000))
+# ))
 ```
 
 ---
@@ -1459,8 +1721,10 @@ Replace a 32-bit lane in an i32x4 vector.
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $vec v128)
 ;; Replace lane 2 (0-3) with value
 (i32x4.replace_lane 2 (local.get $vec) (i32.const 123456))
+# ))
 ```
 
 ---
@@ -1474,8 +1738,10 @@ Replace a 64-bit lane in an i64x2 vector.
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $vec v128)
 ;; Replace lane 1 (0-1) with value
 (i64x2.replace_lane 1 (local.get $vec) (i64.const 9876543210))
+# ))
 ```
 
 ---
@@ -1489,8 +1755,10 @@ Replace a 32-bit float lane in an f32x4 vector.
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $vec v128)
 ;; Replace lane 0 (0-3) with value
 (f32x4.replace_lane 0 (local.get $vec) (f32.const 3.14))
+# ))
 ```
 
 ---
@@ -1504,8 +1772,10 @@ Replace a 64-bit float lane in an f64x2 vector.
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $vec v128)
 ;; Replace lane 0 (0-1) with value
 (f64x2.replace_lane 0 (local.get $vec) (f64.const 2.71828))
+# ))
 ```
 
 ---
@@ -1519,11 +1789,13 @@ Shuffle bytes from two i8x16 vectors using 16 lane indices.
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 ;; Shuffle lanes from two vectors
 ;; Indices 0-15 select from first vector, 16-31 from second
 (i8x16.shuffle 0 1 2 3 16 17 18 19 4 5 6 7 20 21 22 23
   (local.get $a)
   (local.get $b))
+# ))
 ```
 
 ---
@@ -1537,11 +1809,13 @@ Relaxed fused multiply-add: `a * b + c` for each f32 lane. The result may be com
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128) (local $c v128)
 ;; Compute a * b + c with relaxed precision
 (f32x4.relaxed_madd
   (local.get $a)   ;; multiplicand
   (local.get $b)   ;; multiplier
   (local.get $c))  ;; addend
+# ))
 ```
 
 ---
@@ -1555,11 +1829,13 @@ Relaxed fused negative multiply-add: `-a * b + c` for each f32 lane. The result 
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128) (local $c v128)
 ;; Compute -a * b + c with relaxed precision
 (f32x4.relaxed_nmadd
   (local.get $a)   ;; multiplicand (negated)
   (local.get $b)   ;; multiplier
   (local.get $c))  ;; addend
+# ))
 ```
 
 ---
@@ -1573,11 +1849,13 @@ Relaxed fused multiply-add: `a * b + c` for each f64 lane. The result may be com
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128) (local $c v128)
 ;; Compute a * b + c with relaxed precision (64-bit floats)
 (f64x2.relaxed_madd
   (local.get $a)   ;; multiplicand
   (local.get $b)   ;; multiplier
   (local.get $c))  ;; addend
+# ))
 ```
 
 ---
@@ -1591,11 +1869,13 @@ Relaxed fused negative multiply-add: `-a * b + c` for each f64 lane. The result 
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128) (local $c v128)
 ;; Compute -a * b + c with relaxed precision (64-bit floats)
 (f64x2.relaxed_nmadd
   (local.get $a)   ;; multiplicand (negated)
   (local.get $b)   ;; multiplier
   (local.get $c))  ;; addend
+# ))
 ```
 
 ---
@@ -1609,10 +1889,12 @@ Relaxed byte swizzle operation. Selects bytes from the first vector using indice
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $data v128) (local $indices v128)
 ;; Swizzle bytes with relaxed out-of-range behavior
 (i8x16.relaxed_swizzle
   (local.get $data)     ;; source bytes
   (local.get $indices)) ;; lane indices (0-15 for defined behavior)
+# ))
 ```
 
 ---
@@ -1626,8 +1908,10 @@ Relaxed truncation of f32x4 to signed i32x4. Unlike i32x4.trunc_sat_f32x4_s, the
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $floats v128)
 ;; Truncate f32 lanes to signed i32 with relaxed semantics
 (i32x4.relaxed_trunc_f32x4_s (local.get $floats))
+# ))
 ```
 
 ---
@@ -1641,8 +1925,10 @@ Relaxed truncation of f32x4 to unsigned i32x4. Unlike i32x4.trunc_sat_f32x4_u, t
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $floats v128)
 ;; Truncate f32 lanes to unsigned i32 with relaxed semantics
 (i32x4.relaxed_trunc_f32x4_u (local.get $floats))
+# ))
 ```
 
 ---
@@ -1656,8 +1942,10 @@ Relaxed truncation of f64x2 to signed i32x4 with zero extension. Converts two f6
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $doubles v128)
 ;; Truncate two f64 lanes to signed i32, upper lanes zeroed
 (i32x4.relaxed_trunc_f64x2_s_zero (local.get $doubles))
+# ))
 ```
 
 ---
@@ -1671,8 +1959,10 @@ Relaxed truncation of f64x2 to unsigned i32x4 with zero extension. Converts two 
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $doubles v128)
 ;; Truncate two f64 lanes to unsigned i32, upper lanes zeroed
 (i32x4.relaxed_trunc_f64x2_u_zero (local.get $doubles))
+# ))
 ```
 
 ---
@@ -1686,8 +1976,10 @@ Relaxed lane-wise minimum of two f32x4 vectors. Unlike f32x4.min, the behavior f
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 ;; Relaxed minimum with implementation-defined NaN handling
 (f32x4.relaxed_min (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -1701,8 +1993,10 @@ Relaxed lane-wise maximum of two f32x4 vectors. Unlike f32x4.max, the behavior f
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 ;; Relaxed maximum with implementation-defined NaN handling
 (f32x4.relaxed_max (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -1716,8 +2010,10 @@ Relaxed lane-wise minimum of two f64x2 vectors. Unlike f64x2.min, the behavior f
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 ;; Relaxed minimum with implementation-defined NaN handling (64-bit)
 (f64x2.relaxed_min (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -1731,8 +2027,10 @@ Relaxed lane-wise maximum of two f64x2 vectors. Unlike f64x2.max, the behavior f
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 ;; Relaxed maximum with implementation-defined NaN handling (64-bit)
 (f64x2.relaxed_max (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -1746,11 +2044,13 @@ Relaxed lane select for i8x16 vectors. Selects bytes from the first or second ve
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128) (local $mask v128)
 ;; Select bytes based on mask with relaxed semantics
 (i8x16.relaxed_laneselect
   (local.get $a)      ;; selected when mask bit is set
   (local.get $b)      ;; selected when mask bit is clear
   (local.get $mask))  ;; selection mask
+# ))
 ```
 
 ---
@@ -1764,11 +2064,13 @@ Relaxed lane select for i16x8 vectors. Selects 16-bit lanes from the first or se
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128) (local $mask v128)
 ;; Select 16-bit lanes based on mask with relaxed semantics
 (i16x8.relaxed_laneselect
   (local.get $a)      ;; selected when mask bit is set
   (local.get $b)      ;; selected when mask bit is clear
   (local.get $mask))  ;; selection mask
+# ))
 ```
 
 ---
@@ -1782,11 +2084,13 @@ Relaxed lane select for i32x4 vectors. Selects 32-bit lanes from the first or se
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128) (local $mask v128)
 ;; Select 32-bit lanes based on mask with relaxed semantics
 (i32x4.relaxed_laneselect
   (local.get $a)      ;; selected when mask bit is set
   (local.get $b)      ;; selected when mask bit is clear
   (local.get $mask))  ;; selection mask
+# ))
 ```
 
 ---
@@ -1800,11 +2104,13 @@ Relaxed lane select for i64x2 vectors. Selects 64-bit lanes from the first or se
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128) (local $mask v128)
 ;; Select 64-bit lanes based on mask with relaxed semantics
 (i64x2.relaxed_laneselect
   (local.get $a)      ;; selected when mask bit is set
   (local.get $b)      ;; selected when mask bit is clear
   (local.get $mask))  ;; selection mask
+# ))
 ```
 
 ---
@@ -1818,8 +2124,10 @@ Relaxed Q15 rounding multiply returning high half for signed i16x8 lanes. Comput
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 ;; Q15 fixed-point multiply with relaxed overflow
 (i16x8.relaxed_q15mulr_s (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -1833,10 +2141,12 @@ Relaxed dot product of i8x16 and i7x16 (7-bit unsigned) vectors, producing i16x8
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 ;; Dot product: sum of pairwise products of 8-bit lanes
 (i16x8.relaxed_dot_i8x16_i7x16_s
   (local.get $a)   ;; signed 8-bit values
   (local.get $b))  ;; 7-bit unsigned values (high bit behavior undefined)
+# ))
 ```
 
 ---
@@ -1850,11 +2160,13 @@ Relaxed dot product of i8x16 and i7x16 vectors with i32x4 accumulation. Multipli
 **Example:**
 
 ```wat
+# (module (func (result v128) (local $a v128) (local $b v128) (local $acc v128)
 ;; Dot product with accumulation: useful for neural network inference
 (i32x4.relaxed_dot_i8x16_i7x16_add_s
   (local.get $a)     ;; signed 8-bit values
   (local.get $b)     ;; 7-bit unsigned values
   (local.get $acc))  ;; i32x4 accumulator
+# ))
 ```
 
 ---

--- a/packages/docs/src/content/docs/instructions/table.md
+++ b/packages/docs/src/content/docs/instructions/table.md
@@ -14,8 +14,11 @@ Get element from table at index.
 **Example:**
 
 ```wat
+# (module
 (table $funcs 10 funcref)
+# (func (result funcref)
 (table.get $funcs (i32.const 0))
+# ))
 ```
 
 ---
@@ -29,10 +32,15 @@ Set element in table at index.
 **Example:**
 
 ```wat
+# (module
 (table $funcs 10 funcref)
+(func $my_function)
+# (elem declare func $my_function)
+# (func
 (table.set $funcs
   (i32.const 0)
   (ref.func $my_function))
+# ))
 ```
 
 ---
@@ -46,7 +54,11 @@ Get current table size.
 **Example:**
 
 ```wat
+# (module
+# (table $funcs 10 funcref)
+# (func (result i32)
 (table.size $funcs)
+# ))
 ```
 
 ---
@@ -60,9 +72,13 @@ Grow table by delta, returns previous size or -1 on failure.
 **Example:**
 
 ```wat
+# (module
+# (table $funcs 10 funcref)
+# (func (result i32)
 (table.grow $funcs
   (ref.null func)
   (i32.const 5))  ;; Grow by 5 elements
+# ))
 ```
 
 ---
@@ -76,12 +92,15 @@ Fill a region of a table with a value.
 **Example:**
 
 ```wat
+# (module
 (table $funcs 10 funcref)
+# (func
 ;; Fill 5 slots starting at index 0 with null
 (table.fill $funcs
   (i32.const 0)       ;; start index
   (ref.null func)     ;; value
   (i32.const 5))      ;; count
+# ))
 ```
 
 ---
@@ -95,12 +114,15 @@ Copy elements from one table region to another.
 **Example:**
 
 ```wat
+# (module
 (table $funcs 10 funcref)
+# (func
 ;; Copy 3 elements from index 0 to index 5
 (table.copy $funcs $funcs
   (i32.const 5)   ;; destination index
   (i32.const 0)   ;; source index
   (i32.const 3))  ;; count
+# ))
 ```
 
 ---
@@ -114,12 +136,17 @@ Initialize table region from a passive element segment.
 **Example:**
 
 ```wat
+# (module
+# (table $my_table 10 funcref)
+# (func $f1) (func $f2) (func $f3)
 (elem $my_elem func $f1 $f2 $f3)
+# (func
 ;; Copy 3 elements from elem segment to table
 (table.init $my_table $my_elem
   (i32.const 0)   ;; table destination
   (i32.const 0)   ;; elem segment offset
   (i32.const 3))  ;; count
+# ))
 ```
 
 ---
@@ -131,8 +158,12 @@ Drop a passive element segment, freeing its memory.
 **Example:**
 
 ```wat
+# (module
+# (func $f1) (func $f2)
 (elem $my_elem func $f1 $f2)
+# (func
 (elem.drop $my_elem)  ;; Element segment can no longer be used
+# ))
 ```
 
 ---

--- a/packages/docs/src/content/docs/instructions/types.md
+++ b/packages/docs/src/content/docs/instructions/types.md
@@ -11,7 +11,7 @@ sidebar:
 
 **Example:**
 
-```wat
+```wat-snippet
 (local $x i32)
 (global $counter (mut i32) (i32.const 0))
 (param $value i32)
@@ -25,7 +25,7 @@ sidebar:
 
 **Example:**
 
-```wat
+```wat-snippet
 (local $timestamp i64)
 (global $big_number i64 (i64.const 9223372036854775807))
 ```
@@ -38,7 +38,7 @@ sidebar:
 
 **Example:**
 
-```wat
+```wat-snippet
 (local $pi f32)
 (global $epsilon f32 (f32.const 1.1920929e-07))
 ```
@@ -51,7 +51,7 @@ sidebar:
 
 **Example:**
 
-```wat
+```wat-snippet
 (local $precise f64)
 (global $e f64 (f64.const 2.718281828459045))
 ```
@@ -64,7 +64,7 @@ sidebar:
 
 **Example:**
 
-```wat
+```wat-snippet
 (local $vec v128)
 (global $zeros v128 (v128.const i32x4 0 0 0 0))
 ```
@@ -78,7 +78,9 @@ SIMD shape annotation for v128 interpreted as 16 lanes of 8-bit integers. Used w
 **Example:**
 
 ```wat
+# (module (func (result v128)
 (v128.const i8x16 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15)
+# ))
 ```
 
 ---
@@ -90,7 +92,9 @@ SIMD shape annotation for v128 interpreted as 8 lanes of 16-bit integers. Used w
 **Example:**
 
 ```wat
+# (module (func (result v128)
 (v128.const i16x8 0 1 2 3 4 5 6 7)
+# ))
 ```
 
 ---
@@ -102,7 +106,9 @@ SIMD shape annotation for v128 interpreted as 4 lanes of 32-bit integers. Used w
 **Example:**
 
 ```wat
+# (module (func (result v128)
 (v128.const i32x4 1 2 3 4)
+# ))
 ```
 
 ---
@@ -114,7 +120,9 @@ SIMD shape annotation for v128 interpreted as 2 lanes of 64-bit integers. Used w
 **Example:**
 
 ```wat
+# (module (func (result v128)
 (v128.const i64x2 1 2)
+# ))
 ```
 
 ---
@@ -126,7 +134,9 @@ SIMD shape annotation for v128 interpreted as 4 lanes of 32-bit floats. Used wit
 **Example:**
 
 ```wat
+# (module (func (result v128)
 (v128.const f32x4 1.0 2.0 3.0 4.0)
+# ))
 ```
 
 ---
@@ -138,7 +148,9 @@ SIMD shape annotation for v128 interpreted as 2 lanes of 64-bit floats. Used wit
 **Example:**
 
 ```wat
+# (module (func (result v128)
 (v128.const f64x2 1.0 2.0)
+# ))
 ```
 
 ---
@@ -149,7 +161,7 @@ Reference type for functions. Can be null.
 
 **Example:**
 
-```wat
+```wat-snippet
 (table $callbacks 10 funcref)
 (global $current_handler (mut funcref) (ref.null func))
 ```
@@ -162,7 +174,7 @@ Reference type for external (host) values. Can be null.
 
 **Example:**
 
-```wat
+```wat-snippet
 (table $objects 10 externref)
 (func $process (param $obj externref) ...)
 ```
@@ -175,7 +187,7 @@ Reference type that can hold any reference (GC proposal). Equivalent to `(ref nu
 
 **Example:**
 
-```wat
+```wat-snippet
 (global $obj anyref (ref.null any))
 (func $store (param $val anyref) ...)
 ```
@@ -189,8 +201,10 @@ Reference type for values that support equality comparison (GC proposal). Equiva
 **Example:**
 
 ```wat
+# (module
 (func $compare (param $a eqref) (param $b eqref) (result i32)
   (ref.eq (local.get $a) (local.get $b)))
+# )
 ```
 
 ---
@@ -202,10 +216,12 @@ Reference type for 31-bit integers packed into a reference (GC proposal). Equiva
 **Example:**
 
 ```wat
+# (module
 (func $box (param $val i32) (result i31ref)
   (ref.i31 (local.get $val)))
 (func $unbox (param $ref i31ref) (result i32)
   (i31.get_s (local.get $ref)))
+# )
 ```
 
 ---
@@ -216,7 +232,7 @@ Reference type that can hold any struct reference (GC proposal). Equivalent to `
 
 **Example:**
 
-```wat
+```wat-snippet
 (func $get_struct (result structref) ...)
 (func $process (param $s structref) ...)
 ```
@@ -229,7 +245,7 @@ Reference type that can hold any array reference (GC proposal). Equivalent to `(
 
 **Example:**
 
-```wat
+```wat-snippet
 (func $get_array (result arrayref) ...)
 (func $process (param $arr arrayref) ...)
 ```
@@ -243,7 +259,9 @@ Bottom reference type that represents only the null reference (GC proposal). Equ
 **Example:**
 
 ```wat
+# (module
 (global $empty nullref (ref.null none))
+# )
 ```
 
 ---
@@ -255,7 +273,9 @@ Null reference type for functions (GC proposal). Equivalent to `(ref null nofunc
 **Example:**
 
 ```wat
+# (module
 (global $no_func nullfuncref (ref.null nofunc))
+# )
 ```
 
 ---
@@ -267,7 +287,9 @@ Null reference type for external values (GC proposal). Equivalent to `(ref null 
 **Example:**
 
 ```wat
+# (module
 (global $no_extern nullexternref (ref.null noextern))
+# )
 ```
 
 ---
@@ -278,7 +300,7 @@ Reference type for exception objects (exception handling proposal). Equivalent t
 
 **Example:**
 
-```wat
+```wat-snippet
 (block $handler (result exnref)
   (try_table (catch_all_ref $handler)
     (call $may_throw)
@@ -296,7 +318,9 @@ Null reference type for exceptions (exception handling proposal). Equivalent to 
 **Example:**
 
 ```wat
+# (module
 (global $no_exn nullexnref (ref.null noexn))
+# )
 ```
 
 ---
@@ -307,7 +331,7 @@ Null reference type for exceptions (exception handling proposal). Equivalent to 
 
 **Example:**
 
-```wat
+```wat-snippet
 ;; Packed array of bytes
 (type $bytes (array (mut i8)))
 
@@ -329,7 +353,7 @@ Null reference type for exceptions (exception handling proposal). Equivalent to 
 
 **Example:**
 
-```wat
+```wat-snippet
 ;; Packed array of shorts
 (type $shorts (array (mut i16)))
 

--- a/packages/docs/src/content/docs/language/packed-types.md
+++ b/packages/docs/src/content/docs/language/packed-types.md
@@ -27,7 +27,7 @@ Packed types are valid as storage types inside `field` and `array` definitions:
 
 Using `i8` or `i16` as value types in parameters, results, locals, or globals is an error:
 
-```wat
+```wat-snippet
 ;; All of these are invalid:
 (func (param i8))        ;; error: i8 is not a value type
 (func (result i16))      ;; error: i16 is not a value type

--- a/packages/docs/src/plugins/remark-strip-hidden-lines.mjs
+++ b/packages/docs/src/plugins/remark-strip-hidden-lines.mjs
@@ -1,0 +1,20 @@
+/**
+ * Remark plugin that strips hidden context lines from WAT code blocks.
+ *
+ * Lines starting with `# ` (or bare `#`) inside ```wat code blocks are used for
+ * validation context (like Rust doc-tests) but should not appear in rendered docs.
+ */
+import { visit } from 'unist-util-visit';
+
+export function remarkStripHiddenLines() {
+  return (tree) => {
+    visit(tree, 'code', (node) => {
+      if (node.lang === 'wat') {
+        node.value = node.value
+          .split('\n')
+          .filter((line) => !line.startsWith('# ') && line !== '#')
+          .join('\n');
+      }
+    });
+  };
+}

--- a/packages/docs/tests/wat-examples.test.mjs
+++ b/packages/docs/tests/wat-examples.test.mjs
@@ -20,11 +20,22 @@ const DOCS_DIR = join(ROOT, 'src', 'content', 'docs');
  * Known LSP false positives — valid WAT code that the LSP incorrectly flags
  * due to missing support for proposals or type-checking bugs.
  */
-const KNOWN_LSP_ISSUES = new Set([]);
+const KNOWN_LSP_ISSUES = new Set([
+  // WASM LSP false positives on GC/ref operations
+  'instructions/gc-array.md:71',
+  'instructions/gc-array.md:232',
+  'instructions/gc-casts.md:95',
+  'instructions/reference.md:89',
+  'instructions/reference.md:105',
+  'instructions/table.md:139',
+  'instructions/types.md:204',
+]);
 
 /**
  * Extract all ```wat code blocks from a markdown string.
  * Returns an array of { code, lineNumber } where lineNumber is 1-indexed.
+ * Processes `# ` hidden lines: includes them with prefix stripped (Rust doc-test convention).
+ * Skips ```wat-snippet blocks.
  */
 function extractWatBlocks(markdown) {
   const blocks = [];
@@ -45,7 +56,13 @@ function extractWatBlocks(markdown) {
       inBlock = false;
       blocks.push({ code: blockLines.join('\n'), lineNumber: blockStart + 1 });
     } else if (inBlock) {
-      blockLines.push(line);
+      if (line.startsWith('# ')) {
+        blockLines.push(line.slice(2));
+      } else if (line === '#') {
+        blockLines.push('');
+      } else {
+        blockLines.push(line);
+      }
     }
   }
 

--- a/tests/doc_samples.rs
+++ b/tests/doc_samples.rs
@@ -1,0 +1,227 @@
+//! Doc Sample Validation Tests (native only)
+//!
+//! Validates all WAT code samples in the documentation site against the native
+//! diagnostic pipeline. Supports hidden context lines (prefixed with `# `) that
+//! are included during validation but stripped during rendering — following the
+//! Rust doc-test convention.
+//!
+//! Run with: `cargo test doc_samples --features native`
+
+#![cfg(feature = "native")]
+
+use std::fs;
+use std::path::Path;
+use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity};
+use wat_lsp_rust::diagnostics::{
+    merge_all_diagnostics, provide_semantic_diagnostics, provide_tree_sitter_diagnostics,
+    validate_wat,
+};
+use wat_lsp_rust::parser;
+use wat_lsp_rust::ts_facade;
+
+/// Known LSP false positives — valid WAT that the LSP incorrectly flags due to
+/// incomplete type checking or missing proposal support.
+/// Format: "relative/path.md:line_number"
+const KNOWN_ISSUES: &[&str] = &[
+    // br_if/br_table stack validation in typed blocks (type checker limitation)
+    "control/block.md:11",
+    "control/br-table.md:11",
+    "control/branching.md:11",
+    // try_table type checking not fully supported
+    "extensions/exception-handling.md:11",
+    // call_ref syntax: `(call_ref (type $t))` vs `(call_ref $t)`
+    "extensions/typed-func-refs.md:11",
+    // ref.null funcref syntax difference
+    "language/reference-types.md:18",
+    // Inline import after inline export (import ordering with inline syntax)
+    "language/text-format.md:160",
+    // try_table catch clause: type checker doesn't track values delivered via branch
+    "instructions/exceptions.md:78",
+    // i64 atomic RMW operations: type checker returns i32 instead of i64
+    "instructions/atomic.md:397",
+    "instructions/atomic.md:416",
+    "instructions/atomic.md:435",
+    "instructions/atomic.md:454",
+    "instructions/atomic.md:473",
+];
+
+fn is_known_issue(rel_path: &Path, line_number: usize) -> bool {
+    // Normalize Windows backslashes to forward slashes for cross-platform matching
+    let key = format!(
+        "{}:{}",
+        rel_path.display().to_string().replace('\\', "/"),
+        line_number
+    );
+    KNOWN_ISSUES.contains(&key.as_str())
+}
+
+fn get_all_diagnostics(wat: &str) -> Vec<Diagnostic> {
+    let mut parser = ts_facade::create_parser();
+    let tree = parser.parse(wat, None).expect("Failed to parse");
+    let symbols = parser::parse_document_from_tree(&tree, wat).unwrap_or_default();
+
+    let tree_sitter_diags = provide_tree_sitter_diagnostics(&tree, wat);
+    let semantic_diags = provide_semantic_diagnostics(&tree, wat, &symbols);
+    let wast_diags = validate_wat(wat);
+
+    merge_all_diagnostics(tree_sitter_diags, semantic_diags, wast_diags)
+}
+
+/// A WAT code block extracted from a markdown file.
+struct WatBlock {
+    /// The assembled WAT source (hidden lines included, prefix stripped).
+    code: String,
+    /// 1-indexed line number where the code block starts in the markdown file.
+    line_number: usize,
+}
+
+/// Extract all ```wat code blocks from markdown content.
+/// Processes `# ` hidden lines (includes them with prefix stripped).
+/// Skips ```wat-snippet blocks.
+fn extract_wat_blocks(markdown: &str) -> Vec<WatBlock> {
+    let mut blocks = Vec::new();
+    let lines: Vec<&str> = markdown.lines().collect();
+    let mut i = 0;
+
+    while i < lines.len() {
+        let line = lines[i];
+        // Match ```wat but not ```wat-snippet or other variants
+        if line.starts_with("```wat") && !line.starts_with("```wat-") {
+            let block_start = i + 1; // 0-indexed line after the fence
+            let mut block_lines = Vec::new();
+            i += 1;
+
+            while i < lines.len() && !lines[i].starts_with("```") {
+                let content_line = lines[i];
+                if let Some(stripped) = content_line.strip_prefix("# ") {
+                    block_lines.push(stripped.to_string());
+                } else if content_line == "#" {
+                    // Bare `#` is a hidden empty line
+                    block_lines.push(String::new());
+                } else {
+                    block_lines.push(content_line.to_string());
+                }
+                i += 1;
+            }
+
+            blocks.push(WatBlock {
+                code: block_lines.join("\n"),
+                line_number: block_start + 1, // 1-indexed
+            });
+        }
+        i += 1;
+    }
+
+    blocks
+}
+
+/// Recursively collect all .md files under a directory.
+fn collect_md_files(dir: &Path, files: &mut Vec<std::path::PathBuf>) {
+    if let Ok(entries) = fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                collect_md_files(&path, &mut *files);
+            } else if path
+                .extension()
+                .is_some_and(|ext| ext == "md" || ext == "mdx")
+            {
+                files.push(path);
+            }
+        }
+    }
+}
+
+#[test]
+fn doc_samples_have_no_errors() {
+    let docs_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("packages")
+        .join("docs")
+        .join("src")
+        .join("content")
+        .join("docs");
+
+    if !docs_dir.exists() {
+        eprintln!("Docs directory not found: {}", docs_dir.display());
+        return;
+    }
+
+    let mut md_files = Vec::new();
+    collect_md_files(&docs_dir, &mut md_files);
+    md_files.sort();
+
+    let mut failures: Vec<String> = Vec::new();
+    let mut total_blocks = 0;
+    let mut skipped_known = 0;
+
+    for md_path in &md_files {
+        let rel_path = md_path.strip_prefix(&docs_dir).unwrap_or(md_path);
+        let markdown = fs::read_to_string(md_path).expect("Failed to read markdown file");
+        let blocks = extract_wat_blocks(&markdown);
+
+        for block in &blocks {
+            // Every `wat` block must have module context (visible or hidden).
+            // Use ```wat-snippet for syntax-only demos that don't need validation.
+            assert!(
+                block.code.contains("(module"),
+                "Unannotated wat block at {}:{} — add hidden `# (module` context or use ```wat-snippet\n  Code:\n{}",
+                rel_path.display(),
+                block.line_number,
+                block.code.lines().enumerate()
+                    .map(|(i, l)| format!("    {}: {}", i + 1, l))
+                    .collect::<Vec<_>>()
+                    .join("\n"),
+            );
+
+            total_blocks += 1;
+
+            if is_known_issue(rel_path, block.line_number) {
+                skipped_known += 1;
+                continue;
+            }
+
+            let diagnostics = get_all_diagnostics(&block.code);
+            let errors: Vec<&Diagnostic> = diagnostics
+                .iter()
+                .filter(|d| d.severity == Some(DiagnosticSeverity::ERROR))
+                .collect();
+
+            if !errors.is_empty() {
+                let error_msgs: Vec<String> = errors
+                    .iter()
+                    .map(|d| format!("  L{}: {}", d.range.start.line + 1, d.message))
+                    .collect();
+
+                failures.push(format!(
+                    "{}:{} — {} error(s):\n{}\n  Code:\n{}",
+                    rel_path.display(),
+                    block.line_number,
+                    errors.len(),
+                    error_msgs.join("\n"),
+                    block
+                        .code
+                        .lines()
+                        .enumerate()
+                        .map(|(i, l)| format!("    {}: {}", i + 1, l))
+                        .collect::<Vec<_>>()
+                        .join("\n"),
+                ));
+            }
+        }
+    }
+
+    eprintln!(
+        "Doc samples: {} blocks validated, {} known issues skipped, {} failures",
+        total_blocks,
+        skipped_known,
+        failures.len()
+    );
+
+    if !failures.is_empty() {
+        panic!(
+            "\n{} doc sample(s) have errors:\n\n{}",
+            failures.len(),
+            failures.join("\n\n")
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Add Rust integration test (`tests/doc_samples.rs`) that validates all ```wat` code blocks in docs against the native diagnostic pipeline
- Add remark plugin to strip `# `-prefixed hidden context lines from rendered docs (Rust doc-test convention)
- Update JS test to process hidden lines
- Annotate i32.md (37 blocks), memory.md (6 blocks), and control.md (15 blocks) with hidden module/function context
- Fix invalid `0b` binary literals in i32.md (not valid WAT) and a buggy block example in control.md