### PR TITLE
fix i64 atomic RMW consumed types, fix try_table doc sample, remove KNOWN_ISSUES

### DIFF
--- a/packages/docs/src/content/docs/instructions/exceptions.md
+++ b/packages/docs/src/content/docs/instructions/exceptions.md
@@ -77,7 +77,7 @@ Define a block that catches exceptions using a jump table.
 ```wat
 # (module
 # (tag $tag (param i32))
-# (func
+# (func (result i32)
 # (block $handler_label (result i32)
 (try_table (catch $tag $handler_label)
   (throw $tag (i32.const 1))

--- a/src/diagnostics_core/semantic.rs
+++ b/src/diagnostics_core/semantic.rs
@@ -1273,6 +1273,19 @@ fn derive_consumed_types_from_name(
         "memory.atomic.wait64" => Some(vec![ValueType::I32, ValueType::I64, ValueType::I64]),
         "memory.atomic.notify" => Some(vec![ValueType::I32, ValueType::I32]),
 
+        // Atomic RMW — address (i32) + value (prefix type)
+        name if name.contains(".atomic.rmw") => {
+            if let Some(ty) = type_from_prefix(name) {
+                if name.contains("cmpxchg") {
+                    Some(vec![ValueType::I32, ty, ty]) // addr + expected + replacement
+                } else {
+                    Some(vec![ValueType::I32, ty]) // addr + value
+                }
+            } else {
+                None
+            }
+        }
+
         // br_on_null/br_on_non_null handled specially in process_instruction
 
         // Scalar binary operations — 2 operands of prefix type

--- a/tests/doc_samples.rs
+++ b/tests/doc_samples.rs
@@ -19,30 +19,6 @@ use wat_lsp_rust::diagnostics::{
 use wat_lsp_rust::parser;
 use wat_lsp_rust::ts_facade;
 
-/// Known LSP false positives — valid WAT that the LSP incorrectly flags due to
-/// incomplete type checking or missing proposal support.
-/// Format: "relative/path.md:line_number"
-const KNOWN_ISSUES: &[&str] = &[
-    // try_table catch clause: type checker doesn't track values delivered via branch
-    "instructions/exceptions.md:78",
-    // i64 atomic RMW operations: type checker returns i32 instead of i64
-    "instructions/atomic.md:397",
-    "instructions/atomic.md:416",
-    "instructions/atomic.md:435",
-    "instructions/atomic.md:454",
-    "instructions/atomic.md:473",
-];
-
-fn is_known_issue(rel_path: &Path, line_number: usize) -> bool {
-    // Normalize Windows backslashes to forward slashes for cross-platform matching
-    let key = format!(
-        "{}:{}",
-        rel_path.display().to_string().replace('\\', "/"),
-        line_number
-    );
-    KNOWN_ISSUES.contains(&key.as_str())
-}
-
 fn get_all_diagnostics(wat: &str) -> Vec<Diagnostic> {
     let mut parser = ts_facade::create_parser();
     let tree = parser.parse(wat, None).expect("Failed to parse");
@@ -140,7 +116,6 @@ fn doc_samples_have_no_errors() {
 
     let mut failures: Vec<String> = Vec::new();
     let mut total_blocks = 0;
-    let mut skipped_known = 0;
 
     for md_path in &md_files {
         let rel_path = md_path.strip_prefix(&docs_dir).unwrap_or(md_path);
@@ -162,11 +137,6 @@ fn doc_samples_have_no_errors() {
             );
 
             total_blocks += 1;
-
-            if is_known_issue(rel_path, block.line_number) {
-                skipped_known += 1;
-                continue;
-            }
 
             let diagnostics = get_all_diagnostics(&block.code);
             let errors: Vec<&Diagnostic> = diagnostics
@@ -199,9 +169,8 @@ fn doc_samples_have_no_errors() {
     }
 
     eprintln!(
-        "Doc samples: {} blocks validated, {} known issues skipped, {} failures",
+        "Doc samples: {} blocks validated, {} failures",
         total_blocks,
-        skipped_known,
         failures.len()
     );
 


### PR DESCRIPTION
- Fix i64 atomic RMW operations consuming wrong types (`[ty, ty]` → `[I32, ty]`) by adding explicit match before the `is_binary_scalar` catch-all
- Fix exceptions.md try_table doc sample by adding `(result i32)` to the function declaration
- Remove `KNOWN_ISSUES` array and skip logic from doc_samples test — all 6 previously-skipped samples now pass

---

- closes https://github.com/EmNudge/wat-lsp/issues/243