### PR TITLE
defrag: dedup resolve patterns, optimize allocations, tighten visibility

### DIFF
--- a/src/core/types.rs
+++ b/src/core/types.rs
@@ -176,7 +176,6 @@ pub enum DiagnosticSeverity {
 
 /// A diagnostic message (error, warning, etc.)
 #[derive(Debug, Clone)]
-#[cfg_attr(feature = "native", derive(Serialize, Deserialize))]
 pub struct Diagnostic {
     /// The range where the diagnostic applies
     pub range: Range,
@@ -185,9 +184,9 @@ pub struct Diagnostic {
     /// The diagnostic message
     pub message: String,
     /// Optional diagnostic code
-    pub code: Option<String>,
-    /// Optional source identifier (e.g., "wat-lsp")
-    pub source: Option<String>,
+    pub code: Option<&'static str>,
+    /// Source identifier
+    pub source: &'static str,
 }
 
 impl Diagnostic {
@@ -198,7 +197,7 @@ impl Diagnostic {
             severity: DiagnosticSeverity::Error,
             message: message.into(),
             code: None,
-            source: Some("wat-lsp".to_string()),
+            source: "wat-lsp",
         }
     }
 
@@ -209,7 +208,7 @@ impl Diagnostic {
             severity: DiagnosticSeverity::Warning,
             message: message.into(),
             code: None,
-            source: Some("wat-lsp".to_string()),
+            source: "wat-lsp",
         }
     }
 
@@ -220,13 +219,13 @@ impl Diagnostic {
             severity: DiagnosticSeverity::Hint,
             message: message.into(),
             code: None,
-            source: Some("wat-lsp".to_string()),
+            source: "wat-lsp",
         }
     }
 
     /// Set the diagnostic code
-    pub fn with_code(mut self, code: impl Into<String>) -> Self {
-        self.code = Some(code.into());
+    pub fn with_code(mut self, code: &'static str) -> Self {
+        self.code = Some(code);
         self
     }
 }
@@ -373,9 +372,11 @@ impl From<Diagnostic> for lsp::Diagnostic {
         lsp::Diagnostic {
             range: diag.range.into(),
             severity: Some(diag.severity.into()),
-            code: diag.code.map(lsp::NumberOrString::String),
+            code: diag
+                .code
+                .map(|c| lsp::NumberOrString::String(c.to_string())),
             code_description: None,
-            source: diag.source,
+            source: Some(diag.source.to_string()),
             message: diag.message,
             related_information: None,
             tags: None,

--- a/src/diagnostics/semantic_diagnostics.rs
+++ b/src/diagnostics/semantic_diagnostics.rs
@@ -1,4 +1,4 @@
-use crate::diagnostics_core::tree_walk::{walk_tree_for_diagnostics, DiagnosticConfig};
+use crate::diagnostics_core::collect_all_semantic_diagnostics;
 use crate::symbols::SymbolTable;
 use tower_lsp::lsp_types::*;
 use tree_sitter::Tree;
@@ -9,32 +9,10 @@ pub fn provide_semantic_diagnostics(
     source: &str,
     symbols: &SymbolTable,
 ) -> Vec<Diagnostic> {
-    let config = DiagnosticConfig::from_symbols(symbols);
-
-    // Single unified tree walk for all semantic checks (shared implementation)
-    let mut core_diagnostics = Vec::new();
-    walk_tree_for_diagnostics(
-        tree.root_node(),
-        source,
-        symbols,
-        &config,
-        &mut core_diagnostics,
-    );
-
-    // Validate subtype hierarchy
-    core_diagnostics.extend(crate::diagnostics_core::subtype::validate_subtype_hierarchy(symbols));
-
-    // Module-level structural validations
-    core_diagnostics.extend(
-        crate::diagnostics_core::module_checks::validate_module_structure(
-            &tree.root_node(),
-            source,
-            symbols,
-        ),
-    );
-
-    // Convert all core diagnostics to tower_lsp types
-    core_diagnostics.into_iter().map(Into::into).collect()
+    collect_all_semantic_diagnostics(tree.root_node(), source, symbols)
+        .into_iter()
+        .map(Into::into)
+        .collect()
 }
 
 #[cfg(test)]

--- a/src/diagnostics_core/alignment_checks.rs
+++ b/src/diagnostics_core/alignment_checks.rs
@@ -19,8 +19,12 @@ use crate::ts_facade::Node;
 /// - `align=N` where N is not a power of 2
 /// - `align=N` where N exceeds the instruction's natural alignment
 /// - `offset=N` where N exceeds u32::MAX for memory32 targets
-pub fn check_alignment(node: &Node, source: &str, symbols: &SymbolTable) -> Vec<Diagnostic> {
-    let mut diagnostics = Vec::new();
+pub(crate) fn check_alignment(
+    node: &Node,
+    source: &str,
+    symbols: &SymbolTable,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
     let mut instr_name: Option<&str> = None;
     let mut align_node = None;
     let mut offset_node = None;
@@ -62,13 +66,13 @@ pub fn check_alignment(node: &Node, source: &str, symbols: &SymbolTable) -> Vec<
 
     // Only check alignment if we have both a memory instruction and an align_value
     let (Some(instr), Some(align_nd)) = (instr_name, align_node) else {
-        return diagnostics;
+        return;
     };
 
     // Extract the numeric value (u64 to detect overflow)
     let align_val = parse_align_value_u64(&align_nd, source);
     let Some(align) = align_val else {
-        return diagnostics;
+        return;
     };
 
     // Check power of 2
@@ -77,7 +81,7 @@ pub fn check_alignment(node: &Node, source: &str, symbols: &SymbolTable) -> Vec<
             node_to_range(&align_nd),
             "alignment must be a power of 2",
         ));
-        return diagnostics;
+        return;
     }
 
     // Check against natural alignment
@@ -89,8 +93,6 @@ pub fn check_alignment(node: &Node, source: &str, symbols: &SymbolTable) -> Vec<
             ));
         }
     }
-
-    diagnostics
 }
 
 /// Parse the alignment value as u64 to detect values that overflow u32.

--- a/src/diagnostics_core/arity.rs
+++ b/src/diagnostics_core/arity.rs
@@ -15,14 +15,16 @@ use tree_sitter::Node;
 use crate::ts_facade::Node;
 
 /// Check if an instruction has the correct number of parameters (linear format)
-pub fn check_instruction_parameter_count(node: &Node, source: &str) -> Vec<Diagnostic> {
-    let mut diagnostics = Vec::new();
-
+pub(crate) fn check_instruction_parameter_count(
+    node: &Node,
+    source: &str,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
     let mut cursor = node.walk();
     let children: Vec<_> = node.children(&mut cursor).collect();
 
     if children.is_empty() {
-        return diagnostics;
+        return;
     }
 
     let first_child = &children[0];
@@ -39,14 +41,14 @@ pub fn check_instruction_parameter_count(node: &Node, source: &str) -> Vec<Diagn
                     k_ref == "index" || k_ref == "ref_type"
                 })
                 .count();
-            validate_instruction_arity(instr_name, param_count, node, &mut diagnostics);
+            validate_instruction_arity(instr_name, param_count, node, diagnostics);
         }
         "op_const" => {
             let mut op_const_cursor = first_child.walk();
             let op_const_children: Vec<_> = first_child.children(&mut op_const_cursor).collect();
 
             if op_const_children.is_empty() {
-                return diagnostics;
+                return;
             }
 
             let instr_name = source[op_const_children[0].byte_range()].trim();
@@ -58,7 +60,7 @@ pub fn check_instruction_parameter_count(node: &Node, source: &str) -> Vec<Diagn
                     matches!(k_ref, "int" | "float")
                 })
                 .count();
-            validate_instruction_arity(instr_name, param_count, node, &mut diagnostics);
+            validate_instruction_arity(instr_name, param_count, node, diagnostics);
         }
         "op_nullary" => {
             let instr_name = source[first_child.byte_range()].trim();
@@ -70,7 +72,7 @@ pub fn check_instruction_parameter_count(node: &Node, source: &str) -> Vec<Diagn
                     matches!(k_ref, "index" | "expr")
                 })
                 .count();
-            validate_instruction_arity(instr_name, param_count, node, &mut diagnostics);
+            validate_instruction_arity(instr_name, param_count, node, diagnostics);
         }
         k if k.starts_with("op_") => {
             let instr_name = source[first_child.byte_range()].trim();
@@ -82,12 +84,10 @@ pub fn check_instruction_parameter_count(node: &Node, source: &str) -> Vec<Diagn
                     k_ref == "index"
                 })
                 .count();
-            validate_instruction_arity(instr_name, param_count, node, &mut diagnostics);
+            validate_instruction_arity(instr_name, param_count, node, diagnostics);
         }
         _ => {}
     }
-
-    diagnostics
 }
 
 fn validate_instruction_arity(

--- a/src/diagnostics_core/folded_checks.rs
+++ b/src/diagnostics_core/folded_checks.rs
@@ -23,27 +23,26 @@ use crate::ts_facade::Node;
 
 /// Check operand count in folded expressions (expr1_plain nodes).
 ///
-/// Returns diagnostics for instructions with too many or too few operands.
-pub fn check_folded_operand_count(
+/// Pushes diagnostics for instructions with too many or too few operands.
+pub(crate) fn check_folded_operand_count(
     node: &Node,
     source: &str,
     symbols: &SymbolTable,
-) -> Vec<Diagnostic> {
-    let mut diagnostics = Vec::new();
-
+    diagnostics: &mut Vec<Diagnostic>,
+) {
     let mut cursor = node.walk();
 
     // First child should be instr_plain
     let first_child = match node.children(&mut cursor).next() {
         Some(c) if c.kind() == "instr_plain" => c,
-        _ => return diagnostics,
+        _ => return,
     };
 
     // Get the instruction name from instr_plain
     let mut instr_cursor = first_child.walk();
     let first_instr_child = match first_child.children(&mut instr_cursor).next() {
         Some(c) => c,
-        None => return diagnostics,
+        None => return,
     };
 
     let instr_kind = first_instr_child.kind();
@@ -53,7 +52,7 @@ pub fn check_folded_operand_count(
             let result = first_instr_child.children(&mut const_cursor).next();
             match result {
                 Some(c) => source[c.byte_range()].trim(),
-                None => return diagnostics,
+                None => return,
             }
         }
         _ => source[first_instr_child.byte_range()].trim(),
@@ -112,14 +111,12 @@ pub fn check_folded_operand_count(
                     deficit,
                     symbols,
                     source,
-                    &mut diagnostics,
+                    diagnostics,
                 );
             }
             _ => {}
         }
     }
-
-    diagnostics
 }
 
 /// Validate operand count for instructions with dynamic arity (call, throw, struct.new, call_ref, etc.)

--- a/src/diagnostics_core/gc_checks.rs
+++ b/src/diagnostics_core/gc_checks.rs
@@ -27,11 +27,12 @@ use crate::ts_facade::Node;
 /// - Named field not found in struct
 /// - `struct.get_s`/`struct.get_u` on non-packed field type
 /// - Type is not a struct (e.g., array used with struct.get)
-pub fn check_struct_field_access(
+pub(crate) fn check_struct_field_access(
     node: &Node,
     source: &str,
     symbols: &SymbolTable,
-) -> Vec<Diagnostic> {
+    diagnostics: &mut Vec<Diagnostic>,
+) {
     let text = &source[node.byte_range()];
     let first_token = text.split_whitespace().next().unwrap_or("");
 
@@ -39,34 +40,33 @@ pub fn check_struct_field_access(
         first_token,
         "struct.get" | "struct.get_s" | "struct.get_u" | "struct.set"
     ) {
-        return Vec::new();
+        return;
     }
 
     let (type_ref, field_ref) = match extract_two_indices(node, source) {
         Some(pair) => pair,
-        None => return Vec::new(),
+        None => return,
     };
 
     // Resolve type
     let type_def = match resolve_type_def(type_ref, symbols) {
         Some(td) => td,
-        None => return Vec::new(), // Undefined type caught by reference checker
+        None => return, // Undefined type caught by reference checker
     };
 
     let fields = match &type_def.kind {
         TypeKind::Struct { fields } => fields,
         _ => {
-            return vec![Diagnostic::error(
+            diagnostics.push(Diagnostic::error(
                 node_to_range(node),
                 format!(
                     "struct.get/set used on non-struct type {}",
                     type_ref_display(type_ref, type_def.index)
                 ),
-            )];
+            ));
+            return;
         }
     };
-
-    let mut diagnostics = Vec::new();
 
     // Resolve field index
     let field_idx = match resolve_field_index(field_ref, fields) {
@@ -83,7 +83,7 @@ pub fn check_struct_field_access(
                     format!("unknown field {}", idx),
                 ));
             }
-            return diagnostics;
+            return;
         }
     };
 
@@ -108,8 +108,6 @@ pub fn check_struct_field_access(
             diagnostics.push(Diagnostic::error(node_to_range(node), "immutable field"));
         }
     }
-
-    diagnostics
 }
 
 /// Extract two index children from a struct instruction node.
@@ -154,14 +152,7 @@ fn resolve_type_def<'a>(
     type_ref: &str,
     symbols: &'a SymbolTable,
 ) -> Option<&'a crate::symbols::TypeDef> {
-    if type_ref.starts_with('$') {
-        symbols.get_type_by_name(type_ref)
-    } else {
-        type_ref
-            .parse::<usize>()
-            .ok()
-            .and_then(|idx| symbols.get_type_by_index(idx))
-    }
+    symbols.resolve_type(type_ref)
 }
 
 /// Resolve a field reference to an index within the struct fields.

