### PR TITLE
convert 195 wat-snippet blocks to validated wat blocks with hidden context lines

### DIFF
--- a/.github/omni-comment.yml
+++ b/.github/omni-comment.yml
@@ -1,3 +1,4 @@
 sections:
   - docs_preview
   - wast_progress
+  - wat_snippets

--- a/.github/workflows/wat-snippets.yml
+++ b/.github/workflows/wat-snippets.yml
@@ -1,0 +1,203 @@
+name: WAT Snippet Tracking
+
+on:
+  pull_request:
+    branches: [main, master]
+    paths:
+      - 'packages/docs/**'
+
+jobs:
+  wat-snippets:
+    name: WAT Snippets
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v6
+
+      - name: Count snippets (PR branch)
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+
+            function countBlocks(dir) {
+              const results = [];
+
+              function walk(d) {
+                for (const entry of fs.readdirSync(d, { withFileTypes: true })) {
+                  const full = path.join(d, entry.name);
+                  if (entry.isDirectory()) {
+                    walk(full);
+                  } else if (entry.name.endsWith('.md')) {
+                    const content = fs.readFileSync(full, 'utf8');
+                    const snippetCount = (content.match(/```wat-snippet/g) || []).length;
+                    const watCount = (content.match(/```wat$/gm) || []).length;
+                    if (snippetCount > 0 || watCount > 0) {
+                      const rel = path.relative('packages/docs', full);
+                      results.push({ file: rel, snippets: snippetCount, wat: watCount });
+                    }
+                  }
+                }
+              }
+
+              walk(dir);
+              return results;
+            }
+
+            const data = countBlocks('packages/docs');
+            data.sort((a, b) => a.file.localeCompare(b.file));
+
+            const totals = data.reduce((acc, f) => {
+              acc.snippets += f.snippets;
+              acc.wat += f.wat;
+              return acc;
+            }, { snippets: 0, wat: 0 });
+
+            fs.writeFileSync('/tmp/pr-snippets.json', JSON.stringify({ files: data, totals }, null, 2));
+
+      - name: Checkout base branch
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          clean: false
+
+      - name: Count snippets (base branch)
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+
+            function countBlocks(dir) {
+              const results = [];
+
+              function walk(d) {
+                for (const entry of fs.readdirSync(d, { withFileTypes: true })) {
+                  const full = path.join(d, entry.name);
+                  if (entry.isDirectory()) {
+                    walk(full);
+                  } else if (entry.name.endsWith('.md')) {
+                    const content = fs.readFileSync(full, 'utf8');
+                    const snippetCount = (content.match(/```wat-snippet/g) || []).length;
+                    const watCount = (content.match(/```wat$/gm) || []).length;
+                    if (snippetCount > 0 || watCount > 0) {
+                      const rel = path.relative('packages/docs', full);
+                      results.push({ file: rel, snippets: snippetCount, wat: watCount });
+                    }
+                  }
+                }
+              }
+
+              walk(dir);
+              return results;
+            }
+
+            const data = countBlocks('packages/docs');
+            data.sort((a, b) => a.file.localeCompare(b.file));
+
+            const totals = data.reduce((acc, f) => {
+              acc.snippets += f.snippets;
+              acc.wat += f.wat;
+              return acc;
+            }, { snippets: 0, wat: 0 });
+
+            fs.writeFileSync('/tmp/base-snippets.json', JSON.stringify({ files: data, totals }, null, 2));
+
+      - name: Generate comparison
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+
+            const pr = JSON.parse(fs.readFileSync('/tmp/pr-snippets.json', 'utf8'));
+            const base = JSON.parse(fs.readFileSync('/tmp/base-snippets.json', 'utf8'));
+
+            function delta(val) {
+              if (val > 0) return `+${val}`;
+              if (val < 0) return `${val}`;
+              return '—';
+            }
+
+            function pct(snippets, wat) {
+              const total = snippets + wat;
+              if (total === 0) return '—';
+              return `${Math.round(wat / total * 100)}%`;
+            }
+
+            const ps = pr.totals;
+            const bs = base.totals;
+
+            let body = '';
+            body += `\`wat-snippet\` blocks are unvalidated code examples. Converting them to \`wat\` blocks ensures examples stay correct.\n\n`;
+            body += `| Metric | Base | PR | Delta |\n`;
+            body += `|--------|-----:|---:|------:|\n`;
+            body += `| **wat-snippet** (unvalidated) | ${bs.snippets} | ${ps.snippets} | ${delta(ps.snippets - bs.snippets)} |\n`;
+            body += `| **wat** (validated) | ${bs.wat} | ${ps.wat} | ${delta(ps.wat - bs.wat)} |\n`;
+            body += `| **Validated %** | ${pct(bs.snippets, bs.wat)} | ${pct(ps.snippets, ps.wat)} | |\n`;
+
+            // Per-file details
+            const baseByFile = {};
+            for (const f of base.files) baseByFile[f.file] = f;
+            const prByFile = {};
+            for (const f of pr.files) prByFile[f.file] = f;
+
+            const allFiles = new Set([...base.files.map(f => f.file), ...pr.files.map(f => f.file)]);
+            const changedFiles = [];
+
+            for (const file of allFiles) {
+              const bf = baseByFile[file] || { snippets: 0, wat: 0 };
+              const pf = prByFile[file] || { snippets: 0, wat: 0 };
+              if (bf.snippets !== pf.snippets || bf.wat !== pf.wat) {
+                changedFiles.push({
+                  file,
+                  baseSnippets: bf.snippets,
+                  prSnippets: pf.snippets,
+                  baseWat: bf.wat,
+                  prWat: pf.wat,
+                });
+              }
+            }
+
+            if (changedFiles.length > 0) {
+              changedFiles.sort((a, b) => a.file.localeCompare(b.file));
+
+              body += `\n<details>\n<summary>Changed files (${changedFiles.length})</summary>\n\n`;
+              body += `| File | Snippets (base→PR) | WAT (base→PR) |\n`;
+              body += `|------|-------------------:|---------------:|\n`;
+              for (const cf of changedFiles) {
+                body += `| ${cf.file} | ${cf.baseSnippets}→${cf.prSnippets} | ${cf.baseWat}→${cf.prWat} |\n`;
+              }
+              body += `\n</details>\n`;
+            }
+
+            // Files with remaining snippets
+            const filesWithSnippets = pr.files.filter(f => f.snippets > 0);
+            if (filesWithSnippets.length > 0) {
+              filesWithSnippets.sort((a, b) => b.snippets - a.snippets);
+
+              body += `\n<details>\n<summary>Files with wat-snippet blocks (${filesWithSnippets.length} files, ${ps.snippets} total)</summary>\n\n`;
+              body += `| File | Snippets | WAT | Validated % |\n`;
+              body += `|------|-------:|---------:|------------:|\n`;
+              for (const f of filesWithSnippets) {
+                body += `| ${f.file} | ${f.snippets} | ${f.wat} | ${pct(f.snippets, f.wat)} |\n`;
+              }
+              body += `\n</details>\n`;
+            }
+
+            fs.writeFileSync('/tmp/snippets-comment.md', body);
+
+      - name: Checkout PR branch (for omni-comment config)
+        uses: actions/checkout@v6
+        with:
+          clean: false
+
+      - name: Post PR comment
+        uses: mskelton/omni-comment@v2.2.1
+        with:
+          section: wat_snippets
+          title: WAT Snippet Tracking
+          file-path: /tmp/snippets-comment.md

