### PR TITLE
fix 7 doc sample validation issues (#241)

### DIFF
--- a/packages/docs/src/content/docs/control/block.md
+++ b/packages/docs/src/content/docs/control/block.md
@@ -10,9 +10,10 @@ sidebar:
 ```wat
 (module
   (func (param $n i32) (result i32)
-    (block $out (result i32)
+    (block $out
       (br_if $out (i32.eqz (local.get $n)))
-      (i32.const 42)))
+      (return (i32.const 42)))
+    (i32.const 0))
 )
 ```
 

--- a/packages/docs/src/content/docs/control/br-table.md
+++ b/packages/docs/src/content/docs/control/br-table.md
@@ -10,10 +10,10 @@ sidebar:
 ```wat
 (module
   (func (param $tag i32) (result i32)
-    (block $default (result i32)
-      (block $case2 (result i32)
-        (block $case1 (result i32)
-          (block $case0 (result i32)
+    (block $default
+      (block $case2
+        (block $case1
+          (block $case0
             (br_table $case0 $case1 $case2 $default
               (local.get $tag)))
           (return (i32.const 10)))

--- a/packages/docs/src/content/docs/control/branching.md
+++ b/packages/docs/src/content/docs/control/branching.md
@@ -10,10 +10,10 @@ sidebar:
 ```wat
 (module
   (func (param $n i32) (result i32)
-    (block $exit (result i32)
+    (block $exit
       (br_if $exit (i32.gt_s (local.get $n) (i32.const 10)))
-      (i32.const 1)
-      (br $exit)))
+      (return (i32.const 1)))
+    (i32.const 2))
 )
 ```
 

--- a/packages/docs/src/content/docs/extensions/exception-handling.md
+++ b/packages/docs/src/content/docs/extensions/exception-handling.md
@@ -13,7 +13,7 @@ Exception handling introduces `try_table`, `throw`, and related constructs for s
 
   (func (export "mayThrow") (param $x i32) (result i32)
     (block $handler (result i32)
-      (try_table (catch $e $handler)
+      (try_table (result i32) (catch $e $handler)
         (if (i32.eqz (local.get $x))
           (then (throw $e (i32.const 1))))
         (i32.const 0)

--- a/packages/docs/src/content/docs/extensions/typed-func-refs.md
+++ b/packages/docs/src/content/docs/extensions/typed-func-refs.md
@@ -17,7 +17,7 @@ Typed function references make function refs carry specific types and enable `ca
   (elem (i32.const 0) $inc)
 
   (func (export "dispatch") (param $x i32) (result i32)
-    (call_ref (type $t0) (local.get $x) (ref.func $inc)))
+    (call_ref $t0 (local.get $x) (ref.func $inc)))
 )
 ```
 

--- a/packages/docs/src/content/docs/language/reference-types.md
+++ b/packages/docs/src/content/docs/language/reference-types.md
@@ -23,7 +23,7 @@ Reference types let Wasm refer to functions and host objects.
   (elem (i32.const 0) $double)
 
   (func (result i32)
-    (ref.is_null (ref.null funcref)))    ;; -> 1
+    (ref.is_null (ref.null func)))       ;; -> 1
 
   (func (result i32)
     (ref.is_null (ref.func $double)))    ;; -> 0

--- a/packages/docs/src/content/docs/language/text-format.md
+++ b/packages/docs/src/content/docs/language/text-format.md
@@ -158,8 +158,8 @@ The same sugar applies to other definitions:
 
 ```wat
 (module
-  (memory (export "mem") 1)                        ;; inline export
   (global $g (import "env" "val") i32)             ;; inline import
+  (memory (export "mem") 1)                        ;; inline export
   (table (export "tbl") 1 funcref)                 ;; inline export
 )
 ```

--- a/tests/doc_samples.rs
+++ b/tests/doc_samples.rs
@@ -23,18 +23,6 @@ use wat_lsp_rust::ts_facade;
 /// incomplete type checking or missing proposal support.
 /// Format: "relative/path.md:line_number"
 const KNOWN_ISSUES: &[&str] = &[
-    // br_if/br_table stack validation in typed blocks (type checker limitation)
-    "control/block.md:11",
-    "control/br-table.md:11",
-    "control/branching.md:11",
-    // try_table type checking not fully supported
-    "extensions/exception-handling.md:11",
-    // call_ref syntax: `(call_ref (type $t))` vs `(call_ref $t)`
-    "extensions/typed-func-refs.md:11",
-    // ref.null funcref syntax difference
-    "language/reference-types.md:18",
-    // Inline import after inline export (import ordering with inline syntax)
-    "language/text-format.md:160",
     // try_table catch clause: type checker doesn't track values delivered via branch
     "instructions/exceptions.md:78",
     // i64 atomic RMW operations: type checker returns i32 instead of i64


### PR DESCRIPTION
Correct invalid WAT examples in documentation that the type checker rightfully flagged:

- **block/branching/br-table**: use untyped blocks with `return` instead of typed blocks with `br_if` (spec requires label values + i32 condition)
- **exception-handling**: add missing `(result i32)` to `try_table`
- **typed-func-refs**: fix `call_ref` syntax to `(call_ref $t0 ...)`
- **reference-types**: fix `ref.null` to use heap type `func` not `funcref`
- **text-format**: reorder inline import before definitions

Removes 7 resolved entries from `KNOWN_ISSUES` in `doc_samples` test (6 remain).

---

- closes https://github.com/EmNudge/wat-lsp/issues/241