--- a/src/diagnostics_core/local_init.rs
+++ b/src/diagnostics_core/local_init.rs
@@ -27,17 +27,18 @@ pub(crate) fn check_uninitialized_locals(
     func_node: &Node,
     source: &str,
     symbols: &SymbolTable,
-) -> Vec<Diagnostic> {
+    diagnostics: &mut Vec<Diagnostic>,
+) {
     let func_line = func_node.start_position().row as u32;
     let func = match symbols.find_function_containing_line(func_line) {
         Some(f) => f,
-        None => return vec![],
+        None => return,
     };
 
     // Scan the AST to find which locals have non-defaultable (non-nullable ref) types
     let non_defaultable = find_non_defaultable_locals(func_node, source, func);
     if non_defaultable.is_empty() {
-        return vec![];
+        return;
     }
 
     // Initialize tracking: params are always initialized, defaultable locals are initialized
@@ -45,8 +46,6 @@ pub(crate) fn check_uninitialized_locals(
     let num_params = func.parameters.len();
     let total = num_params + func.locals.len();
     let mut initialized: Vec<bool> = (0..total).map(|i| !non_defaultable.contains(&i)).collect();
-
-    let mut diagnostics = Vec::new();
 
     // Find and walk the instr_list
     let mut cursor = func_node.walk();
@@ -59,13 +58,11 @@ pub(crate) fn check_uninitialized_locals(
                 func,
                 &non_defaultable,
                 &mut initialized,
-                &mut diagnostics,
+                diagnostics,
             );
             break;
         }
     }
-
-    diagnostics
 }
 
 /// Scan function AST for local declarations with non-nullable reference types.