--- a/build.rs
+++ b/build.rs
@@ -126,6 +126,10 @@ fn parse_docs(content: &str) -> HashMap<String, String> {
         // Inside code blocks, preserve original indentation
         if in_code_block {
             if instruction_name.is_some() {
+                // Strip hidden context lines (# prefix) from hover display
+                if line.starts_with("# ") || line == "#" {
+                    continue;
+                }
                 doc_lines.push(line);
             }
             continue;

--- a/packages/docs/instructions.md
+++ b/packages/docs/instructions.md
@@ -7458,7 +7458,7 @@ Signature: `(param args... i32) (result T)`
 
 Example:
 
-```wat-snippet
+```wat
 (module
   (type $sig (func (param i32) (result i32)))
   (table 1 funcref)
@@ -7482,8 +7482,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i8x16.sub (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -7496,8 +7498,10 @@ Signature: `(param v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (i8x16.neg (local.get $a))
+# ))
 ```
 
 ---
@@ -7510,8 +7514,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i8x16.min_s (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -7524,8 +7530,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i8x16.min_u (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -7538,8 +7546,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i8x16.max_s (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -7552,8 +7562,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i8x16.max_u (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -7566,8 +7578,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i8x16.avgr_u (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -7580,8 +7594,10 @@ Signature: `(param v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (i8x16.abs (local.get $a))
+# ))
 ```
 
 ---
@@ -7594,8 +7610,10 @@ Signature: `(param v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (i8x16.popcnt (local.get $a))
+# ))
 ```
 
 ---
@@ -7608,8 +7626,10 @@ Signature: `(param v128) (result i32)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (i8x16.bitmask (local.get $a))
+# ))
 ```
 
 ---
@@ -7622,8 +7642,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i8x16.narrow_i16x8_s (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -7636,8 +7658,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i8x16.narrow_i16x8_u (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -7650,8 +7674,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i8x16.add_sat_s (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -7664,8 +7690,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i8x16.add_sat_u (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -7678,8 +7706,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i8x16.sub_sat_s (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -7692,8 +7722,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i8x16.sub_sat_u (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -7706,8 +7738,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i16x8.sub (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -7720,8 +7754,10 @@ Signature: `(param v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (i16x8.neg (local.get $a))
+# ))
 ```
 
 ---
@@ -7734,8 +7770,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i16x8.mul (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -7748,8 +7786,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i16x8.min_s (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -7762,8 +7802,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i16x8.min_u (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -7776,8 +7818,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i16x8.max_s (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -7790,8 +7834,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i16x8.max_u (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -7804,8 +7850,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i16x8.avgr_u (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -7818,8 +7866,10 @@ Signature: `(param v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (i16x8.abs (local.get $a))
+# ))
 ```
 
 ---
@@ -7832,8 +7882,10 @@ Signature: `(param v128) (result i32)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (i16x8.all_true (local.get $a))
+# ))
 ```
 
 ---
@@ -7846,8 +7898,10 @@ Signature: `(param v128) (result i32)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (i16x8.bitmask (local.get $a))
+# ))
 ```
 
 ---
@@ -7860,8 +7914,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i16x8.narrow_i32x4_s (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -7874,8 +7930,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i16x8.narrow_i32x4_u (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -7888,8 +7946,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i16x8.add_sat_s (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -7902,8 +7962,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i16x8.add_sat_u (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -7916,8 +7978,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i16x8.sub_sat_s (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -7930,8 +7994,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i16x8.sub_sat_u (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -7944,8 +8010,10 @@ Signature: `(param v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (i16x8.extend_low_i8x16_s (local.get $a))
+# ))
 ```
 
 ---
@@ -7958,8 +8026,10 @@ Signature: `(param v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (i16x8.extend_low_i8x16_u (local.get $a))
+# ))
 ```
 
 ---
@@ -7972,8 +8042,10 @@ Signature: `(param v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (i16x8.extend_high_i8x16_s (local.get $a))
+# ))
 ```
 
 ---
@@ -7986,8 +8058,10 @@ Signature: `(param v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (i16x8.extend_high_i8x16_u (local.get $a))
+# ))
 ```
 
 ---
@@ -8000,8 +8074,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i16x8.extmul_low_i8x16_s (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -8014,8 +8090,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i16x8.extmul_low_i8x16_u (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -8028,8 +8106,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i16x8.extmul_high_i8x16_s (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -8042,8 +8122,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i16x8.extmul_high_i8x16_u (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -8056,8 +8138,10 @@ Signature: `(param v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (i16x8.extadd_pairwise_i8x16_s (local.get $a))
+# ))
 ```
 
 ---
@@ -8070,8 +8154,10 @@ Signature: `(param v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (i16x8.extadd_pairwise_i8x16_u (local.get $a))
+# ))
 ```
 
 ---
@@ -8084,8 +8170,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i16x8.q15mulr_sat_s (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -8098,8 +8186,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i32x4.sub (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -8112,8 +8202,10 @@ Signature: `(param v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (i32x4.neg (local.get $a))
+# ))
 ```
 
 ---
@@ -8126,8 +8218,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i32x4.mul (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -8140,8 +8234,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i32x4.min_s (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -8154,8 +8250,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i32x4.min_u (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -8168,8 +8266,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i32x4.max_s (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -8182,8 +8282,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i32x4.max_u (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -8196,8 +8298,10 @@ Signature: `(param v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (i32x4.extend_low_i16x8_s (local.get $a))
+# ))
 ```
 
 ---
@@ -8210,8 +8314,10 @@ Signature: `(param v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (i32x4.extend_low_i16x8_u (local.get $a))
+# ))
 ```
 
 ---
@@ -8224,8 +8330,10 @@ Signature: `(param v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (i32x4.extend_high_i16x8_s (local.get $a))
+# ))
 ```
 
 ---
@@ -8238,8 +8346,10 @@ Signature: `(param v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (i32x4.extend_high_i16x8_u (local.get $a))
+# ))
 ```
 
 ---
@@ -8252,8 +8362,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i32x4.extmul_low_i16x8_s (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -8266,8 +8378,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i32x4.extmul_low_i16x8_u (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -8280,8 +8394,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i32x4.extmul_high_i16x8_s (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -8294,8 +8410,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i32x4.extmul_high_i16x8_u (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -8308,8 +8426,10 @@ Signature: `(param v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (i32x4.extadd_pairwise_i16x8_s (local.get $a))
+# ))
 ```
 
 ---
@@ -8322,8 +8442,10 @@ Signature: `(param v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (i32x4.extadd_pairwise_i16x8_u (local.get $a))
+# ))
 ```
 
 ---
@@ -8336,8 +8458,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i32x4.dot_i16x8_s (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -8350,8 +8474,10 @@ Signature: `(param v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (i32x4.trunc_sat_f64x2_s_zero (local.get $a))
+# ))
 ```
 
 ---
@@ -8364,8 +8490,10 @@ Signature: `(param v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (i32x4.trunc_sat_f64x2_u_zero (local.get $a))
+# ))
 ```
 
 ---
@@ -8378,8 +8506,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i64x2.sub (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -8392,8 +8522,10 @@ Signature: `(param v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (i64x2.neg (local.get $a))
+# ))
 ```
 
 ---
@@ -8406,8 +8538,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i64x2.mul (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -8420,8 +8554,10 @@ Signature: `(param v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (i64x2.abs (local.get $a))
+# ))
 ```
 
 ---
@@ -8434,8 +8570,10 @@ Signature: `(param v128) (result i32)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result i32) (local $a v128)
 (i64x2.all_true (local.get $a))
+# ))
 ```
 
 ---
@@ -8448,8 +8586,10 @@ Signature: `(param v128) (result i32)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result i32) (local $a v128)
 (i64x2.bitmask (local.get $a))
+# ))
 ```
 
 ---
@@ -8462,8 +8602,10 @@ Signature: `(param v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (i64x2.extend_low_i32x4_s (local.get $a))
+# ))
 ```
 
 ---
@@ -8476,8 +8618,10 @@ Signature: `(param v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (i64x2.extend_low_i32x4_u (local.get $a))
+# ))
 ```
 
 ---
@@ -8490,8 +8634,10 @@ Signature: `(param v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (i64x2.extend_high_i32x4_s (local.get $a))
+# ))
 ```
 
 ---
@@ -8504,8 +8650,10 @@ Signature: `(param v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (i64x2.extend_high_i32x4_u (local.get $a))
+# ))
 ```
 
 ---
@@ -8518,8 +8666,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i64x2.extmul_low_i32x4_s (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -8532,8 +8682,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i64x2.extmul_low_i32x4_u (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -8546,8 +8698,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i64x2.extmul_high_i32x4_s (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -8560,8 +8714,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i64x2.extmul_high_i32x4_u (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -8574,8 +8730,10 @@ Signature: `(param v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (f32x4.demote_f64x2_zero (local.get $a))
+# ))
 ```
 
 ---
@@ -8588,8 +8746,10 @@ Signature: `(param v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (f64x2.convert_low_i32x4_s (local.get $a))
+# ))
 ```
 
 ---
@@ -8602,8 +8762,10 @@ Signature: `(param v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (f64x2.convert_low_i32x4_u (local.get $a))
+# ))
 ```
 
 ---
@@ -8616,8 +8778,10 @@ Signature: `(param v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (f64x2.promote_low_f32x4 (local.get $a))
+# ))
 ```
 
 ---
@@ -8630,8 +8794,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (v128.andnot (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -8644,8 +8810,10 @@ Signature: `(param v128 v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128) (local $mask v128)
 (v128.bitselect (local.get $a) (local.get $b) (local.get $mask))
+# ))
 ```
 
 ---
@@ -8658,8 +8826,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i8x16.eq (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -8672,8 +8842,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i8x16.ne (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -8686,8 +8858,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i8x16.lt_s (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -8700,8 +8874,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i8x16.lt_u (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -8714,8 +8890,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i8x16.gt_s (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -8728,8 +8906,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i8x16.gt_u (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -8742,8 +8922,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i8x16.le_s (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -8756,8 +8938,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i8x16.le_u (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -8770,8 +8954,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i8x16.ge_s (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -8784,8 +8970,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i8x16.ge_u (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -8798,8 +8986,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i16x8.eq (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -8812,8 +9002,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i16x8.ne (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -8826,8 +9018,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i16x8.lt_s (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -8840,8 +9034,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i16x8.lt_u (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -8854,8 +9050,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i16x8.gt_s (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -8868,8 +9066,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i16x8.gt_u (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -8882,8 +9082,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i16x8.le_s (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -8896,8 +9098,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i16x8.le_u (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -8910,8 +9114,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i16x8.ge_s (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -8924,8 +9130,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i16x8.ge_u (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -8938,8 +9146,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i8x16.mul (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -8952,8 +9162,10 @@ Signature: `(param v128 i32) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $vec v128)
 (i8x16.shl (local.get $vec) (i32.const 2))  ;; Shift all lanes left by 2
+# ))
 ```
 
 ---
@@ -8966,8 +9178,10 @@ Signature: `(param v128 i32) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $vec v128)
 (i8x16.shr_s (local.get $vec) (i32.const 2))  ;; Arithmetic shift right by 2
+# ))
 ```
 
 ---
@@ -8980,8 +9194,10 @@ Signature: `(param v128 i32) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $vec v128)
 (i8x16.shr_u (local.get $vec) (i32.const 2))  ;; Logical shift right by 2
+# ))
 ```
 
 ---
@@ -8994,8 +9210,10 @@ Signature: `(param i32) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128)
 (i8x16.splat (i32.const 42))
+# ))
 ```
 
 ---
@@ -9008,9 +9226,11 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $vec v128) (local $indices v128)
 ;; Rearrange lanes of first vector using indices from second vector
 (i8x16.swizzle (local.get $vec) (local.get $indices))
+# ))
 ```
 
 ---
@@ -9023,8 +9243,10 @@ Signature: `(param i32) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (memory 1) (func (result v128)
 (i16x8.load8x8_s (i32.const 0))
+# ))
 ```
 
 ---
@@ -9037,8 +9259,10 @@ Signature: `(param i32) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (memory 1) (func (result v128)
 (i16x8.load8x8_u (i32.const 0))
+# ))
 ```
 
 ---
@@ -9051,8 +9275,10 @@ Signature: `(param v128 i32) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $vec v128)
 (i16x8.shl (local.get $vec) (i32.const 2))  ;; Shift all lanes left by 2
+# ))
 ```
 
 ---
@@ -9065,8 +9291,10 @@ Signature: `(param v128 i32) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $vec v128)
 (i16x8.shr_s (local.get $vec) (i32.const 2))  ;; Arithmetic shift right by 2
+# ))
 ```
 
 ---
@@ -9079,8 +9307,10 @@ Signature: `(param v128 i32) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $vec v128)
 (i16x8.shr_u (local.get $vec) (i32.const 2))  ;; Logical shift right by 2
+# ))
 ```
 
 ---
@@ -9093,8 +9323,10 @@ Signature: `(param i32) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128)
 (i16x8.splat (i32.const 42))
+# ))
 ```
 
 ---
@@ -9107,8 +9339,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i32x4.ge_s (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -9121,8 +9355,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i32x4.ge_u (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -9135,8 +9371,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i32x4.le_u (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -9149,8 +9387,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i32x4.lt_u (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -9163,8 +9403,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i32x4.ne (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -9177,8 +9419,10 @@ Signature: `(param v128 i32) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $vec v128)
 (i32x4.shr_u (local.get $vec) (i32.const 2))  ;; Logical shift right by 2
+# ))
 ```
 
 ---
@@ -9191,8 +9435,10 @@ Signature: `(param i32) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (memory 1) (func (result v128)
 (i32x4.load16x4_s (i32.const 0))
+# ))
 ```
 
 ---
@@ -9205,8 +9451,10 @@ Signature: `(param i32) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (memory 1) (func (result v128)
 (i32x4.load16x4_u (i32.const 0))
+# ))
 ```
 
 ---
@@ -9219,8 +9467,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i64x2.eq (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -9233,8 +9483,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i64x2.ne (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -9247,8 +9499,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i64x2.lt_s (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -9261,8 +9515,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i64x2.gt_s (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -9275,8 +9531,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i64x2.le_s (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -9289,8 +9547,10 @@ Signature: `(param v128 v128) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i64x2.ge_s (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -9303,8 +9563,10 @@ Signature: `(param v128 i32) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $vec v128)
 (i64x2.shl (local.get $vec) (i32.const 2))  ;; Shift all lanes left by 2
+# ))
 ```
 
 ---
@@ -9317,8 +9579,10 @@ Signature: `(param v128 i32) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $vec v128)
 (i64x2.shr_s (local.get $vec) (i32.const 2))  ;; Arithmetic shift right by 2
+# ))
 ```
 
 ---
@@ -9331,8 +9595,10 @@ Signature: `(param v128 i32) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $vec v128)
 (i64x2.shr_u (local.get $vec) (i32.const 2))  ;; Logical shift right by 2
+# ))
 ```
 
 ---
@@ -9345,8 +9611,10 @@ Signature: `(param i64) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (func (result v128)
 (i64x2.splat (i64.const 42))
+# ))
 ```
 
 ---
@@ -9359,8 +9627,10 @@ Signature: `(param i32) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (memory 1) (func (result v128)
 (i64x2.load32x2_s (i32.const 0))
+# ))
 ```
 
 ---
@@ -9373,8 +9643,10 @@ Signature: `(param i32) (result v128)`
 
 Example:
 
-```wat-snippet
+```wat
+# (module (memory 1) (func (result v128)
 (i64x2.load32x2_u (i32.const 0))
+# ))
 ```
 
 ---

--- a/packages/docs/src/content/docs/extensions/memory64.md
+++ b/packages/docs/src/content/docs/extensions/memory64.md
@@ -7,7 +7,7 @@ sidebar:
 
 Memory64 allows memories and tables to use `i64` indices instead of `i32`, expanding the addressable space from 4 GiB to 16 EiB.
 
-```wat-snippet
+```wat
 (module
   ;; 64-bit addressed memory (1 page minimum)
   (memory $mem i64 1)

--- a/packages/docs/src/content/docs/instructions/control.md
+++ b/packages/docs/src/content/docs/instructions/control.md
@@ -388,13 +388,14 @@ Branch to a label if the reference is not null. The non-null reference is passed
 
 **Example:**
 
-```wat-snippet
-(block $not_null (param (ref $type))
-  (br_on_non_null $not_null (local.get $maybe_null_ref))
-  ;; Reference was null, handle null case
-  (return)
-)
-;; Target block receives non-null ref
+```wat
+# (module
+# (type $type (func))
+# (func (param $maybe_null_ref (ref null $type)) (result (ref $type))
+# (block $label (result (ref $type))
+(br_on_non_null $label (local.get $maybe_null_ref))
+# (unreachable))
+# ))
 ```
 
 ---

--- a/packages/docs/src/content/docs/instructions/exceptions.md
+++ b/packages/docs/src/content/docs/instructions/exceptions.md
@@ -139,14 +139,18 @@ Catches exceptions with a specific tag and provides the exception reference.
 
 **Example:**
 
-```wat-snippet
+```wat
+# (module
+# (tag $error_tag (param i32))
+# (func $may_throw)
+# (func (result i32 exnref)
 (block $handler (result i32 exnref)
   (try_table (catch_ref $error_tag $handler)
     (call $may_throw)
-    (unreachable)
   )
+  (unreachable)
 )
-;; $handler receives payload and exnref for rethrowing
+# ))
 ```
 
 ---
@@ -157,14 +161,17 @@ Catches any exception and provides the exception reference.
 
 **Example:**
 
-```wat-snippet
+```wat
+# (module
+# (func $may_throw)
+# (func (result exnref)
 (block $handler (result exnref)
   (try_table (catch_all_ref $handler)
     (call $may_throw)
-    (unreachable)
   )
+  (unreachable)
 )
-;; Can rethrow with throw_ref
+# ))
 ```
 
 ---

--- a/packages/docs/src/content/docs/instructions/gc-array.md
+++ b/packages/docs/src/content/docs/instructions/gc-array.md
@@ -87,8 +87,13 @@ Create a new array from an element segment.
 
 **Example:**
 
-```wat-snippet
+```wat
+# (module
+# (type $my_array (array (mut funcref)))
+# (elem $elem_index funcref)
+# (func (result (ref $my_array))
 (array.new_elem $my_array $elem_index (i32.const 0) (i32.const 10))
+# ))
 ```
 
 ---
@@ -252,12 +257,13 @@ Initialize a portion of an array from a passive element segment. Takes the array
 
 **Example:**
 
-```wat-snippet
-(array.init_elem $funcref_array $elem_segment
-  (local.get $arr)     ;; array reference
-  (i32.const 0)        ;; destination offset in array
-  (i32.const 0)        ;; source offset in elem segment
-  (i32.const 10))      ;; number of elements to copy
+```wat
+# (module
+# (type $funcref_array (array (mut funcref)))
+# (elem $elem_index funcref)
+# (func (param $arr (ref $funcref_array))
+(array.init_elem $funcref_array $elem_index (local.get $arr) (i32.const 0) (i32.const 0) (i32.const 3))
+# ))
 ```
 
 ---

--- a/packages/docs/src/content/docs/instructions/gc-casts.md
+++ b/packages/docs/src/content/docs/instructions/gc-casts.md
@@ -63,8 +63,14 @@ Branch if a reference can be cast to a type.
 
 **Example:**
 
-```wat-snippet
-(br_on_cast $label (ref null $target_type) (local.get $ref))
+```wat
+# (module
+# (type $target_type (struct (field i32)))
+# (func (param $ref (ref null $target_type)) (result (ref $target_type))
+# (block $label (result (ref $target_type))
+(br_on_cast $label (ref null $target_type) (ref $target_type) (local.get $ref))
+# (unreachable))
+# ))
 ```
 
 ---
@@ -77,8 +83,14 @@ Branch if a reference cannot be cast to a type.
 
 **Example:**
 
-```wat-snippet
-(br_on_cast_fail $label (ref null $target_type) (local.get $ref))
+```wat
+# (module
+# (type $target_type (struct (field i32)))
+# (func (param $ref (ref null $target_type)) (result (ref null $target_type))
+# (block $label (result (ref null $target_type))
+(br_on_cast_fail $label (ref null $target_type) (ref $target_type) (local.get $ref))
+# (unreachable))
+# ))
 ```
 
 ---

--- a/packages/docs/src/content/docs/instructions/module.md
+++ b/packages/docs/src/content/docs/instructions/module.md
@@ -151,7 +151,8 @@ Declares linear memory for the module.
 
 **Example:**
 
-```wat-snippet
+```wat
+# (module
 ;; 1 page minimum
 (memory $mem 1)
 
@@ -160,6 +161,7 @@ Declares linear memory for the module.
 
 ;; Named export
 (memory (export "memory") 1)
+# )
 ```
 
 ---

--- a/packages/docs/src/content/docs/instructions/simd.md
+++ b/packages/docs/src/content/docs/instructions/simd.md
@@ -2307,8 +2307,10 @@ Lane-wise population count (number of set bits) of an i8x16 vector.
 
 **Example:**
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (i8x16.popcnt (local.get $a))
+# ))
 ```
 
 ---
@@ -2705,8 +2707,10 @@ Widen the low 8 lanes of an i8x16 vector to i16x8 with sign extension.
 
 **Example:**
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (i16x8.extend_low_i8x16_s (local.get $a))
+# ))
 ```
 
 ---
@@ -2719,8 +2723,10 @@ Widen the low 8 lanes of an i8x16 vector to i16x8 with zero extension.
 
 **Example:**
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (i16x8.extend_low_i8x16_u (local.get $a))
+# ))
 ```
 
 ---
@@ -2733,8 +2739,10 @@ Widen the high 8 lanes of an i8x16 vector to i16x8 with sign extension.
 
 **Example:**
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (i16x8.extend_high_i8x16_s (local.get $a))
+# ))
 ```
 
 ---
@@ -2747,8 +2755,10 @@ Widen the high 8 lanes of an i8x16 vector to i16x8 with zero extension.
 
 **Example:**
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (i16x8.extend_high_i8x16_u (local.get $a))
+# ))
 ```
 
 ---
@@ -2761,8 +2771,10 @@ Extended multiply: multiply low 8 lanes of two i8x16 vectors and widen to i16x8 
 
 **Example:**
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i16x8.extmul_low_i8x16_s (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -2775,8 +2787,10 @@ Extended multiply: multiply low 8 lanes of two i8x16 vectors and widen to i16x8 
 
 **Example:**
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i16x8.extmul_low_i8x16_u (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -2789,8 +2803,10 @@ Extended multiply: multiply high 8 lanes of two i8x16 vectors and widen to i16x8
 
 **Example:**
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i16x8.extmul_high_i8x16_s (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -2803,8 +2819,10 @@ Extended multiply: multiply high 8 lanes of two i8x16 vectors and widen to i16x8
 
 **Example:**
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i16x8.extmul_high_i8x16_u (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -2817,8 +2835,10 @@ Pairwise add adjacent i8x16 lanes and widen to i16x8 (signed).
 
 **Example:**
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (i16x8.extadd_pairwise_i8x16_s (local.get $a))
+# ))
 ```
 
 ---
@@ -2831,8 +2851,10 @@ Pairwise add adjacent i8x16 lanes and widen to i16x8 (unsigned).
 
 **Example:**
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (i16x8.extadd_pairwise_i8x16_u (local.get $a))
+# ))
 ```
 
 ---
@@ -2845,8 +2867,10 @@ Q15 fixed-point saturating rounding multiply of two i16x8 vectors.
 
 **Example:**
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i16x8.q15mulr_sat_s (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -2971,8 +2995,10 @@ Widen the low 4 lanes of an i16x8 vector to i32x4 with sign extension.
 
 **Example:**
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (i32x4.extend_low_i16x8_s (local.get $a))
+# ))
 ```
 
 ---
@@ -2985,8 +3011,10 @@ Widen the low 4 lanes of an i16x8 vector to i32x4 with zero extension.
 
 **Example:**
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (i32x4.extend_low_i16x8_u (local.get $a))
+# ))
 ```
 
 ---
@@ -2999,8 +3027,10 @@ Widen the high 4 lanes of an i16x8 vector to i32x4 with sign extension.
 
 **Example:**
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (i32x4.extend_high_i16x8_s (local.get $a))
+# ))
 ```
 
 ---
@@ -3013,8 +3043,10 @@ Widen the high 4 lanes of an i16x8 vector to i32x4 with zero extension.
 
 **Example:**
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (i32x4.extend_high_i16x8_u (local.get $a))
+# ))
 ```
 
 ---
@@ -3027,8 +3059,10 @@ Extended multiply: multiply low 4 lanes of two i16x8 vectors and widen to i32x4 
 
 **Example:**
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i32x4.extmul_low_i16x8_s (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -3041,8 +3075,10 @@ Extended multiply: multiply low 4 lanes of two i16x8 vectors and widen to i32x4 
 
 **Example:**
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i32x4.extmul_low_i16x8_u (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -3055,8 +3091,10 @@ Extended multiply: multiply high 4 lanes of two i16x8 vectors and widen to i32x4
 
 **Example:**
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i32x4.extmul_high_i16x8_s (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -3069,8 +3107,10 @@ Extended multiply: multiply high 4 lanes of two i16x8 vectors and widen to i32x4
 
 **Example:**
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i32x4.extmul_high_i16x8_u (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -3083,8 +3123,10 @@ Pairwise add adjacent i16x8 lanes and widen to i32x4 (signed).
 
 **Example:**
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (i32x4.extadd_pairwise_i16x8_s (local.get $a))
+# ))
 ```
 
 ---
@@ -3097,8 +3139,10 @@ Pairwise add adjacent i16x8 lanes and widen to i32x4 (unsigned).
 
 **Example:**
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (i32x4.extadd_pairwise_i16x8_u (local.get $a))
+# ))
 ```
 
 ---
@@ -3111,8 +3155,10 @@ Dot product: multiply pairs of i16x8 lanes and sum adjacent products to i32x4.
 
 **Example:**
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i32x4.dot_i16x8_s (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -3125,8 +3171,10 @@ Convert f64x2 to i32x4 with signed saturating truncation, zero-extending the upp
 
 **Example:**
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (i32x4.trunc_sat_f64x2_s_zero (local.get $a))
+# ))
 ```
 
 ---
@@ -3139,8 +3187,10 @@ Convert f64x2 to i32x4 with unsigned saturating truncation, zero-extending the u
 
 **Example:**
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (i32x4.trunc_sat_f64x2_u_zero (local.get $a))
+# ))
 ```
 
 ---
@@ -3201,8 +3251,10 @@ Lane-wise absolute value of an i64x2 vector.
 
 **Example:**
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (i64x2.abs (local.get $a))
+# ))
 ```
 
 ---
@@ -3215,8 +3267,10 @@ Returns 1 if all lanes are non-zero, 0 otherwise.
 
 **Example:**
 
-```wat-snippet
+```wat
+# (module (func (result i32) (local $a v128)
 (i64x2.all_true (local.get $a))
+# ))
 ```
 
 ---
@@ -3229,8 +3283,10 @@ Extract the high bit of each lane as an i32 bitmask.
 
 **Example:**
 
-```wat-snippet
+```wat
+# (module (func (result i32) (local $a v128)
 (i64x2.bitmask (local.get $a))
+# ))
 ```
 
 ---
@@ -3243,8 +3299,10 @@ Widen the low 2 lanes of an i32x4 vector to i64x2 with sign extension.
 
 **Example:**
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (i64x2.extend_low_i32x4_s (local.get $a))
+# ))
 ```
 
 ---
@@ -3257,8 +3315,10 @@ Widen the low 2 lanes of an i32x4 vector to i64x2 with zero extension.
 
 **Example:**
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (i64x2.extend_low_i32x4_u (local.get $a))
+# ))
 ```
 
 ---
@@ -3271,8 +3331,10 @@ Widen the high 2 lanes of an i32x4 vector to i64x2 with sign extension.
 
 **Example:**
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (i64x2.extend_high_i32x4_s (local.get $a))
+# ))
 ```
 
 ---
@@ -3285,8 +3347,10 @@ Widen the high 2 lanes of an i32x4 vector to i64x2 with zero extension.
 
 **Example:**
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (i64x2.extend_high_i32x4_u (local.get $a))
+# ))
 ```
 
 ---
@@ -3299,8 +3363,10 @@ Extended multiply: multiply low 2 lanes of two i32x4 vectors and widen to i64x2 
 
 **Example:**
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i64x2.extmul_low_i32x4_s (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -3313,8 +3379,10 @@ Extended multiply: multiply low 2 lanes of two i32x4 vectors and widen to i64x2 
 
 **Example:**
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i64x2.extmul_low_i32x4_u (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -3327,8 +3395,10 @@ Extended multiply: multiply high 2 lanes of two i32x4 vectors and widen to i64x2
 
 **Example:**
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i64x2.extmul_high_i32x4_s (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -3341,8 +3411,10 @@ Extended multiply: multiply high 2 lanes of two i32x4 vectors and widen to i64x2
 
 **Example:**
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128) (local $b v128)
 (i64x2.extmul_high_i32x4_u (local.get $a) (local.get $b))
+# ))
 ```
 
 ---
@@ -3355,8 +3427,10 @@ Demote f64x2 to f32x4, zero-extending the upper lanes.
 
 **Example:**
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (f32x4.demote_f64x2_zero (local.get $a))
+# ))
 ```
 
 ---
@@ -3369,8 +3443,10 @@ Convert the low 2 lanes of i32x4 to f64x2 (signed).
 
 **Example:**
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (f64x2.convert_low_i32x4_s (local.get $a))
+# ))
 ```
 
 ---
@@ -3383,8 +3459,10 @@ Convert the low 2 lanes of i32x4 to f64x2 (unsigned).
 
 **Example:**
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (f64x2.convert_low_i32x4_u (local.get $a))
+# ))
 ```
 
 ---
@@ -3397,8 +3475,10 @@ Promote the low 2 lanes of f32x4 to f64x2.
 
 **Example:**
 
-```wat-snippet
+```wat
+# (module (func (result v128) (local $a v128)
 (f64x2.promote_low_f32x4 (local.get $a))
+# ))
 ```
 
 ---

--- a/packages/docs/src/content/docs/instructions/types.md
+++ b/packages/docs/src/content/docs/instructions/types.md
@@ -11,10 +11,15 @@ sidebar:
 
 **Example:**
 
-```wat-snippet
+```wat
+# (module
+# (func
 (local $x i32)
+# )
 (global $counter (mut i32) (i32.const 0))
+# (func
 (param $value i32)
+# ))
 ```
 
 ---
@@ -25,9 +30,13 @@ sidebar:
 
 **Example:**
 
-```wat-snippet
+```wat
+# (module
+# (func
 (local $timestamp i64)
+# )
 (global $big_number i64 (i64.const 9223372036854775807))
+# )
 ```
 
 ---
@@ -38,9 +47,13 @@ sidebar:
 
 **Example:**
 
-```wat-snippet
+```wat
+# (module
+# (func
 (local $pi f32)
+# )
 (global $epsilon f32 (f32.const 1.1920929e-07))
+# )
 ```
 
 ---
@@ -51,9 +64,13 @@ sidebar:
 
 **Example:**
 
-```wat-snippet
+```wat
+# (module
+# (func
 (local $precise f64)
+# )
 (global $e f64 (f64.const 2.718281828459045))
+# )
 ```
 
 ---
@@ -64,9 +81,13 @@ sidebar:
 
 **Example:**
 
-```wat-snippet
+```wat
+# (module
+# (func
 (local $vec v128)
+# )
 (global $zeros v128 (v128.const i32x4 0 0 0 0))
+# )
 ```
 
 ---
@@ -202,9 +223,12 @@ Reference type for values that support equality comparison (GC proposal). Equiva
 
 **Example:**
 
-```wat-snippet
-(func $compare (param $a eqref) (param $b eqref) (result i32)
-  (ref.eq (local.get $a) (local.get $b)))
+```wat
+# (module
+(func (param $a eqref) (param $b eqref) (result i32)
+  (ref.eq (local.get $a) (local.get $b))
+)
+# )
 ```
 
 ---
@@ -300,13 +324,17 @@ Reference type for exception objects (exception handling proposal). Equivalent t
 
 **Example:**
 
-```wat-snippet
+```wat
+# (module
+# (func $may_throw)
+# (func (result exnref)
 (block $handler (result exnref)
   (try_table (catch_all_ref $handler)
     (call $may_throw)
-    (unreachable)
   )
+  (unreachable)
 )
+# ))
 ```
 
 ---

--- a/packages/docs/src/content/docs/language/subtyping.md
+++ b/packages/docs/src/content/docs/language/subtyping.md
@@ -77,7 +77,10 @@ Immutable fields are **covariant**: if `$sub` is a subtype of `$super`, then an 
 
 Mutable fields are **invariant**: the field type must match exactly, because the field can be both read and written.
 
-```wat-snippet
+```wat
+# (module
+# (type $string (sub (array (mut i8))))
+# (type $nonempty_str (sub $string (array (mut i8))))
 (type $animal (sub (struct
   (field $name (ref $string)))))       ;; immutable -- covariant
 
@@ -90,6 +93,7 @@ Mutable fields are **invariant**: the field type must match exactly, because the
 ;; Invalid: cannot narrow a mutable field
 ;; (type $pet_cell (sub $cell (struct
 ;;   (field $value (mut (ref $pet))))))  ;; NOT allowed
+# )
 ```
 
 ## The `final` keyword

--- a/packages/docs/tests/wat-examples.test.mjs
+++ b/packages/docs/tests/wat-examples.test.mjs
@@ -29,6 +29,67 @@ const KNOWN_LSP_ISSUES = new Set([
   'instructions/reference.md:105',
   'instructions/table.md:139',
   'instructions/types.md:204',
+
+  // Memory64: validator doesn't handle i64-addressed memories (#247)
+  'extensions/memory64.md:11',
+
+  // br_on_non_null: missing from grammar.js entirely (#247)
+  'instructions/control.md:392',
+
+  // GC array elem/data segment refs: checker confuses segment refs with type refs (#247)
+  'instructions/gc-array.md:91',
+  'instructions/gc-array.md:237',
+  'instructions/gc-array.md:261',
+
+  // GC cast type refs: checker treats type refs in br_on_cast as labels (#247)
+  'instructions/gc-casts.md:67',
+  'instructions/gc-casts.md:87',
+
+  // ref.eq / eqref: grammar gap or diagnostic checker issue (#247)
+  'instructions/gc-casts.md:107',
+  'instructions/types.md:227',
+
+  // SIMD extended ops: defined in grammar.js but parser.c never regenerated (#247)
+  'instructions/simd.md:2311',
+  'instructions/simd.md:2711',
+  'instructions/simd.md:2727',
+  'instructions/simd.md:2743',
+  'instructions/simd.md:2759',
+  'instructions/simd.md:2775',
+  'instructions/simd.md:2791',
+  'instructions/simd.md:2807',
+  'instructions/simd.md:2823',
+  'instructions/simd.md:2839',
+  'instructions/simd.md:2855',
+  'instructions/simd.md:2871',
+  'instructions/simd.md:2999',
+  'instructions/simd.md:3015',
+  'instructions/simd.md:3031',
+  'instructions/simd.md:3047',
+  'instructions/simd.md:3063',
+  'instructions/simd.md:3079',
+  'instructions/simd.md:3095',
+  'instructions/simd.md:3111',
+  'instructions/simd.md:3127',
+  'instructions/simd.md:3143',
+  'instructions/simd.md:3159',
+  'instructions/simd.md:3175',
+  'instructions/simd.md:3191',
+  'instructions/simd.md:3255',
+  'instructions/simd.md:3271',
+  'instructions/simd.md:3287',
+  'instructions/simd.md:3303',
+  'instructions/simd.md:3319',
+  'instructions/simd.md:3335',
+  'instructions/simd.md:3351',
+  'instructions/simd.md:3367',
+  'instructions/simd.md:3383',
+  'instructions/simd.md:3399',
+  'instructions/simd.md:3415',
+  'instructions/simd.md:3431',
+  'instructions/simd.md:3447',
+  'instructions/simd.md:3463',
+  'instructions/simd.md:3479',
 ]);
 
 /**


### PR DESCRIPTION
## Summary

- Strip hidden context lines (`# ` prefix) from hover code blocks in `build.rs`
- Convert 195 `wat-snippet` blocks to validated `wat` blocks with hidden module/function context across 11 files
- 16 blocks remain as `wat-snippet` where conversion is not possible (bare tokens, `...` placeholders, deliberately invalid code, mixed scopes, deprecated instructions, wast-incompatible aliases)