@@ -458,7 +455,7 @@ mod tests {
         diagnostics: &mut Vec<Diagnostic>,
     ) {
         if node.kind() == "module_field_func" {
-            diagnostics.extend(check_uninitialized_locals(&node, source, symbols));
+            check_uninitialized_locals(&node, source, symbols, diagnostics);
         }
         let mut cursor = node.walk();
         for child in node.children(&mut cursor) {

--- a/src/diagnostics_core/memory_checks.rs
+++ b/src/diagnostics_core/memory_checks.rs
@@ -16,29 +16,32 @@ use tree_sitter::Node;
 use crate::ts_facade::Node;
 
 /// Check if an atomic operation is used on non-shared memory
-pub fn check_atomic_operation(node: &Node, first_token: &str) -> Vec<Diagnostic> {
+pub(crate) fn check_atomic_operation(
+    node: &Node,
+    first_token: &str,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
     if !is_atomic_memory_operation(first_token) {
-        return vec![];
+        return;
     }
 
-    vec![Diagnostic::warning(
+    diagnostics.push(Diagnostic::warning(
         node_to_range(node),
         format!(
             "Atomic operation '{}' requires shared memory. Declare memory with 'shared' keyword: (memory 1 1 shared)",
             first_token
         ),
-    )]
+    ));
 }
 
 /// Check memory64 hints for a specific instruction
-pub fn check_memory64_for_instruction(
+pub(crate) fn check_memory64_for_instruction(
     node: &Node,
     source: &str,
     symbols: &SymbolTable,
     first_token: &str,
-) -> Vec<Diagnostic> {
-    let mut diagnostics = Vec::new();
-
+    diagnostics: &mut Vec<Diagnostic>,
+) {
     // Check memory.size and memory.grow
     if first_token == "memory.size" || first_token == "memory.grow" {
         if let Some(memory) = get_memory_for_instruction(node, source, symbols) {
@@ -82,12 +85,10 @@ pub fn check_memory64_for_instruction(
             }
         }
     }
-
-    diagnostics
 }
 
 /// Check if an instruction is an atomic memory operation that requires shared memory
-pub fn is_atomic_memory_operation(instr: &str) -> bool {
+pub(crate) fn is_atomic_memory_operation(instr: &str) -> bool {
     if instr == "atomic.fence" {
         return false;
     }
@@ -119,7 +120,7 @@ fn get_memory_for_instruction<'a>(
 }
 
 /// Check if an instruction is a memory load or store operation
-pub fn is_memory_load_store(instr: &str) -> bool {
+pub(crate) fn is_memory_load_store(instr: &str) -> bool {
     if instr.ends_with(".load")
         || instr.contains(".load8_")
         || instr.contains(".load16_")

--- a/src/diagnostics_core/mod.rs
+++ b/src/diagnostics_core/mod.rs
@@ -24,3 +24,41 @@ pub(crate) use termination::sequence_always_terminates;
 // Re-export used by wasm/api.rs (appears unused under native-only compilation)
 #[cfg(all(feature = "wasm", not(feature = "native")))]
 pub(crate) use tree_sitter::provide_tree_sitter_diagnostics;
+
+use crate::core::types::Diagnostic;
+use crate::symbols::SymbolTable;
+
+/// Collect all semantic diagnostics (tree walk + subtype + module structure).
+/// Shared between native and WASM diagnostic pipelines.
+#[cfg(feature = "native")]
+pub(crate) fn collect_all_semantic_diagnostics(
+    root: ::tree_sitter::Node,
+    source: &str,
+    symbols: &SymbolTable,
+) -> Vec<Diagnostic> {
+    let config = tree_walk::DiagnosticConfig::from_symbols(symbols);
+    let mut diagnostics = Vec::new();
+    tree_walk::walk_tree_for_diagnostics(root, source, symbols, &config, &mut diagnostics);
+    diagnostics.extend(subtype::validate_subtype_hierarchy(symbols));
+    diagnostics.extend(module_checks::validate_module_structure(
+        &root, source, symbols,
+    ));
+    diagnostics
+}
+
+#[cfg(all(feature = "wasm", not(feature = "native")))]
+pub(crate) fn collect_all_semantic_diagnostics(
+    root: crate::ts_facade::Node,
+    source: &str,
+    symbols: &SymbolTable,
+) -> Vec<Diagnostic> {
+    let config = tree_walk::DiagnosticConfig::from_symbols(symbols);
+    let mut diagnostics = Vec::new();
+    // module_checks borrows root; walk_tree moves it (WASM Node is not Copy)
+    diagnostics.extend(module_checks::validate_module_structure(
+        &root, source, symbols,
+    ));
+    tree_walk::walk_tree_for_diagnostics(root, source, symbols, &config, &mut diagnostics);
+    diagnostics.extend(subtype::validate_subtype_hierarchy(symbols));
+    diagnostics
+}

--- a/src/diagnostics_core/module_checks.rs
+++ b/src/diagnostics_core/module_checks.rs
@@ -32,7 +32,7 @@ use crate::ts_facade::Node;
 // ============================================================================
 
 /// Validate module-level structure and return diagnostics.
-pub fn validate_module_structure(
+pub(crate) fn validate_module_structure(
     root: &Node,
     source: &str,
     symbols: &SymbolTable,
@@ -251,7 +251,7 @@ fn check_start_signature(
 // ============================================================================
 
 fn check_duplicate_exports(module: &Node, source: &str, diagnostics: &mut Vec<Diagnostic>) {
-    let mut seen_exports: HashMap<String, Range> = HashMap::new();
+    let mut seen_exports: HashMap<&str, Range> = HashMap::new();
 
     for_each_module_field(module, |field| {
         node_kind!(fk = field);
@@ -300,20 +300,20 @@ fn extract_name_child<'a>(node: &Node, source: &'a str) -> Option<&'a str> {
     None
 }
 
-fn check_export_name(
-    name: &str,
+fn check_export_name<'a>(
+    name: &'a str,
     node: &Node,
-    seen: &mut HashMap<String, Range>,
+    seen: &mut HashMap<&'a str, Range>,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
     let range = node_to_range(node);
-    if let Some(_first) = seen.get(name) {
+    if seen.contains_key(name) {
         diagnostics.push(Diagnostic::error(
             range,
             format!("Duplicate export name \"{}\"", name),
         ));
     } else {
-        seen.insert(name.to_string(), range);
+        seen.insert(name, range);
     }
 }
 
@@ -391,12 +391,12 @@ pub(super) fn has_inline_import(node: &Node) -> bool {
 // ============================================================================
 
 fn check_duplicate_identifiers(module: &Node, source: &str, diagnostics: &mut Vec<Diagnostic>) {
-    let mut seen_func: HashMap<String, Range> = HashMap::new();
-    let mut seen_global: HashMap<String, Range> = HashMap::new();
-    let mut seen_table: HashMap<String, Range> = HashMap::new();
-    let mut seen_memory: HashMap<String, Range> = HashMap::new();
-    let mut seen_type: HashMap<String, Range> = HashMap::new();
-    let mut seen_tag: HashMap<String, Range> = HashMap::new();
+    let mut seen_func: HashMap<&str, Range> = HashMap::new();
+    let mut seen_global: HashMap<&str, Range> = HashMap::new();
+    let mut seen_table: HashMap<&str, Range> = HashMap::new();
+    let mut seen_memory: HashMap<&str, Range> = HashMap::new();
+    let mut seen_type: HashMap<&str, Range> = HashMap::new();
+    let mut seen_tag: HashMap<&str, Range> = HashMap::new();
 
     for_each_module_field(module, |field| {
         node_kind!(fk = field);
@@ -455,10 +455,10 @@ fn check_duplicate_identifiers(module: &Node, source: &str, diagnostics: &mut Ve
     });
 }
 
-fn check_identifier_dup(
+fn check_identifier_dup<'a>(
     node: &Node,
-    source: &str,
-    seen: &mut HashMap<String, Range>,
+    source: &'a str,
+    seen: &mut HashMap<&'a str, Range>,
     kind_name: &str,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
@@ -466,27 +466,27 @@ fn check_identifier_dup(
         let name = node_text(&id_node, source);
         if name.starts_with('$') {
             let range = node_to_range(&id_node);
-            if let Some(_first) = seen.get(name) {
+            if seen.contains_key(name) {
                 diagnostics.push(Diagnostic::error(
                     range,
                     format!("Duplicate {} identifier {}", kind_name, name),
                 ));
             } else {
-                seen.insert(name.to_string(), range);
+                seen.insert(name, range);
             }
         }
     }
 }
 
 #[allow(clippy::too_many_arguments)]
-fn check_import_identifier_dup(
+fn check_import_identifier_dup<'a>(
     import_node: &Node,
-    source: &str,
-    seen_func: &mut HashMap<String, Range>,
-    seen_global: &mut HashMap<String, Range>,
-    seen_table: &mut HashMap<String, Range>,
-    seen_memory: &mut HashMap<String, Range>,
-    seen_tag: &mut HashMap<String, Range>,
+    source: &'a str,
+    seen_func: &mut HashMap<&'a str, Range>,
+    seen_global: &mut HashMap<&'a str, Range>,
+    seen_table: &mut HashMap<&'a str, Range>,
+    seen_memory: &mut HashMap<&'a str, Range>,
+    seen_tag: &mut HashMap<&'a str, Range>,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
     let mut cursor = import_node.walk();
@@ -549,15 +549,15 @@ fn check_duplicate_struct_fields(
     source: &str,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
-    let mut seen_fields: HashMap<String, Range> = HashMap::new();
+    let mut seen_fields: HashMap<&str, Range> = HashMap::new();
     find_struct_and_check_fields(type_node, source, &mut seen_fields, diagnostics);
 }
 
 /// Recursively find struct_type nodes and check their fields for duplicates.
-fn find_struct_and_check_fields(
+fn find_struct_and_check_fields<'a>(
     node: &Node,
-    source: &str,
-    seen: &mut HashMap<String, Range>,
+    source: &'a str,
+    seen: &mut HashMap<&'a str, Range>,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
     let mut cursor = node.walk();
@@ -572,10 +572,10 @@ fn find_struct_and_check_fields(
 }
 
 /// Collect and check named fields in a struct for duplicates.
-fn collect_struct_field_names(
+fn collect_struct_field_names<'a>(
     node: &Node,
-    source: &str,
-    seen: &mut HashMap<String, Range>,
+    source: &'a str,
+    seen: &mut HashMap<&'a str, Range>,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
     let mut cursor = node.walk();
@@ -588,13 +588,13 @@ fn collect_struct_field_names(
                 if inner_child.kind() == "identifier" {
                     let name = node_text(&inner_child, source);
                     let range = node_to_range(&inner_child);
-                    if let Some(_first) = seen.get(name) {
+                    if seen.contains_key(name) {
                         diagnostics.push(Diagnostic::error(
                             range,
                             format!("duplicate field {}", name),
                         ));
                     } else {
-                        seen.insert(name.to_string(), range);
+                        seen.insert(name, range);
                     }
                 }
             }
@@ -691,27 +691,16 @@ fn resolve_type_use<'a>(
         node_kind!(ck = child);
         if ck == "index" {
             let text = node_text(&child, source);
-            // Try as name reference
-            if text.starts_with('$') {
-                return symbols.get_type_by_name(text);
+            if let Some(td) = symbols.resolve_type(text) {
+                return Some(td);
             }
-            // Try as numeric index
-            if let Ok(idx) = text.parse::<usize>() {
-                return symbols.get_type_by_index(idx);
-            }
-            // Index may contain an identifier child
+            // Index may contain an identifier or nat child
             let mut ic = child.walk();
             for idx_child in child.children(&mut ic) {
                 node_kind!(ik = idx_child);
-                if ik == "identifier" {
-                    let id_text = node_text(&idx_child, source);
-                    return symbols.get_type_by_name(id_text);
-                }
-                if ik == "nat" {
-                    let nat_text = node_text(&idx_child, source);
-                    if let Ok(idx) = nat_text.parse::<usize>() {
-                        return symbols.get_type_by_index(idx);
-                    }
+                if ik == "identifier" || ik == "nat" {
+                    let child_text = node_text(&idx_child, source);
+                    return symbols.resolve_type(child_text);
                 }
             }
         }
@@ -1754,17 +1743,20 @@ fn check_ref_func_target(
 // ============================================================================
 
 /// Check that end labels match opening labels on block/loop/if statements.
-pub fn check_block_label_mismatch(node: &Node, source: &str) -> Vec<Diagnostic> {
-    let mut diagnostics = Vec::new();
+pub(crate) fn check_block_label_mismatch(
+    node: &Node,
+    source: &str,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
     node_kind!(kind = node);
 
     if !matches!(kind, "block_block" | "block_loop" | "block_if") {
-        return diagnostics;
+        return;
     }
 
     let child_count = node.child_count();
     if child_count == 0 {
-        return diagnostics;
+        return;
     }
 
     // Single-pass: find opening label and check end/else labels
@@ -1790,7 +1782,7 @@ pub fn check_block_label_mismatch(node: &Node, source: &str) -> Vec<Diagnostic> 
                         &end_label,
                         &child,
                         "end",
-                        &mut diagnostics,
+                        diagnostics,
                     );
                 } else if after_else {
                     let else_label = normalize_identifier(node_text(&child, source));
@@ -1799,7 +1791,7 @@ pub fn check_block_label_mismatch(node: &Node, source: &str) -> Vec<Diagnostic> 
                         &else_label,
                         &child,
                         "else",
-                        &mut diagnostics,
+                        diagnostics,
                     );
                 }
                 after_end = false;
@@ -1826,8 +1818,6 @@ pub fn check_block_label_mismatch(node: &Node, source: &str) -> Vec<Diagnostic> 
             }
         }
     }
-
-    diagnostics
 }
 
 fn check_label_match(
@@ -3519,7 +3509,7 @@ mod tests {
     ) {
         let kind = node.kind();
         if matches!(kind, "block_block" | "block_loop" | "block_if") {
-            diags.extend(check_block_label_mismatch(&node, source));
+            check_block_label_mismatch(&node, source, diags);
         }
         let mut cursor = node.walk();
         for child in node.children(&mut cursor) {

--- a/src/diagnostics_core/references.rs
+++ b/src/diagnostics_core/references.rs
@@ -19,12 +19,12 @@ use crate::ts_facade::Node;
 /// Check references in a catch_clause node (try_table syntax)
 /// For (catch $tag $label) and (catch_ref $tag $label): first index is tag, second is label
 /// For (catch_all $label) and (catch_all_ref $label): single index is label
-pub fn check_catch_clause_references(
+pub(crate) fn check_catch_clause_references(
     node: &Node,
     source: &str,
     symbols: &SymbolTable,
-) -> Vec<Diagnostic> {
-    let mut diagnostics = Vec::new();
+    diagnostics: &mut Vec<Diagnostic>,
+) {
     let text = &source[node.byte_range()];
 
     // Determine if this is catch/catch_ref (has tag) or catch_all/catch_all_ref (no tag)
@@ -49,30 +49,27 @@ pub fn check_catch_clause_references(
         } else {
             InstructionContext::Branch
         };
-        diagnostics.extend(find_undefined_identifiers(
-            index_node, source, symbols, &context,
-        ));
+        find_undefined_identifiers(index_node, source, symbols, &context, diagnostics);
     }
-
-    diagnostics
 }
 
 /// Check the first index child of a node against the given instruction context.
 /// Used for nodes that contain a single index reference (start, try_catch, try_delegate).
-pub fn check_first_index_reference(
+pub(crate) fn check_first_index_reference(
     node: &Node,
     source: &str,
     symbols: &SymbolTable,
     context: &InstructionContext,
-) -> Vec<Diagnostic> {
+    diagnostics: &mut Vec<Diagnostic>,
+) {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         node_kind!(kind = child);
         if kind == "index" {
-            return find_undefined_identifiers(&child, source, symbols, context);
+            find_undefined_identifiers(&child, source, symbols, context, diagnostics);
+            return;
         }
     }
-    vec![]
 }
 
 /// Find and validate only the first index identifier in a node
@@ -82,25 +79,23 @@ fn find_first_index_identifier(
     source: &str,
     symbols: &SymbolTable,
     context: &InstructionContext,
-) -> Vec<Diagnostic> {
-    let mut diagnostics = Vec::new();
-
+    diagnostics: &mut Vec<Diagnostic>,
+) {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         node_kind!(kind = child);
 
         if kind == "index" {
             // Found the first index, check its identifier
-            diagnostics.extend(find_undefined_identifiers(&child, source, symbols, context));
-            return diagnostics; // Only check the first one
+            find_undefined_identifiers(&child, source, symbols, context, diagnostics);
+            return; // Only check the first one
         }
         // Recurse into instr_plain to find the index
         if kind == "instr_plain" {
-            return find_first_index_identifier(&child, source, symbols, context);
+            find_first_index_identifier(&child, source, symbols, context, diagnostics);
+            return;
         }
     }
-
-    diagnostics
 }
 
 /// Recursively find identifier nodes and check if they're defined
@@ -109,9 +104,8 @@ fn find_undefined_identifiers(
     source: &str,
     symbols: &SymbolTable,
     context: &InstructionContext,
-) -> Vec<Diagnostic> {
-    let mut diagnostics = Vec::new();
-
+    diagnostics: &mut Vec<Diagnostic>,
+) {
     node_kind!(kind = node);
 
     if kind == "identifier" {
@@ -119,7 +113,7 @@ fn find_undefined_identifiers(
 
         // Only check identifiers that start with $
         if !raw_name.starts_with('$') {
-            return diagnostics;
+            return;
         }
 
         // Normalize quoted identifiers: $"fh" → $fh
@@ -205,7 +199,7 @@ fn find_undefined_identifiers(
             let diagnostic = create_undefined_reference_diagnostic(node, identifier_name, context);
             diagnostics.push(diagnostic);
         }
-        return diagnostics;
+        return;
     }
 
     // Check numeric indices (nat nodes inside index parents)
@@ -267,31 +261,30 @@ fn find_undefined_identifiers(
                 }
             }
         }
-        return diagnostics;
+        return;
     }
 
     // Don't recurse into nested expr nodes - they contain nested instructions
     // that will be checked separately with their own context
     if kind == "expr" {
-        return diagnostics;
+        return;
     }
 
     // Recursively check children (but not nested expressions)
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        diagnostics.extend(find_undefined_identifiers(&child, source, symbols, context));
+        find_undefined_identifiers(&child, source, symbols, context, diagnostics);
     }
-
-    diagnostics
 }
 
 /// Check if references in this instruction are defined
-pub fn check_references(
+pub(crate) fn check_references(
     node: &Node,
     source: &str,
     symbols: &SymbolTable,
     context: &InstructionContext,
-) -> Vec<Diagnostic> {
+    diagnostics: &mut Vec<Diagnostic>,
+) {
     let text = &source[node.byte_range()];
     let first_token = text.split_whitespace().next().unwrap_or("");
 
@@ -299,7 +292,8 @@ pub fn check_references(
     // The second index is a field reference which we don't validate yet
     if *context == InstructionContext::Type && STRUCT_OPS.contains(&first_token) {
         // Only validate the first index child
-        return find_first_index_identifier(node, source, symbols, context);
+        find_first_index_identifier(node, source, symbols, context, diagnostics);
+        return;
     }
 
     // Multi-index instructions: table.init / memory.init
@@ -312,42 +306,55 @@ pub fn check_references(
         } else {
             InstructionContext::Memory
         };
-        return check_init_instruction(node, source, symbols, context, &secondary);
+        check_init_instruction(node, source, symbols, context, &secondary, diagnostics);
+        return;
     }
 
     // memory.copy and table.copy take two indices of the same context (dest, src)
     if first_token == "memory.copy" || first_token == "table.copy" {
-        return check_multi_index_instruction(node, source, symbols, context, context);
+        check_multi_index_instruction(node, source, symbols, context, context, diagnostics);
+        return;
     }
 
     // array.new_data / array.init_data: first index is Type, second is Data
     if first_token == "array.new_data" || first_token == "array.init_data" {
-        return check_multi_index_instruction(
+        check_multi_index_instruction(
             node,
             source,
             symbols,
             &InstructionContext::Type,
             &InstructionContext::Data,
+            diagnostics,
         );
+        return;
     }
 
     // array.new_elem / array.init_elem: first index is Type, second is Elem
     if first_token == "array.new_elem" || first_token == "array.init_elem" {
-        return check_multi_index_instruction(
+        check_multi_index_instruction(
             node,
             source,
             symbols,
             &InstructionContext::Type,
             &InstructionContext::Elem,
+            diagnostics,
         );
+        return;
     }
 
     // br_on_cast / br_on_cast_fail: first index is Branch, rest are heap types (not validated)
     if first_token == "br_on_cast" || first_token == "br_on_cast_fail" {
-        return check_first_index_reference(node, source, symbols, &InstructionContext::Branch);
+        check_first_index_reference(
+            node,
+            source,
+            symbols,
+            &InstructionContext::Branch,
+            diagnostics,
+        );
+        return;
     }
 
-    find_undefined_identifiers(node, source, symbols, context)
+    find_undefined_identifiers(node, source, symbols, context, diagnostics);
 }
 
 /// Check table.init / memory.init where the index order depends on count:
@@ -359,14 +366,14 @@ fn check_init_instruction(
     symbols: &SymbolTable,
     primary_context: &InstructionContext,   // Elem or Data
     secondary_context: &InstructionContext, // Table or Memory
-) -> Vec<Diagnostic> {
+    diagnostics: &mut Vec<Diagnostic>,
+) {
     // Count indices first
     let mut total_indices = 0usize;
     find_indices_recursive(node, &mut |_| {
         total_indices += 1;
     });
 
-    let mut diagnostics = Vec::new();
     let mut index_count = 0usize;
     find_indices_recursive(node, &mut |index_node| {
         let ctx = if total_indices == 1 {
@@ -379,11 +386,9 @@ fn check_init_instruction(
             // Full form: second is primary (elem/data)
             primary_context
         };
-        diagnostics.extend(find_undefined_identifiers(index_node, source, symbols, ctx));
+        find_undefined_identifiers(index_node, source, symbols, ctx, diagnostics);
         index_count += 1;
     });
-
-    diagnostics
 }
 
 /// Check a multi-index instruction where the first and second index have different contexts.
@@ -393,8 +398,8 @@ fn check_multi_index_instruction(
     symbols: &SymbolTable,
     first_context: &InstructionContext,
     second_context: &InstructionContext,
-) -> Vec<Diagnostic> {
-    let mut diagnostics = Vec::new();
+    diagnostics: &mut Vec<Diagnostic>,
+) {
     let mut index_count = 0;
 
     // Walk the node tree to find index nodes. They may be nested several
@@ -405,11 +410,9 @@ fn check_multi_index_instruction(
         } else {
             second_context
         };
-        diagnostics.extend(find_undefined_identifiers(index_node, source, symbols, ctx));
+        find_undefined_identifiers(index_node, source, symbols, ctx, diagnostics);
         index_count += 1;
     });
-
-    diagnostics
 }
 
 /// Recursively find all `index` nodes within instruction wrapper nodes.
@@ -462,11 +465,12 @@ fn create_undefined_reference_diagnostic(
 /// These are module-level constructs that reference symbols (functions, globals, tables,
 /// memories, tags) but aren't inside instructions, so the normal instruction-context
 /// checking doesn't cover them.
-pub fn check_module_level_references(
+pub(crate) fn check_module_level_references(
     node: &Node,
     source: &str,
     symbols: &SymbolTable,
-) -> Vec<Diagnostic> {
+    diagnostics: &mut Vec<Diagnostic>,
+) {
     node_kind!(kind = node);
 
     let context = match &*kind {
@@ -483,7 +487,6 @@ pub fn check_module_level_references(
             // module_field_elem: in the abbreviated form `(elem (offset) $a $b)`, bare
             //   index nodes appear directly under module_field_elem without an elem_list.
             //   The first index child (before offset) is the elem segment's own name — skip it.
-            let mut diagnostics = Vec::new();
             let mut cursor = node.walk();
             let is_field = &*kind == "module_field_elem";
             let mut seen_offset = false;
@@ -505,16 +508,17 @@ pub fn check_module_level_references(
                     continue;
                 }
 
-                diagnostics.extend(find_undefined_identifiers(
+                find_undefined_identifiers(
                     &child,
                     source,
                     symbols,
                     &InstructionContext::Call,
-                ));
+                    diagnostics,
+                );
             }
-            return diagnostics;
+            return;
         }
-        _ => return vec![],
+        _ => return,
     };
 
     // For export descriptors and table_use/memory_use, find the index child
@@ -524,15 +528,14 @@ pub fn check_module_level_references(
         node_kind!(child_kind = child);
 
         if child_kind == "index" {
-            return find_undefined_identifiers(&child, source, symbols, &context);
+            find_undefined_identifiers(&child, source, symbols, &context, diagnostics);
+            return;
         }
     }
-
-    vec![]
 }
 
 /// Check if a node is nested inside another expr (meaning it can't use stack values)
-pub fn is_nested_in_expr(node: &Node) -> bool {
+pub(crate) fn is_nested_in_expr(node: &Node) -> bool {
     let mut current = node.parent();
     while let Some(parent) = current {
         node_kind!(kind = parent);

--- a/src/diagnostics_core/semantic.rs
+++ b/src/diagnostics_core/semantic.rs
@@ -12,6 +12,8 @@
 // but is a no-op for native (&str -> &str)
 #![allow(clippy::useless_asref)]
 
+use std::borrow::Cow;
+
 use crate::core::types::Diagnostic;
 use crate::instruction_metadata::{
     infer_simd_instruction_arity, is_terminating_instruction, lookup_instruction_arity, OperandMode,
@@ -73,31 +75,42 @@ fn simd_splat_input_type(name: &str) -> ValueType {
     }
 }
 
+/// Check if a node kind represents an inner block wrapper (block/loop/if/try).
+fn is_inner_block_kind(kind: &str) -> bool {
+    matches!(
+        kind,
+        "block_block" | "block_loop" | "if_block" | "block_if" | "block_try_table" | "block_try"
+    )
+}
+
 /// Derive consumed types for SIMD lane instructions (i8x16.*, i16x8.*, i32x4.*, i64x2.*, f32x4.*, f64x2.*).
-fn derive_simd_consumed_types(name: &str) -> Option<Vec<ValueType>> {
+fn derive_simd_consumed_types(name: &str) -> Option<Cow<'static, [ValueType]>> {
     // Splat: scalar -> v128
     if name.ends_with(".splat") {
-        return Some(vec![simd_splat_input_type(name)]);
+        return Some(Cow::Owned(vec![simd_splat_input_type(name)]));
     }
 
     // Extract lane: v128 -> scalar (lane index is immediate, not stack operand)
     if name.contains(".extract_lane") {
-        return Some(vec![ValueType::V128]);
+        return Some(Cow::Borrowed(&[ValueType::V128]));
     }
 
     // Replace lane: v128 + scalar -> v128
     if name.contains(".replace_lane") {
-        return Some(vec![ValueType::V128, simd_splat_input_type(name)]);
+        return Some(Cow::Owned(vec![
+            ValueType::V128,
+            simd_splat_input_type(name),
+        ]));
     }
 
     // Reductions: v128 -> i32
     if name.ends_with(".all_true") || name.ends_with(".bitmask") {
-        return Some(vec![ValueType::V128]);
+        return Some(Cow::Borrowed(&[ValueType::V128]));
     }
 
     // Shift operations: v128 + i32 -> v128
     if name.ends_with(".shl") || name.ends_with(".shr_s") || name.ends_with(".shr_u") {
-        return Some(vec![ValueType::V128, ValueType::I32]);
+        return Some(Cow::Borrowed(&[ValueType::V128, ValueType::I32]));
     }
 
     // Unary ops: v128 -> v128
@@ -118,7 +131,7 @@ fn derive_simd_consumed_types(name: &str) -> Option<Vec<ValueType>> {
         || name.contains(".demote_")
         || name.contains(".extadd_pairwise_")
     {
-        return Some(vec![ValueType::V128]);
+        return Some(Cow::Borrowed(&[ValueType::V128]));
     }
 
     // Ternary relaxed SIMD ops: (v128, v128, v128) -> v128
@@ -127,41 +140,45 @@ fn derive_simd_consumed_types(name: &str) -> Option<Vec<ValueType>> {
         || name.contains(".relaxed_laneselect")
         || name.contains(".relaxed_dot_i8x16_i7x16_add")
     {
-        return Some(vec![ValueType::V128, ValueType::V128, ValueType::V128]);
+        return Some(Cow::Borrowed(&[
+            ValueType::V128,
+            ValueType::V128,
+            ValueType::V128,
+        ]));
     }
 
     // Unary relaxed SIMD ops
     if name.contains(".relaxed_trunc") {
-        return Some(vec![ValueType::V128]);
+        return Some(Cow::Borrowed(&[ValueType::V128]));
     }
 
     // i8x16.shuffle: (v128, v128) -> v128 (lane indices are immediates)
     if name == "i8x16.shuffle" {
-        return Some(vec![ValueType::V128, ValueType::V128]);
+        return Some(Cow::Borrowed(&[ValueType::V128, ValueType::V128]));
     }
 
     // Narrow operations: (v128, v128) -> v128
     if name.contains(".narrow_") {
-        return Some(vec![ValueType::V128, ValueType::V128]);
+        return Some(Cow::Borrowed(&[ValueType::V128, ValueType::V128]));
     }
 
     // Swizzle: (v128, v128) -> v128
     if name.ends_with(".swizzle") || name.contains(".relaxed_swizzle") {
-        return Some(vec![ValueType::V128, ValueType::V128]);
+        return Some(Cow::Borrowed(&[ValueType::V128, ValueType::V128]));
     }
 
     // Dot product: (v128, v128) -> v128
     if name.contains(".dot_") {
-        return Some(vec![ValueType::V128, ValueType::V128]);
+        return Some(Cow::Borrowed(&[ValueType::V128, ValueType::V128]));
     }
 
     // Extmul: (v128, v128) -> v128
     if name.contains(".extmul_") {
-        return Some(vec![ValueType::V128, ValueType::V128]);
+        return Some(Cow::Borrowed(&[ValueType::V128, ValueType::V128]));
     }
 
-    // Default: binary ops (v128, v128) -> v128 (add, sub, mul, min, max, eq, ne, lt, gt, le, ge, etc.)
-    Some(vec![ValueType::V128, ValueType::V128])
+    // Default: binary ops (v128, v128) -> v128
+    Some(Cow::Borrowed(&[ValueType::V128, ValueType::V128]))
 }
 
 /// Track stack state through an instruction list and report underflow/type errors.
@@ -169,7 +186,7 @@ fn derive_simd_consumed_types(name: &str) -> Option<Vec<ValueType>> {
 /// Returns diagnostics as core::types::Diagnostic.
 ///
 /// Uses TypeChecker with typed value stack + control stack per Wasm spec §3.3.
-pub fn track_stack_in_instr_list(
+pub(crate) fn track_stack_in_instr_list(
     instr_list: &Node,
     source: &str,
     symbols: &SymbolTable,
@@ -440,13 +457,7 @@ fn get_block_label(node: &Node, source: &str) -> Option<String> {
             return Some(source[child.byte_range()].trim().to_string());
         }
         // Check inside block_block, loop_block, block_if, block_try_table, etc.
-        let is_inner_block = kind == "block_block"
-            || kind == "block_loop"
-            || kind == "if_block"
-            || kind == "block_if"
-            || kind == "block_try_table"
-            || kind == "block_try";
-        if is_inner_block {
+        if is_inner_block_kind(kind) {
             let mut inner_cursor = child.walk();
             for inner_child in child.children(&mut inner_cursor) {
                 node_kind!(ik = inner_child);
@@ -507,7 +518,7 @@ fn is_try_table_node(node: &Node) -> bool {
 
 /// Get the instruction name from an instr_plain node.
 /// Returns a borrowed slice from `source`, avoiding allocation.
-pub fn get_instruction_name<'a>(instr_node: &Node, source: &'a str) -> Option<&'a str> {
+pub(crate) fn get_instruction_name<'a>(instr_node: &Node, source: &'a str) -> Option<&'a str> {
     let mut cursor = instr_node.walk();
     for child in instr_node.children(&mut cursor) {
         node_kind!(kind = child);
@@ -841,15 +852,7 @@ fn process_instruction(
     // Check global.set targets a mutable global
     if instr_name == "global.set" {
         if let Some(index) = get_index_from_node(node, source) {
-            let is_immutable = if let Some(global) = symbols.get_global_by_name(index) {
-                !global.is_mutable
-            } else if let Ok(idx) = index.parse::<usize>() {
-                symbols
-                    .get_global_by_index(idx)
-                    .is_some_and(|g| !g.is_mutable)
-            } else {
-                false
-            };
+            let is_immutable = symbols.resolve_global(index).is_some_and(|g| !g.is_mutable);
             if is_immutable {
                 checker.diagnostics.push(
                     Diagnostic::error(node_to_range(node), "global is immutable")
@@ -897,7 +900,7 @@ fn get_instruction_consumed_types(
     instr_name: &str,
     symbols: &SymbolTable,
     source: &str,
-) -> Vec<ValueType> {
+) -> Cow<'static, [ValueType]> {
     // Try pattern-based type derivation first
     if let Some(types) = derive_consumed_types_from_name(instr_name, node, symbols, source) {
         return types;
@@ -912,10 +915,10 @@ fn get_instruction_consumed_types(
     } else if let Some((c, _p)) = infer_simd_instruction_arity(instr_name) {
         c
     } else {
-        return vec![];
+        return Cow::Borrowed(&[]);
     };
 
-    vec![ValueType::Unknown; count]
+    Cow::Owned(vec![ValueType::Unknown; count])
 }
 
 /// Derive typed consumed operands from instruction name pattern.
@@ -925,7 +928,7 @@ fn derive_consumed_types_from_name(
     node: &Node,
     symbols: &SymbolTable,
     source: &str,
-) -> Option<Vec<ValueType>> {
+) -> Option<Cow<'static, [ValueType]>> {
     // Helper to check if an instruction is a scalar binary op (2 operands of prefix type)
     let is_binary_scalar = |name: &str| -> bool {
         if is_simd_instruction(name) {
@@ -973,53 +976,52 @@ fn derive_consumed_types_from_name(
 
     match instr_name {
         // Constants — consume nothing
-        "i32.const" | "i64.const" | "f32.const" | "f64.const" | "v128.const" => Some(vec![]),
+        "i32.const" | "i64.const" | "f32.const" | "f64.const" | "v128.const" => {
+            Some(Cow::Borrowed(&[]))
+        }
 
         // Nop, unreachable — consume nothing
-        "nop" | "unreachable" => Some(vec![]),
+        "nop" | "unreachable" => Some(Cow::Borrowed(&[])),
 
         // Drop — consume any one value
-        "drop" => Some(vec![ValueType::Unknown]),
+        "drop" => Some(Cow::Borrowed(&[ValueType::Unknown])),
 
         // Select — 2 same-type values + i32 condition
         // Typed select: (select (result T)) uses declared type for operands
         "select" => {
             let ty = get_select_result_type(node, source).unwrap_or(ValueType::Unknown);
-            Some(vec![ty, ty, ValueType::I32])
+            Some(Cow::Owned(vec![ty, ty, ValueType::I32]))
         }
 
         // Local/global get — consume nothing
-        "local.get" | "global.get" => Some(vec![]),
+        "local.get" | "global.get" => Some(Cow::Borrowed(&[])),
 
         // Local set — consume the local's type
         "local.set" => {
             let ty = get_local_type_from_node(node, symbols, source).unwrap_or(ValueType::Unknown);
-            Some(vec![ty])
+            Some(Cow::Owned(vec![ty]))
         }
 
         // Local tee — consume and re-produce the local's type
         "local.tee" => {
             let ty = get_local_type_from_node(node, symbols, source).unwrap_or(ValueType::Unknown);
-            Some(vec![ty])
+            Some(Cow::Owned(vec![ty]))
         }
 
         // Global set — consume the global's type
         "global.set" => {
             let ty = get_global_type_from_node(node, symbols, source).unwrap_or(ValueType::Unknown);
-            Some(vec![ty])
+            Some(Cow::Owned(vec![ty]))
         }
 
         // Call — consume parameter types
         "call" | "return_call" => {
             if let Some(func_ref) = get_index_from_node(node, source) {
-                let func = symbols.get_function_by_name(func_ref).or_else(|| {
-                    func_ref
-                        .parse::<usize>()
-                        .ok()
-                        .and_then(|idx| symbols.get_function_by_index(idx))
-                });
+                let func = symbols.resolve_function(func_ref);
                 if let Some(f) = func {
-                    return Some(f.parameters.iter().map(|p| p.param_type).collect());
+                    return Some(Cow::Owned(
+                        f.parameters.iter().map(|p| p.param_type).collect(),
+                    ));
                 }
             }
             None // fall back to untyped
@@ -1028,12 +1030,12 @@ fn derive_consumed_types_from_name(
         // Call_ref — consume param types + typed funcref (ref null $type)
         "call_ref" | "return_call_ref" => {
             if let Some(type_ref) = get_index_from_node(node, source) {
-                if let Some(td) = resolve_type_ref(type_ref, symbols) {
+                if let Some(td) = symbols.resolve_type(type_ref) {
                     if let TypeKind::Func { params, .. } = &td.kind {
                         let mut types = Vec::with_capacity(params.len() + 1);
                         types.extend_from_slice(params);
                         types.push(ValueType::RefNull(td.index as u32));
-                        return Some(types);
+                        return Some(Cow::Owned(types));
                     }
                 }
             }
@@ -1041,42 +1043,46 @@ fn derive_consumed_types_from_name(
         }
 
         // Conversions — consume source type
-        "i32.wrap_i64" => Some(vec![ValueType::I64]),
-        "i64.extend_i32_s" | "i64.extend_i32_u" => Some(vec![ValueType::I32]),
+        "i32.wrap_i64" => Some(Cow::Borrowed(&[ValueType::I64])),
+        "i64.extend_i32_s" | "i64.extend_i32_u" => Some(Cow::Borrowed(&[ValueType::I32])),
         "i32.trunc_f32_s" | "i32.trunc_f32_u" | "i32.trunc_sat_f32_s" | "i32.trunc_sat_f32_u" => {
-            Some(vec![ValueType::F32])
+            Some(Cow::Borrowed(&[ValueType::F32]))
         }
         "i32.trunc_f64_s" | "i32.trunc_f64_u" | "i32.trunc_sat_f64_s" | "i32.trunc_sat_f64_u" => {
-            Some(vec![ValueType::F64])
+            Some(Cow::Borrowed(&[ValueType::F64]))
         }
         "i64.trunc_f32_s" | "i64.trunc_f32_u" | "i64.trunc_sat_f32_s" | "i64.trunc_sat_f32_u" => {
-            Some(vec![ValueType::F32])
+            Some(Cow::Borrowed(&[ValueType::F32]))
         }
         "i64.trunc_f64_s" | "i64.trunc_f64_u" | "i64.trunc_sat_f64_s" | "i64.trunc_sat_f64_u" => {
-            Some(vec![ValueType::F64])
+            Some(Cow::Borrowed(&[ValueType::F64]))
         }
-        "f32.convert_i32_s" | "f32.convert_i32_u" => Some(vec![ValueType::I32]),
-        "f32.convert_i64_s" | "f32.convert_i64_u" => Some(vec![ValueType::I64]),
-        "f64.convert_i32_s" | "f64.convert_i32_u" => Some(vec![ValueType::I32]),
-        "f64.convert_i64_s" | "f64.convert_i64_u" => Some(vec![ValueType::I64]),
-        "f32.demote_f64" => Some(vec![ValueType::F64]),
-        "f64.promote_f32" => Some(vec![ValueType::F32]),
-        "i32.reinterpret_f32" => Some(vec![ValueType::F32]),
-        "i64.reinterpret_f64" => Some(vec![ValueType::F64]),
-        "f32.reinterpret_i32" => Some(vec![ValueType::I32]),
-        "f64.reinterpret_i64" => Some(vec![ValueType::I64]),
+        "f32.convert_i32_s" | "f32.convert_i32_u" => Some(Cow::Borrowed(&[ValueType::I32])),
+        "f32.convert_i64_s" | "f32.convert_i64_u" => Some(Cow::Borrowed(&[ValueType::I64])),
+        "f64.convert_i32_s" | "f64.convert_i32_u" => Some(Cow::Borrowed(&[ValueType::I32])),
+        "f64.convert_i64_s" | "f64.convert_i64_u" => Some(Cow::Borrowed(&[ValueType::I64])),
+        "f32.demote_f64" => Some(Cow::Borrowed(&[ValueType::F64])),
+        "f64.promote_f32" => Some(Cow::Borrowed(&[ValueType::F32])),
+        "i32.reinterpret_f32" => Some(Cow::Borrowed(&[ValueType::F32])),
+        "i64.reinterpret_f64" => Some(Cow::Borrowed(&[ValueType::F64])),
+        "f32.reinterpret_i32" => Some(Cow::Borrowed(&[ValueType::I32])),
+        "f64.reinterpret_i64" => Some(Cow::Borrowed(&[ValueType::I64])),
 
         // ---- SIMD instruction type signatures ----
         // v128 bitwise: (v128, v128) -> v128
         "v128.and" | "v128.or" | "v128.xor" | "v128.andnot" => {
-            Some(vec![ValueType::V128, ValueType::V128])
+            Some(Cow::Borrowed(&[ValueType::V128, ValueType::V128]))
         }
         // v128 bitselect: (v128, v128, v128) -> v128
-        "v128.bitselect" => Some(vec![ValueType::V128, ValueType::V128, ValueType::V128]),
+        "v128.bitselect" => Some(Cow::Borrowed(&[
+            ValueType::V128,
+            ValueType::V128,
+            ValueType::V128,
+        ])),
         // v128 not: (v128) -> v128
-        "v128.not" => Some(vec![ValueType::V128]),
+        "v128.not" => Some(Cow::Borrowed(&[ValueType::V128])),
         // v128.any_true: (v128) -> i32
-        "v128.any_true" => Some(vec![ValueType::V128]),
+        "v128.any_true" => Some(Cow::Borrowed(&[ValueType::V128])),
 
         // SIMD lane instructions
         name if is_simd_instruction(name) => derive_simd_consumed_types(name),
@@ -1084,60 +1090,66 @@ fn derive_consumed_types_from_name(
         // SIMD lane load/store — consume address + v128 vector
         name if name.contains("_lane") && name.starts_with("v128.load") => {
             let addr_type = get_memory_address_type(node, symbols, source);
-            Some(vec![addr_type, ValueType::V128])
+            Some(Cow::Owned(vec![addr_type, ValueType::V128]))
         }
         name if name.contains("_lane") && name.starts_with("v128.store") => {
             let addr_type = get_memory_address_type(node, symbols, source);
-            Some(vec![addr_type, ValueType::V128])
+            Some(Cow::Owned(vec![addr_type, ValueType::V128]))
         }
 
         // Memory load — consume address (i32 for memory32, i64 for memory64)
         name if name.contains(".load") => {
             let addr_type = get_memory_address_type(node, symbols, source);
-            Some(vec![addr_type])
+            Some(Cow::Owned(vec![addr_type]))
         }
 
         // Memory store — consume address + value
         name if name.contains(".store") => {
             let addr_type = get_memory_address_type(node, symbols, source);
             let value_type = type_from_prefix(name).unwrap_or(ValueType::Unknown);
-            Some(vec![addr_type, value_type])
+            Some(Cow::Owned(vec![addr_type, value_type]))
         }
 
         // Memory size — no operands
-        "memory.size" => Some(vec![]),
+        "memory.size" => Some(Cow::Borrowed(&[])),
         // Memory grow — consume delta (i32 for memory32, i64 for memory64)
         "memory.grow" => {
             let addr_type = get_memory_address_type(node, symbols, source);
-            Some(vec![addr_type])
+            Some(Cow::Owned(vec![addr_type]))
         }
 
         // Reference instructions
-        "ref.null" => Some(vec![]),
-        "ref.func" => Some(vec![]),
-        "ref.is_null" => Some(vec![ValueType::Unknown]), // any ref
+        "ref.null" => Some(Cow::Borrowed(&[])),
+        "ref.func" => Some(Cow::Borrowed(&[])),
+        "ref.is_null" => Some(Cow::Borrowed(&[ValueType::Unknown])), // any ref
         // ref.as_non_null handled specially in process_instruction
-        "ref.eq" => Some(vec![ValueType::Eqref, ValueType::Eqref]),
+        "ref.eq" => Some(Cow::Borrowed(&[ValueType::Eqref, ValueType::Eqref])),
 
         // GC instructions
-        "ref.i31" => Some(vec![ValueType::I32]),
-        "i31.get_s" | "i31.get_u" => Some(vec![ValueType::I31ref]),
-        "any.convert_extern" => Some(vec![ValueType::Externref]),
-        "extern.convert_any" => Some(vec![ValueType::Anyref]),
+        "ref.i31" => Some(Cow::Borrowed(&[ValueType::I32])),
+        "i31.get_s" | "i31.get_u" => Some(Cow::Borrowed(&[ValueType::I31ref])),
+        "any.convert_extern" => Some(Cow::Borrowed(&[ValueType::Externref])),
+        "extern.convert_any" => Some(Cow::Borrowed(&[ValueType::Anyref])),
 
         // Struct operations
-        "struct.get" | "struct.get_s" | "struct.get_u" => Some(vec![ValueType::Unknown]), // structref
-        "struct.set" => Some(vec![ValueType::Unknown, ValueType::Unknown]), // structref + value
-        "struct.new_default" => Some(vec![]),
+        "struct.get" | "struct.get_s" | "struct.get_u" => {
+            Some(Cow::Borrowed(&[ValueType::Unknown]))
+        } // structref
+        "struct.set" => Some(Cow::Borrowed(&[ValueType::Unknown, ValueType::Unknown])), // structref + value
+        "struct.new_default" => Some(Cow::Borrowed(&[])),
 
         // Array operations
-        "array.new" => Some(vec![ValueType::Unknown, ValueType::I32]), // value, length
-        "array.new_default" => Some(vec![ValueType::I32]),             // length
+        "array.new" => Some(Cow::Borrowed(&[ValueType::Unknown, ValueType::I32])), // value, length
+        "array.new_default" => Some(Cow::Borrowed(&[ValueType::I32])),             // length
         "array.get" | "array.get_s" | "array.get_u" => {
-            Some(vec![ValueType::Unknown, ValueType::I32])
+            Some(Cow::Borrowed(&[ValueType::Unknown, ValueType::I32]))
         } // arrayref, index
-        "array.set" => Some(vec![ValueType::Unknown, ValueType::I32, ValueType::Unknown]), // arrayref, index, value
-        "array.len" => Some(vec![ValueType::Unknown]), // arrayref
+        "array.set" => Some(Cow::Borrowed(&[
+            ValueType::Unknown,
+            ValueType::I32,
+            ValueType::Unknown,
+        ])), // arrayref, index, value
+        "array.len" => Some(Cow::Borrowed(&[ValueType::Unknown])),                 // arrayref
         "array.fill" => {
             // arrayref, i32 offset, value, i32 length
             // Resolve element type from the type index to type-check the value operand
@@ -1149,20 +1161,20 @@ fn derive_consumed_types_from_name(
                     _ => None,
                 })
                 .unwrap_or(ValueType::Unknown);
-            Some(vec![
+            Some(Cow::Owned(vec![
                 ValueType::Unknown,
                 ValueType::I32,
                 val_ty,
                 ValueType::I32,
-            ])
+            ]))
         }
-        "array.copy" => Some(vec![
+        "array.copy" => Some(Cow::Borrowed(&[
             ValueType::Unknown,
             ValueType::I32,
             ValueType::Unknown,
             ValueType::I32,
             ValueType::I32,
-        ]),
+        ])),
         "array.new_fixed" => {
             // array.new_fixed $type N: consumes N elements of the array's element type
             let elem_ty = resolve_first_type_index(node, symbols, source)
@@ -1174,18 +1186,20 @@ fn derive_consumed_types_from_name(
                 })
                 .unwrap_or(ValueType::Unknown);
             let count = get_array_new_fixed_count(node, source);
-            Some(vec![elem_ty; count])
+            Some(Cow::Owned(vec![elem_ty; count]))
         }
-        "array.new_data" | "array.new_elem" => Some(vec![ValueType::I32, ValueType::I32]), // offset, length
-        "array.init_data" | "array.init_elem" => Some(vec![
+        "array.new_data" | "array.new_elem" => {
+            Some(Cow::Borrowed(&[ValueType::I32, ValueType::I32]))
+        } // offset, length
+        "array.init_data" | "array.init_elem" => Some(Cow::Borrowed(&[
             ValueType::Unknown,
             ValueType::I32,
             ValueType::I32,
             ValueType::I32,
-        ]),
+        ])),
 
         // Ref test/cast
-        "ref.test" | "ref.cast" | "ref.cast_null" => Some(vec![ValueType::Unknown]),
+        "ref.test" | "ref.cast" | "ref.cast_null" => Some(Cow::Borrowed(&[ValueType::Unknown])),
         // br_on_cast/br_on_cast_fail handled as branch instructions above
 
         // Exceptions
@@ -1196,48 +1210,48 @@ fn derive_consumed_types_from_name(
                     .get_tag_by_name(tag_ref)
                     .or_else(|| parse_wat_nat(tag_ref).and_then(|i| symbols.tags.get(i as usize)));
                 if let Some(tag) = tag {
-                    return Some(tag.params.clone());
+                    return Some(Cow::Owned(tag.params.clone()));
                 }
             }
-            Some(vec![])
+            Some(Cow::Borrowed(&[]))
         }
-        "throw_ref" => Some(vec![ValueType::Unknown]), // exnref
+        "throw_ref" => Some(Cow::Borrowed(&[ValueType::Unknown])), // exnref
 
         // Bulk memory — addresses are i32/i64 depending on memory type
         "memory.copy" => {
             let addr_type = get_memory_address_type(node, symbols, source);
-            Some(vec![addr_type, addr_type, addr_type])
+            Some(Cow::Owned(vec![addr_type, addr_type, addr_type]))
         }
         "memory.fill" => {
             let addr_type = get_memory_address_type(node, symbols, source);
-            Some(vec![addr_type, ValueType::I32, addr_type])
+            Some(Cow::Owned(vec![addr_type, ValueType::I32, addr_type]))
         }
         "memory.init" => {
             let addr_type = get_memory_address_type(node, symbols, source);
-            Some(vec![addr_type, ValueType::I32, ValueType::I32])
+            Some(Cow::Owned(vec![addr_type, ValueType::I32, ValueType::I32]))
         }
-        "data.drop" | "elem.drop" => Some(vec![]),
+        "data.drop" | "elem.drop" => Some(Cow::Borrowed(&[])),
 
         // Table operations — resolve element type and index type from symbol table
         "table.get" => {
             let idx_type = get_table_index_type(node, symbols, source);
-            Some(vec![idx_type])
+            Some(Cow::Owned(vec![idx_type]))
         }
         "table.set" => {
             let idx_type = get_table_index_type(node, symbols, source);
             let elem_type = get_table_elem_type(node, symbols, source);
-            Some(vec![idx_type, elem_type])
+            Some(Cow::Owned(vec![idx_type, elem_type]))
         }
-        "table.size" => Some(vec![]),
+        "table.size" => Some(Cow::Borrowed(&[])),
         "table.grow" => {
             let idx_type = get_table_index_type(node, symbols, source);
             let elem_type = get_table_elem_type(node, symbols, source);
-            Some(vec![elem_type, idx_type])
+            Some(Cow::Owned(vec![elem_type, idx_type]))
         }
         "table.fill" => {
             let idx_type = get_table_index_type(node, symbols, source);
             let elem_type = get_table_elem_type(node, symbols, source);
-            Some(vec![idx_type, elem_type, idx_type])
+            Some(Cow::Owned(vec![idx_type, elem_type, idx_type]))
         }
         "table.copy" => {
             // table.copy $dst $src: (d:dst_addr, s:src_addr, n:min(dst_addr, src_addr))
@@ -1248,7 +1262,7 @@ fn derive_consumed_types_from_name(
             } else {
                 ValueType::I32
             };
-            Some(vec![dst_type, src_type, n_type])
+            Some(Cow::Owned(vec![dst_type, src_type, n_type]))
         }
         "table.init" => {
             // table.init $table $elem: (d:table_addr, s:i32, n:i32)
@@ -1262,24 +1276,32 @@ fn derive_consumed_types_from_name(
                     }
                 })
                 .unwrap_or(ValueType::I32);
-            Some(vec![addr_type, ValueType::I32, ValueType::I32])
+            Some(Cow::Owned(vec![addr_type, ValueType::I32, ValueType::I32]))
         }
 
         // Atomic fence — no operands
-        "atomic.fence" => Some(vec![]),
+        "atomic.fence" => Some(Cow::Borrowed(&[])),
 
         // Wait/notify
-        "memory.atomic.wait32" => Some(vec![ValueType::I32, ValueType::I32, ValueType::I64]),
-        "memory.atomic.wait64" => Some(vec![ValueType::I32, ValueType::I64, ValueType::I64]),
-        "memory.atomic.notify" => Some(vec![ValueType::I32, ValueType::I32]),
+        "memory.atomic.wait32" => Some(Cow::Borrowed(&[
+            ValueType::I32,
+            ValueType::I32,
+            ValueType::I64,
+        ])),
+        "memory.atomic.wait64" => Some(Cow::Borrowed(&[
+            ValueType::I32,
+            ValueType::I64,
+            ValueType::I64,
+        ])),
+        "memory.atomic.notify" => Some(Cow::Borrowed(&[ValueType::I32, ValueType::I32])),
 
         // Atomic RMW — address (i32) + value (prefix type)
         name if name.contains(".atomic.rmw") => {
             if let Some(ty) = type_from_prefix(name) {
                 if name.contains("cmpxchg") {
-                    Some(vec![ValueType::I32, ty, ty]) // addr + expected + replacement
+                    Some(Cow::Owned(vec![ValueType::I32, ty, ty])) // addr + expected + replacement
                 } else {
-                    Some(vec![ValueType::I32, ty]) // addr + value
+                    Some(Cow::Owned(vec![ValueType::I32, ty])) // addr + value
                 }
             } else {
                 None
@@ -1291,7 +1313,7 @@ fn derive_consumed_types_from_name(
         // Scalar binary operations — 2 operands of prefix type
         name if is_binary_scalar(name) => {
             if let Some(ty) = type_from_prefix(name) {
-                Some(vec![ty, ty])
+                Some(Cow::Owned(vec![ty, ty]))
             } else {
                 None
             }
@@ -1300,7 +1322,7 @@ fn derive_consumed_types_from_name(
         // Scalar unary operations — 1 operand of prefix type
         name if is_unary_scalar(name) => {
             if let Some(ty) = type_from_prefix(name) {
-                Some(vec![ty])
+                Some(Cow::Owned(vec![ty]))
             } else {
                 None
             }
@@ -1468,12 +1490,7 @@ fn get_dynamic_operand_count(
     match instr_name {
         "call" | "return_call" => {
             if let Some(func_ref) = get_index_from_node(node, source) {
-                let func = symbols.get_function_by_name(func_ref).or_else(|| {
-                    func_ref
-                        .parse::<usize>()
-                        .ok()
-                        .and_then(|idx| symbols.get_function_by_index(idx))
-                });
+                let func = symbols.resolve_function(func_ref);
                 if let Some(f) = func {
                     return f.parameters.len();
                 }
@@ -1482,7 +1499,7 @@ fn get_dynamic_operand_count(
         }
         "call_ref" | "return_call_ref" => {
             if let Some(type_ref) = get_index_from_node(node, source) {
-                if let Some(td) = resolve_type_ref(type_ref, symbols) {
+                if let Some(td) = symbols.resolve_type(type_ref) {
                     if let TypeKind::Func { params, .. } = &td.kind {
                         return params.len() + 1;
                     }
@@ -1492,7 +1509,7 @@ fn get_dynamic_operand_count(
         }
         "call_indirect" | "return_call_indirect" => {
             if let Some(type_ref) = get_index_from_node(node, source) {
-                if let Some(td) = resolve_type_ref(type_ref, symbols) {
+                if let Some(td) = symbols.resolve_type(type_ref) {
                     if let TypeKind::Func { params, .. } = &td.kind {
                         return params.len() + 1;
                     }
@@ -1502,7 +1519,7 @@ fn get_dynamic_operand_count(
         }
         "struct.new" => {
             if let Some(type_ref) = get_index_from_node(node, source) {
-                if let Some(td) = resolve_type_ref(type_ref, symbols) {
+                if let Some(td) = symbols.resolve_type(type_ref) {
                     if let TypeKind::Struct { fields } = &td.kind {
                         return fields.len();
                     }
@@ -1513,12 +1530,7 @@ fn get_dynamic_operand_count(
         "array.new_fixed" => get_array_new_fixed_count(node, source),
         "throw" => {
             if let Some(tag_ref) = get_index_from_node(node, source) {
-                let tag = symbols.get_tag_by_name(tag_ref).or_else(|| {
-                    tag_ref
-                        .parse::<usize>()
-                        .ok()
-                        .and_then(|idx| symbols.get_tag_by_index(idx))
-                });
+                let tag = symbols.resolve_tag(tag_ref);
                 if let Some(t) = tag {
                     return t.params.len();
                 }
@@ -1894,12 +1906,7 @@ fn get_ref_func_result_type(node: &Node, symbols: &SymbolTable, source: &str) ->
 /// Get result types for a call instruction
 fn get_call_result_types(node: &Node, symbols: &SymbolTable, source: &str) -> Vec<ValueType> {
     if let Some(func_ref) = get_index_from_node(node, source) {
-        let func = symbols.get_function_by_name(func_ref).or_else(|| {
-            func_ref
-                .parse::<usize>()
-                .ok()
-                .and_then(|idx| symbols.get_function_by_index(idx))
-        });
+        let func = symbols.resolve_function(func_ref);
         if let Some(f) = func {
             return f.results.clone();
         }
@@ -1910,7 +1917,7 @@ fn get_call_result_types(node: &Node, symbols: &SymbolTable, source: &str) -> Ve
 /// Get result types for a call_ref instruction
 fn get_call_ref_result_types(node: &Node, symbols: &SymbolTable, source: &str) -> Vec<ValueType> {
     if let Some(type_ref) = get_index_from_node(node, source) {
-        if let Some(td) = resolve_type_ref(type_ref, symbols) {
+        if let Some(td) = symbols.resolve_type(type_ref) {
             if let TypeKind::Func { results, .. } = &td.kind {
                 return results.clone();
             }
@@ -1942,7 +1949,7 @@ fn resolve_call_indirect_type<'a>(
     }
     // No type_use found — try first index as a type reference (single-table mode)
     if let Some(idx_text) = first_index {
-        return resolve_type_ref(idx_text, symbols);
+        return symbols.resolve_type(idx_text);
     }
     None
 }
@@ -2589,12 +2596,7 @@ fn get_expr1_result_types(expr1: &Node, source: &str, symbols: &SymbolTable) -> 
                 }
             }
             if let Some(func_ref) = get_index_from_expr1_call(expr1, source) {
-                let func = symbols.get_function_by_name(func_ref).or_else(|| {
-                    func_ref
-                        .parse::<usize>()
-                        .ok()
-                        .and_then(|idx| symbols.get_function_by_index(idx))
-                });
+                let func = symbols.resolve_function(func_ref);
                 if let Some(f) = func {
                     return f.results.clone();
                 }
@@ -2632,13 +2634,7 @@ fn resolve_block_type_use<'a>(
         if kind == "type_use" {
             return resolve_type_use_node(&child, source, symbols);
         }
-        if kind == "block_block"
-            || kind == "block_loop"
-            || kind == "if_block"
-            || kind == "block_if"
-            || kind == "block_try_table"
-            || kind == "block_try"
-        {
+        if is_inner_block_kind(kind) {
             let mut inner_cursor = child.walk();
             for inner_child in child.children(&mut inner_cursor) {
                 node_kind!(inner_kind = inner_child);
@@ -2650,16 +2646,6 @@ fn resolve_block_type_use<'a>(
         }
     }
     None
-}
-
-/// Resolve a type reference (name or numeric index) to a TypeDef.
-fn resolve_type_ref<'a>(type_ref: &str, symbols: &'a SymbolTable) -> Option<&'a TypeDef> {
-    symbols.get_type_by_name(type_ref).or_else(|| {
-        type_ref
-            .parse::<usize>()
-            .ok()
-            .and_then(|idx| symbols.get_type_by_index(idx))
-    })
 }
 
 /// Resolve a type_use node to a TypeDef via the symbol table.
@@ -2745,13 +2731,7 @@ fn get_block_result_types(
         if kind == "block_type" {
             return parse_result_types(&child, source, symbols);
         }
-        if kind == "block_block"
-            || kind == "block_loop"
-            || kind == "if_block"
-            || kind == "block_if"
-            || kind == "block_try_table"
-            || kind == "block_try"
-        {
+        if is_inner_block_kind(kind) {
             let mut inner_cursor = child.walk();
             for inner_child in child.children(&mut inner_cursor) {
                 node_kind!(inner_kind = inner_child);
@@ -2786,13 +2766,7 @@ fn get_block_param_types(block_node: &Node, source: &str, symbols: &SymbolTable)
             has_explicit_params = true;
             types.extend(parse_func_type_results(&child, source, Some(symbols)));
         }
-        if kind == "block_block"
-            || kind == "block_loop"
-            || kind == "if_block"
-            || kind == "block_if"
-            || kind == "block_try_table"
-            || kind == "block_try"
-        {
+        if is_inner_block_kind(kind) {
             let mut inner_cursor = child.walk();
             for inner_child in child.children(&mut inner_cursor) {
                 node_kind!(inner_kind = inner_child);
@@ -3111,23 +3085,13 @@ fn apply_nonnull_to_callee_results(
 ) -> Vec<ValueType> {
     // Find the callee's type definition
     let type_def = match instr_name {
-        "return_call_ref" => get_index_from_node(node, source).and_then(|type_ref| {
-            symbols.get_type_by_name(type_ref).or_else(|| {
-                type_ref
-                    .parse::<usize>()
-                    .ok()
-                    .and_then(|idx| symbols.get_type_by_index(idx))
-            })
-        }),
+        "return_call_ref" => {
+            get_index_from_node(node, source).and_then(|type_ref| symbols.resolve_type(type_ref))
+        }
         "return_call" => {
             // For return_call, get the function's type via its type_index
             get_index_from_node(node, source).and_then(|func_ref| {
-                let func = symbols.get_function_by_name(func_ref).or_else(|| {
-                    func_ref
-                        .parse::<usize>()
-                        .ok()
-                        .and_then(|idx| symbols.get_function_by_index(idx))
-                })?;
+                let func = symbols.resolve_function(func_ref)?;
                 func.type_index
                     .and_then(|tidx| symbols.get_type_by_index(tidx))
             })

--- a/src/diagnostics_core/simd_checks.rs
+++ b/src/diagnostics_core/simd_checks.rs
@@ -15,9 +15,7 @@ use crate::ts_facade::Node;
 ///
 /// Returns diagnostics for any lane index that exceeds the valid range
 /// for the given instruction.
-pub fn check_simd_lane_index(node: &Node, source: &str) -> Vec<Diagnostic> {
-    let mut diagnostics = Vec::new();
-
+pub(crate) fn check_simd_lane_index(node: &Node, source: &str, diagnostics: &mut Vec<Diagnostic>) {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         node_kind!(kind_ref = child);
@@ -58,8 +56,6 @@ pub fn check_simd_lane_index(node: &Node, source: &str) -> Vec<Diagnostic> {
             }
         }
     }
-
-    diagnostics
 }
 
 /// Find the instruction name from an op_simd_lane node.

--- a/src/diagnostics_core/subtype.rs
+++ b/src/diagnostics_core/subtype.rs
@@ -11,7 +11,7 @@ use super::type_check::types_compatible_with_symbols;
 /// Validate subtype hierarchy in the symbol table.
 /// Returns diagnostics for invalid parent references, final type violations,
 /// and structural incompatibilities.
-pub fn validate_subtype_hierarchy(symbols: &SymbolTable) -> Vec<Diagnostic> {
+pub(crate) fn validate_subtype_hierarchy(symbols: &SymbolTable) -> Vec<Diagnostic> {
     let mut diagnostics = Vec::new();
 
     for type_def in &symbols.types {
@@ -57,14 +57,7 @@ pub fn validate_subtype_hierarchy(symbols: &SymbolTable) -> Vec<Diagnostic> {
 
 /// Resolve a parent reference (either "$name" or numeric index) to a TypeDef.
 fn resolve_parent<'a>(symbols: &'a SymbolTable, parent_ref: &str) -> Option<&'a TypeDef> {
-    if parent_ref.starts_with('$') {
-        symbols.get_type_by_name(parent_ref)
-    } else {
-        parent_ref
-            .parse::<usize>()
-            .ok()
-            .and_then(|idx| symbols.get_type_by_index(idx))
-    }
+    symbols.resolve_type(parent_ref)
 }
 
 /// Check structural compatibility between a child type and its declared parent.

--- a/src/diagnostics_core/termination.rs
+++ b/src/diagnostics_core/termination.rs
@@ -22,7 +22,7 @@ use crate::ts_facade::Node;
 /// This is used to determine whether a block's declared result types should be
 /// pushed onto the stack - if the block always terminates, it doesn't produce
 /// values via fall-through.
-pub fn sequence_always_terminates(node: &Node, source: &str) -> bool {
+pub(crate) fn sequence_always_terminates(node: &Node, source: &str) -> bool {
     node_kind!(kind = node);
 
     match kind.as_ref() {

--- a/src/diagnostics_core/tree_sitter.rs
+++ b/src/diagnostics_core/tree_sitter.rs
@@ -12,7 +12,7 @@ use tree_sitter::{Node, Tree};
 use crate::ts_facade::{Node, Tree};
 
 /// Provide diagnostics for syntax errors in the document.
-pub fn provide_tree_sitter_diagnostics(tree: &Tree, source: &str) -> Vec<Diagnostic> {
+pub(crate) fn provide_tree_sitter_diagnostics(tree: &Tree, source: &str) -> Vec<Diagnostic> {
     let mut diagnostics = Vec::new();
     walk_tree_for_errors(tree.root_node(), source, &mut diagnostics);
     diagnostics
@@ -49,7 +49,7 @@ fn create_error_diagnostic(node: &Node, source: &str) -> Diagnostic {
         severity: DiagnosticSeverity::Error,
         message,
         code: None,
-        source: Some("wat-lsp".to_string()),
+        source: "wat-lsp",
     }
 }
 
@@ -59,7 +59,7 @@ fn create_missing_diagnostic(node: &Node) -> Diagnostic {
         severity: DiagnosticSeverity::Error,
         message: format!("Missing {}", node.kind()),
         code: None,
-        source: Some("wat-lsp".to_string()),
+        source: "wat-lsp",
     }
 }
 

--- a/src/diagnostics_core/tree_walk.rs
+++ b/src/diagnostics_core/tree_walk.rs
@@ -17,14 +17,14 @@ use tree_sitter::Node;
 use crate::ts_facade::Node;
 
 /// Pre-computed configuration for which diagnostic checks to perform.
-pub struct DiagnosticConfig {
-    pub check_atomics: bool,
-    pub check_memory64: bool,
+pub(crate) struct DiagnosticConfig {
+    pub(crate) check_atomics: bool,
+    pub(crate) check_memory64: bool,
 }
 
 impl DiagnosticConfig {
     /// Build config from symbol table state.
-    pub fn from_symbols(symbols: &SymbolTable) -> Self {
+    pub(crate) fn from_symbols(symbols: &SymbolTable) -> Self {
         let (has_shared, has_memory64) = symbols
             .memories
             .iter()
@@ -43,7 +43,7 @@ impl DiagnosticConfig {
 /// This is the shared implementation used by both native and WASM builds.
 /// Callers can convert the returned `Vec<Diagnostic>` to platform-specific
 /// types as needed (e.g., `tower_lsp::lsp_types::Diagnostic` for native).
-pub fn walk_tree_for_diagnostics(
+pub(crate) fn walk_tree_for_diagnostics(
     node: Node,
     source: &str,
     symbols: &SymbolTable,
@@ -69,8 +69,10 @@ pub fn walk_tree_for_diagnostics(
 
     // Check block label mismatches
     if matches!(kind_str, "block_block" | "block_loop" | "block_if") {
-        diagnostics.extend(
-            crate::diagnostics_core::module_checks::check_block_label_mismatch(&node, source),
+        crate::diagnostics_core::module_checks::check_block_label_mismatch(
+            &node,
+            source,
+            diagnostics,
         );
     }
 
@@ -111,10 +113,11 @@ pub fn walk_tree_for_diagnostics(
 
         // Check for uninitialized non-nullable ref locals
         if !is_import {
-            diagnostics.extend(
-                crate::diagnostics_core::local_init::check_uninitialized_locals(
-                    &node, source, symbols,
-                ),
+            crate::diagnostics_core::local_init::check_uninitialized_locals(
+                &node,
+                source,
+                symbols,
+                diagnostics,
             );
         }
 
@@ -126,90 +129,91 @@ pub fn walk_tree_for_diagnostics(
 
     // Special handling for catch clauses (try_table)
     if kind_str == "catch_clause" {
-        diagnostics.extend(
-            crate::diagnostics_core::references::check_catch_clause_references(
-                &node, source, symbols,
-            ),
+        crate::diagnostics_core::references::check_catch_clause_references(
+            &node,
+            source,
+            symbols,
+            diagnostics,
         );
         return;
     }
 
     // Special handling for legacy try catch clause
     if kind_str == "try_catch_clause" {
-        diagnostics.extend(
-            crate::diagnostics_core::references::check_first_index_reference(
-                &node,
-                source,
-                symbols,
-                &InstructionContext::Tag,
-            ),
+        crate::diagnostics_core::references::check_first_index_reference(
+            &node,
+            source,
+            symbols,
+            &InstructionContext::Tag,
+            diagnostics,
         );
         // Continue recursing to check nested instructions
     }
 
     // Special handling for start directive
     if kind_str == "module_field_start" {
-        diagnostics.extend(
-            crate::diagnostics_core::references::check_first_index_reference(
-                &node,
-                source,
-                symbols,
-                &InstructionContext::Call,
-            ),
+        crate::diagnostics_core::references::check_first_index_reference(
+            &node,
+            source,
+            symbols,
+            &InstructionContext::Call,
+            diagnostics,
         );
         return;
     }
 
     // Check module-level references (exports, elem/data segment refs)
     {
-        let module_ref_diags = crate::diagnostics_core::references::check_module_level_references(
-            &node, source, symbols,
+        let prev_len = diagnostics.len();
+        crate::diagnostics_core::references::check_module_level_references(
+            &node,
+            source,
+            symbols,
+            diagnostics,
         );
-        if !module_ref_diags.is_empty() {
-            diagnostics.extend(module_ref_diags);
-            if kind_str != "module_field_elem" {
-                return;
-            }
+        if diagnostics.len() > prev_len && kind_str != "module_field_elem" {
+            return;
         }
     }
 
     // Special handling for try_delegate_clause (legacy try): index is a label reference
     if kind_str == "try_delegate_clause" {
-        diagnostics.extend(
-            crate::diagnostics_core::references::check_first_index_reference(
-                &node,
-                source,
-                symbols,
-                &InstructionContext::Branch,
-            ),
+        crate::diagnostics_core::references::check_first_index_reference(
+            &node,
+            source,
+            symbols,
+            &InstructionContext::Branch,
+            diagnostics,
         );
         return;
     }
 
     // Check folded expression operand count (expr1_plain nodes)
     if kind_str == "expr1_plain" {
-        diagnostics.extend(
-            crate::diagnostics_core::folded_checks::check_folded_operand_count(
-                &node, source, symbols,
-            ),
+        crate::diagnostics_core::folded_checks::check_folded_operand_count(
+            &node,
+            source,
+            symbols,
+            diagnostics,
         );
 
         let text = &source[node.byte_range()];
         let first_token = text.split_whitespace().next().unwrap_or("");
 
         if config.check_atomics {
-            diagnostics.extend(
-                crate::diagnostics_core::memory_checks::check_atomic_operation(&node, first_token),
+            crate::diagnostics_core::memory_checks::check_atomic_operation(
+                &node,
+                first_token,
+                diagnostics,
             );
         }
         if config.check_memory64 {
-            diagnostics.extend(
-                crate::diagnostics_core::memory_checks::check_memory64_for_instruction(
-                    &node,
-                    source,
-                    symbols,
-                    first_token,
-                ),
+            crate::diagnostics_core::memory_checks::check_memory64_for_instruction(
+                &node,
+                source,
+                symbols,
+                first_token,
+                diagnostics,
             );
         }
     }
@@ -231,9 +235,13 @@ pub fn walk_tree_for_diagnostics(
     // Check for undefined references based on instruction context
     let context = determine_instruction_context_at_node(&node, source);
     if context != InstructionContext::General {
-        diagnostics.extend(crate::diagnostics_core::references::check_references(
-            &node, source, symbols, &context,
-        ));
+        crate::diagnostics_core::references::check_references(
+            &node,
+            source,
+            symbols,
+            &context,
+            diagnostics,
+        );
 
         // For instr_plain, also check atomic, memory64, and arity (linear format)
         if kind_str == "instr_plain" {
@@ -241,11 +249,10 @@ pub fn walk_tree_for_diagnostics(
             let first_token = text.split_whitespace().next().unwrap_or("");
 
             if config.check_atomics {
-                diagnostics.extend(
-                    crate::diagnostics_core::memory_checks::check_atomic_operation(
-                        &node,
-                        first_token,
-                    ),
+                crate::diagnostics_core::memory_checks::check_atomic_operation(
+                    &node,
+                    first_token,
+                    diagnostics,
                 );
             }
 
@@ -255,19 +262,18 @@ pub fn walk_tree_for_diagnostics(
                 .unwrap_or(false);
             if !parent_is_expr1 {
                 if config.check_memory64 {
-                    diagnostics.extend(
-                        crate::diagnostics_core::memory_checks::check_memory64_for_instruction(
-                            &node,
-                            source,
-                            symbols,
-                            first_token,
-                        ),
+                    crate::diagnostics_core::memory_checks::check_memory64_for_instruction(
+                        &node,
+                        source,
+                        symbols,
+                        first_token,
+                        diagnostics,
                     );
                 }
-                diagnostics.extend(
-                    crate::diagnostics_core::arity::check_instruction_parameter_count(
-                        &node, source,
-                    ),
+                crate::diagnostics_core::arity::check_instruction_parameter_count(
+                    &node,
+                    source,
+                    diagnostics,
                 );
             }
         }
@@ -296,14 +302,18 @@ fn check_instruction_diagnostics(
     symbols: &SymbolTable,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
-    diagnostics.extend(crate::diagnostics_core::simd_checks::check_simd_lane_index(
-        instr_node, source,
-    ));
-    diagnostics.extend(crate::diagnostics_core::alignment_checks::check_alignment(
-        instr_node, source, symbols,
-    ));
-    diagnostics.extend(
-        crate::diagnostics_core::gc_checks::check_struct_field_access(instr_node, source, symbols),
+    crate::diagnostics_core::simd_checks::check_simd_lane_index(instr_node, source, diagnostics);
+    crate::diagnostics_core::alignment_checks::check_alignment(
+        instr_node,
+        source,
+        symbols,
+        diagnostics,
+    );
+    crate::diagnostics_core::gc_checks::check_struct_field_access(
+        instr_node,
+        source,
+        symbols,
+        diagnostics,
     );
 }
 

--- a/src/diagnostics_core/type_check.rs
+++ b/src/diagnostics_core/type_check.rs
@@ -17,7 +17,7 @@ use crate::ts_facade::Node;
 
 /// What kind of control frame this is. Affects label_types resolution.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub enum CtrlOpcode {
+pub(super) enum CtrlOpcode {
     Function,
     Block,
     Loop,
@@ -27,35 +27,35 @@ pub enum CtrlOpcode {
 
 /// A control frame on the control stack, per spec §3.3 appendix.
 #[derive(Debug, Clone)]
-pub struct CtrlFrame {
-    pub opcode: CtrlOpcode,
+pub(super) struct CtrlFrame {
+    pub(super) opcode: CtrlOpcode,
     /// Block parameter types (consumed from outer stack on entry)
-    pub start_types: Vec<ValueType>,
+    pub(super) start_types: Vec<ValueType>,
     /// Block result types (left on stack on exit)
-    pub end_types: Vec<ValueType>,
+    pub(super) end_types: Vec<ValueType>,
     /// Value stack height when this frame was entered
-    pub height: usize,
+    pub(super) height: usize,
     /// True after unreachable/br/return — polymorphic stack bottom
-    pub unreachable: bool,
+    pub(super) unreachable: bool,
     /// Optional label name (e.g., "$loop1") for named branch resolution
-    pub label: Option<String>,
+    pub(super) label: Option<String>,
 }
 
 /// Core type checker state machine implementing Wasm spec validation.
 #[derive(Default)]
-pub struct TypeChecker {
+pub(super) struct TypeChecker {
     /// Value stack of types
     val_stack: Vec<ValueType>,
     /// Control frame stack
     ctrl_stack: Vec<CtrlFrame>,
     /// Collected diagnostics
-    pub diagnostics: Vec<Diagnostic>,
+    pub(super) diagnostics: Vec<Diagnostic>,
 }
 
 /// Check if two types are compatible for validation purposes.
 /// Unknown matches anything (polymorphic). Otherwise types must match exactly,
 /// with basic reference subtyping.
-pub fn types_compatible(actual: &ValueType, expected: &ValueType) -> bool {
+pub(super) fn types_compatible(actual: &ValueType, expected: &ValueType) -> bool {
     if *actual == ValueType::Unknown || *expected == ValueType::Unknown {
         return true;
     }
@@ -127,7 +127,7 @@ fn is_ref_subtype(sub: &ValueType, sup: &ValueType) -> bool {
 /// This extends `types_compatible()` with knowledge of concrete type definitions,
 /// enabling validation of `Ref(n)` / `RefNull(n)` against abstract supertypes
 /// (structref, arrayref, eqref, anyref) and concrete parent chains.
-pub fn types_compatible_with_symbols(
+pub(super) fn types_compatible_with_symbols(
     actual: &ValueType,
     expected: &ValueType,
     symbols: &SymbolTable,
@@ -502,19 +502,19 @@ fn resolve_type_ref(ref_str: &str, symbols: &SymbolTable) -> Option<usize> {
 
 impl TypeChecker {
     /// Create a new TypeChecker.
-    pub fn new() -> Self {
+    pub(super) fn new() -> Self {
         Self::default()
     }
 
     /// Push a value type onto the value stack.
-    pub fn push_val(&mut self, ty: ValueType) {
+    pub(super) fn push_val(&mut self, ty: ValueType) {
         self.val_stack.push(ty);
     }
 
     /// Pop a value from the value stack.
     /// If stack is at or below frame height AND frame is unreachable, returns Unknown.
     /// If stack underflows (below frame height, not unreachable), returns None.
-    pub fn pop_val(&mut self) -> Option<ValueType> {
+    pub(super) fn pop_val(&mut self) -> Option<ValueType> {
         let height = self.current_frame_height();
         if self.val_stack.len() == height {
             if self.is_current_unreachable() {
@@ -528,7 +528,7 @@ impl TypeChecker {
     /// Pop a value and check it matches the expected type.
     /// Returns the actual type popped, or None on underflow.
     /// Emits diagnostic on type mismatch or underflow.
-    pub fn pop_expect(&mut self, expected: &ValueType, node: &Node) -> Option<ValueType> {
+    pub(super) fn pop_expect(&mut self, expected: &ValueType, node: &Node) -> Option<ValueType> {
         let actual = self.pop_val();
         match actual {
             Some(ref ty) => {
@@ -562,7 +562,7 @@ impl TypeChecker {
     /// Pop a value and check it matches, without emitting diagnostics (caller handles errors).
     /// Returns (actual_type, matched). matched is false if type mismatch.
     /// Push multiple values onto the stack.
-    pub fn push_vals(&mut self, types: &[ValueType]) {
+    pub(super) fn push_vals(&mut self, types: &[ValueType]) {
         self.val_stack.extend_from_slice(types);
     }
 
@@ -570,14 +570,14 @@ impl TypeChecker {
     /// Returns true if all popped successfully and matched.
     /// Does NOT emit diagnostics — callers should use `pop_vals_for_instr` for
     /// instruction-level checks with proper diagnostic messages.
-    pub fn pop_vals(&mut self, expected: &[ValueType], node: &Node) -> bool {
+    pub(super) fn pop_vals(&mut self, expected: &[ValueType], node: &Node) -> bool {
         self.pop_vals_inner(expected, node, None)
     }
 
     /// Pop multiple values for a named instruction.
     /// On underflow, emits a "Stack underflow" diagnostic with instruction name.
     /// On type mismatch, emits a "type mismatch" diagnostic.
-    pub fn pop_vals_for_instr(
+    pub(super) fn pop_vals_for_instr(
         &mut self,
         expected: &[ValueType],
         node: &Node,
@@ -656,7 +656,7 @@ impl TypeChecker {
     }
 
     /// Enter a new control frame (block, loop, if, function).
-    pub fn push_ctrl(
+    pub(super) fn push_ctrl(
         &mut self,
         opcode: CtrlOpcode,
         start_types: Vec<ValueType>,
@@ -666,7 +666,7 @@ impl TypeChecker {
     }
 
     /// Enter a new control frame with an optional label name for named branch resolution.
-    pub fn push_ctrl_labeled(
+    pub(super) fn push_ctrl_labeled(
         &mut self,
         opcode: CtrlOpcode,
         start_types: Vec<ValueType>,
@@ -688,7 +688,7 @@ impl TypeChecker {
 
     /// Exit a control frame. Validates that end_types match the stack.
     /// Returns the popped frame, or None if ctrl_stack is empty.
-    pub fn pop_ctrl(&mut self, node: &Node) {
+    pub(super) fn pop_ctrl(&mut self, node: &Node) {
         if self.ctrl_stack.is_empty() {
             return;
         }
@@ -729,7 +729,7 @@ impl TypeChecker {
     /// Handle the else transition in an if block.
     /// Validates the then branch produced end_types, resets stack to frame height,
     /// and pushes start_types for the else branch.
-    pub fn else_transition(&mut self, node: &Node) {
+    pub(super) fn else_transition(&mut self, node: &Node) {
         if let Some(frame) = self.ctrl_stack.last() {
             let end_types = frame.end_types.clone();
             let start_types = frame.start_types.clone();
@@ -769,7 +769,7 @@ impl TypeChecker {
 
     /// Mark the current frame as unreachable.
     /// Truncates val_stack to frame height (polymorphic bottom).
-    pub fn mark_unreachable(&mut self) {
+    pub(super) fn mark_unreachable(&mut self) {
         if let Some(frame) = self.ctrl_stack.last_mut() {
             self.val_stack.truncate(frame.height);
             frame.unreachable = true;
@@ -777,7 +777,7 @@ impl TypeChecker {
     }
 
     /// Check if the current frame is in an unreachable state (polymorphic stack).
-    pub fn is_unreachable(&self) -> bool {
+    pub(super) fn is_unreachable(&self) -> bool {
         self.ctrl_stack
             .last()
             .map(|f| f.unreachable)
@@ -787,7 +787,7 @@ impl TypeChecker {
     /// Get the label types for a frame at the given depth.
     /// For loops, label types are start_types (br restarts with params).
     /// For everything else, label types are end_types.
-    pub fn label_types(&self, depth: usize) -> Option<&[ValueType]> {
+    pub(super) fn label_types(&self, depth: usize) -> Option<&[ValueType]> {
         let idx = self.ctrl_stack.len().checked_sub(1 + depth)?;
         let frame = &self.ctrl_stack[idx];
         Some(match frame.opcode {
@@ -798,7 +798,7 @@ impl TypeChecker {
 
     /// Look up label types at depth, copy them, and pop them for the given instruction.
     /// Returns the label types if found (owned, for callers that need to push them back).
-    pub fn pop_label_types_for_instr(
+    pub(super) fn pop_label_types_for_instr(
         &mut self,
         depth: usize,
         node: &Node,
@@ -811,7 +811,7 @@ impl TypeChecker {
 
     /// Get an owned copy of label types at the given depth.
     /// Useful when the caller needs both the types and a mutable borrow on self.
-    pub fn label_types_vec(&self, depth: usize) -> Option<Vec<ValueType>> {
+    pub(super) fn label_types_vec(&self, depth: usize) -> Option<Vec<ValueType>> {
         self.label_types(depth).map(|t| t.to_vec())
     }
 
@@ -830,7 +830,7 @@ impl TypeChecker {
 
     /// Resolve a named label (e.g., "$loop1") to a control stack depth.
     /// Returns the depth (0 = current frame) if found.
-    pub fn resolve_label_depth(&self, label: &str) -> Option<usize> {
+    pub(super) fn resolve_label_depth(&self, label: &str) -> Option<usize> {
         for (i, frame) in self.ctrl_stack.iter().rev().enumerate() {
             if let Some(ref name) = frame.label {
                 if name == label {
@@ -843,7 +843,7 @@ impl TypeChecker {
 
     /// Peek at the Nth value from the top of the stack (0 = top).
     /// Returns None if the stack doesn't have enough values.
-    pub fn peek(&self, n: usize) -> Option<&ValueType> {
+    pub(super) fn peek(&self, n: usize) -> Option<&ValueType> {
         let len = self.val_stack.len();
         let height = self.current_frame_height();
         if len > height + n {
@@ -854,20 +854,20 @@ impl TypeChecker {
     }
 
     /// Get the current control stack depth.
-    pub fn ctrl_depth(&self) -> usize {
+    pub(super) fn ctrl_depth(&self) -> usize {
         self.ctrl_stack.len()
     }
 
     /// Pop the function's return types for a `return` instruction.
     /// Copies end_types from the function frame and pops them from the stack.
-    pub fn pop_function_return_types(&mut self, node: &Node, instr_name: &str) {
+    pub(super) fn pop_function_return_types(&mut self, node: &Node, instr_name: &str) {
         if let Some(end_types) = self.ctrl_stack.first().map(|f| f.end_types.clone()) {
             self.pop_vals_for_instr(&end_types, node, instr_name);
         }
     }
 
     /// Take all collected diagnostics out of the checker.
-    pub fn take_diagnostics(&mut self) -> Vec<Diagnostic> {
+    pub(super) fn take_diagnostics(&mut self) -> Vec<Diagnostic> {
         std::mem::take(&mut self.diagnostics)
     }
 }

--- a/src/features/signature/tests.rs
+++ b/src/features/signature/tests.rs
@@ -3,15 +3,10 @@ use super::*;
 use crate::features::test_utils::{create_signature_test_symbols, create_test_tree};
 use crate::utils::format_function_signature;
 
-// Alias for backwards compatibility with existing tests
-fn create_test_symbols() -> SymbolTable {
-    create_signature_test_symbols()
-}
-
 #[test]
 fn test_signature_help_simple_call() {
     let document = "call $add(";
-    let symbols = create_test_symbols();
+    let symbols = create_signature_test_symbols();
     let position = Position::new(0, 10); // After opening paren
 
     let sig_help =
@@ -32,7 +27,7 @@ fn test_signature_help_simple_call() {
 #[test]
 fn test_signature_help_with_first_arg() {
     let document = "call $add(5,";
-    let symbols = create_test_symbols();
+    let symbols = create_signature_test_symbols();
     let position = Position::new(0, 12); // After first comma
 
     let sig_help =
@@ -47,7 +42,7 @@ fn test_signature_help_with_first_arg() {
 #[test]
 fn test_signature_help_multi_param() {
     let document = "call $process(1,";
-    let symbols = create_test_symbols();
+    let symbols = create_signature_test_symbols();
     let position = Position::new(0, 16);
 
     let sig_help =
@@ -65,7 +60,7 @@ fn test_signature_help_multi_param() {
 #[test]
 fn test_signature_help_third_param() {
     let document = "call $process(1, 2,";
-    let symbols = create_test_symbols();
+    let symbols = create_signature_test_symbols();
     let position = Position::new(0, 19);
 
     let sig_help =
@@ -79,7 +74,7 @@ fn test_signature_help_third_param() {
 #[test]
 fn test_signature_help_nonexistent_function() {
     let document = "call $nonexistent(";
-    let symbols = create_test_symbols();
+    let symbols = create_signature_test_symbols();
     let position = Position::new(0, 18);
 
     let sig_help =
@@ -91,7 +86,7 @@ fn test_signature_help_nonexistent_function() {
 #[test]
 fn test_signature_help_by_index() {
     let document = "call 0(";
-    let symbols = create_test_symbols();
+    let symbols = create_signature_test_symbols();
     let position = Position::new(0, 7);
 
     let sig_help =
@@ -266,7 +261,7 @@ fn test_format_function_signature_unnamed_params() {
 #[test]
 fn test_signature_help_parameter_info() {
     let document = "call $add(";
-    let symbols = create_test_symbols();
+    let symbols = create_signature_test_symbols();
     let position = Position::new(0, 10);
 
     let sig_help =
@@ -323,7 +318,7 @@ fn test_find_function_call_call_ref_by_index() {
 #[test]
 fn test_signature_help_call_ref() {
     let document = "call_ref $binop(";
-    let symbols = create_test_symbols();
+    let symbols = create_signature_test_symbols();
     let position = Position::new(0, 16);
 
     let sig_help =
@@ -353,7 +348,7 @@ fn test_signature_help_call_ref() {
 #[test]
 fn test_signature_help_return_call_ref() {
     let document = "return_call_ref $complex_fn(";
-    let symbols = create_test_symbols();
+    let symbols = create_signature_test_symbols();
     let position = Position::new(0, 28);
 
     let sig_help =
@@ -373,7 +368,7 @@ fn test_signature_help_return_call_ref() {
 #[test]
 fn test_signature_help_call_ref_nonexistent_type() {
     let document = "call_ref $nonexistent(";
-    let symbols = create_test_symbols();
+    let symbols = create_signature_test_symbols();
     let position = Position::new(0, 22);
 
     let sig_help =
@@ -385,7 +380,7 @@ fn test_signature_help_call_ref_nonexistent_type() {
 #[test]
 fn test_signature_help_call_ref_by_index() {
     let document = "call_ref 0(";
-    let symbols = create_test_symbols();
+    let symbols = create_signature_test_symbols();
     let position = Position::new(0, 11);
 
     let sig_help =

--- a/src/features/symbols/mod.rs
+++ b/src/features/symbols/mod.rs
@@ -349,10 +349,10 @@ pub struct SymbolTable {
     pub num_imported_globals: usize,
 }
 
-/// Macro to generate add/get methods for symbol types.
-/// Eliminates boilerplate for the 8 symbol type method triplets.
+/// Macro to generate add/get/resolve methods for symbol types.
+/// Eliminates boilerplate for the 8 symbol type method sets.
 macro_rules! impl_symbol_accessors {
-    ($add_name:ident, $get_by_name:ident, $get_by_index:ident,
+    ($add_name:ident, $get_by_name:ident, $get_by_index:ident, $resolve:ident,
      $type:ty, $vec:ident, $map:ident) => {
         pub fn $add_name(&mut self, item: $type) {
             let index = self.$vec.len();
@@ -368,6 +368,16 @@ macro_rules! impl_symbol_accessors {
 
         pub fn $get_by_index(&self, index: usize) -> Option<&$type> {
             self.$vec.get(index)
+        }
+
+        /// Resolve by name (starting with '$') or numeric index.
+        pub fn $resolve(&self, name_or_index: &str) -> Option<&$type> {
+            self.$get_by_name(name_or_index).or_else(|| {
+                name_or_index
+                    .parse::<usize>()
+                    .ok()
+                    .and_then(|idx| self.$get_by_index(idx))
+            })
         }
     };
 }
@@ -401,6 +411,7 @@ impl SymbolTable {
         add_function,
         get_function_by_name,
         get_function_by_index,
+        resolve_function,
         Function,
         functions,
         function_map
@@ -409,6 +420,7 @@ impl SymbolTable {
         add_global,
         get_global_by_name,
         get_global_by_index,
+        resolve_global,
         Global,
         globals,
         global_map
@@ -417,6 +429,7 @@ impl SymbolTable {
         add_table,
         get_table_by_name,
         get_table_by_index,
+        resolve_table,
         Table,
         tables,
         table_map
@@ -425,6 +438,7 @@ impl SymbolTable {
         add_memory,
         get_memory_by_name,
         get_memory_by_index,
+        resolve_memory,
         Memory,
         memories,
         memory_map
@@ -433,6 +447,7 @@ impl SymbolTable {
         add_type,
         get_type_by_name,
         get_type_by_index,
+        resolve_type,
         TypeDef,
         types,
         type_map
@@ -441,6 +456,7 @@ impl SymbolTable {
         add_tag,
         get_tag_by_name,
         get_tag_by_index,
+        resolve_tag,
         Tag,
         tags,
         tag_map
@@ -449,6 +465,7 @@ impl SymbolTable {
         add_data,
         get_data_by_name,
         get_data_by_index,
+        resolve_data,
         DataSegment,
         data_segments,
         data_map
@@ -457,6 +474,7 @@ impl SymbolTable {
         add_elem,
         get_elem_by_name,
         get_elem_by_index,
+        resolve_elem,
         ElemSegment,
         elem_segments,
         elem_map

--- a/src/wasm/api.rs
+++ b/src/wasm/api.rs
@@ -9,7 +9,6 @@ use crate::core::types::{
     CompletionItem, CompletionItemKind, Diagnostic as CoreDiagnostic, HoverResult,
     InsertTextFormat, Position, Range,
 };
-use crate::diagnostics_core::tree_walk::{walk_tree_for_diagnostics, DiagnosticConfig};
 use crate::folding::{provide_folding_ranges, FoldingRangeKind};
 use crate::hover::provide_hover_core;
 use crate::parser::parse_document_from_tree;
@@ -150,26 +149,11 @@ impl WatLSP {
                 js_array.push(&core_diagnostic_to_js(&diag));
             }
 
-            // Semantic diagnostics via shared tree walk
-            let config = DiagnosticConfig::from_symbols(symbols);
-            let mut diagnostics = Vec::new();
-            walk_tree_for_diagnostics(
+            // Semantic diagnostics via shared pipeline
+            let diagnostics = crate::diagnostics_core::collect_all_semantic_diagnostics(
                 tree.root_node(),
                 &self.document,
                 symbols,
-                &config,
-                &mut diagnostics,
-            );
-
-            // Subtype hierarchy + module-level structural validations
-            diagnostics
-                .extend(crate::diagnostics_core::subtype::validate_subtype_hierarchy(symbols));
-            diagnostics.extend(
-                crate::diagnostics_core::module_checks::validate_module_structure(
-                    &tree.root_node(),
-                    &self.document,
-                    symbols,
-                ),
             );
 
             for diag in diagnostics {


### PR DESCRIPTION
## Summary

- Add `resolve_*` methods to SymbolTable, replacing 10+ copies of name-or-index lookup pattern
- Convert `derive_consumed_types_from_name` to return `Cow<'static, [ValueType]>`, eliminating ~60 per-instruction heap allocations
- Convert 14 diagnostic check functions from returning `Vec<Diagnostic>` to taking `&mut Vec` parameter
- Change `Diagnostic.source` to `&'static str` and `code` to `Option<&'static str>`
- Convert 8 `HashMap<String, Range>` to `HashMap<&str, Range>` in module_checks
- Extract shared `collect_all_semantic_diagnostics` used by both native and WASM
- Tighten ~50 `pub` items to `pub(crate)`/`pub(super)` across diagnostics_core
- Extract `is_inner_block_kind()` predicate from 4 duplicated 6-way checks