### PR TITLE
feat: add folded/linear WAT format toggle to docs site

### DIFF
--- a/packages/docs/src/components/CodeMirrorEnhancer.tsx
+++ b/packages/docs/src/components/CodeMirrorEnhancer.tsx
@@ -16,6 +16,7 @@ import { oneDark } from '@codemirror/theme-one-dark';
 import { createWatLSP } from '@emnudge/wat-lsp';
 import treeSitterWasmUrl from '@emnudge/wat-lsp/wasm/tree-sitter.wasm?url';
 import watLspWasmUrl from '@emnudge/wat-lsp/wasm/wat_lsp_rust_bg.wasm?url';
+import { foldedToLinear } from '../lib/wat-linearizer';
 
 // WAT language definition for CodeMirror StreamLanguage
 const watLanguage = StreamLanguage.define({
@@ -486,7 +487,27 @@ async function enhanceCodeBlock(pre: HTMLElement) {
 
   if (!code.trim()) return;
 
-  // Create container - use max-height to let CodeMirror size itself properly
+  // Pre-compute linear form for toggle
+  const isInstructionPage = window.location.pathname.includes('/instructions/');
+  const hasFoldedExprs = code.includes('(func') && /\(\w+[\w.]*\s+\(/.test(code);
+  let linearCode: string | null = null;
+  if (hasFoldedExprs && !isInstructionPage) {
+    try {
+      const converted = foldedToLinear(code);
+      if (converted !== code) linearCode = converted;
+    } catch {
+      // Conversion failed — skip toggle
+    }
+  }
+
+  // Create outer wrapper (position context for toggle) and inner scroll container
+  const wrapper = document.createElement('div');
+  wrapper.className = 'wat-editor-wrapper not-content';
+  wrapper.style.cssText = `
+    position: relative;
+    margin-block: 1rem;
+  `;
+
   const container = document.createElement('div');
   container.className = 'wat-editor-container';
   container.style.cssText = `
@@ -494,12 +515,13 @@ async function enhanceCodeBlock(pre: HTMLElement) {
     min-height: 120px;
     border-radius: 8px;
     overflow: auto;
-    margin-block: 1rem;
   `;
+
+  wrapper.appendChild(container);
 
   // Replace only the figure, not the entire .expressive-code wrapper
   // (the wrapper may contain sibling figures for other languages)
-  target.replaceWith(container);
+  target.replaceWith(wrapper);
 
   // Build extensions list
   const extensions = [
@@ -529,10 +551,51 @@ async function enhanceCodeBlock(pre: HTMLElement) {
     extensions,
   });
 
-  new EditorView({
+  const view = new EditorView({
     state,
     parent: container,
   });
+
+  // Add folded/linear toggle if applicable
+  if (linearCode) {
+    let isFolded = true;
+    const foldedCode = code;
+
+    const toggle = document.createElement('div');
+    toggle.className = 'wat-format-toggle';
+
+    const btnFolded = document.createElement('button');
+    btnFolded.className = 'wat-format-btn active';
+    btnFolded.textContent = 'Folded';
+    btnFolded.type = 'button';
+
+    const btnLinear = document.createElement('button');
+    btnLinear.className = 'wat-format-btn';
+    btnLinear.textContent = 'Linear';
+    btnLinear.type = 'button';
+
+    toggle.appendChild(btnFolded);
+    toggle.appendChild(btnLinear);
+    wrapper.appendChild(toggle);
+
+    const switchTo = (folded: boolean) => {
+      if (folded === isFolded) return;
+      isFolded = folded;
+      const newCode = folded ? foldedCode : linearCode!;
+      view.dispatch({
+        changes: { from: 0, to: view.state.doc.length, insert: newCode },
+      });
+      // Re-parse for hover/diagnostics
+      initLSP().then((lsp) => {
+        if (lsp?.ready) lsp.parse(newCode);
+      });
+      btnFolded.className = `wat-format-btn${folded ? ' active' : ''}`;
+      btnLinear.className = `wat-format-btn${folded ? '' : ' active'}`;
+    };
+
+    btnFolded.addEventListener('click', () => switchTo(true));
+    btnLinear.addEventListener('click', () => switchTo(false));
+  }
 }
 
 async function enhanceAllWatBlocks() {

--- a/packages/docs/src/lib/wat-linearizer.ts
+++ b/packages/docs/src/lib/wat-linearizer.ts
@@ -1,0 +1,608 @@
+// Folded (S-expression) → Linear (stack) WAT format converter.
+// Only transforms instruction bodies inside func forms; module structure is preserved.
+
+// ── Token types ──
+
+const enum TT {
+  LPAREN,
+  RPAREN,
+  STRING,
+  LINE_COMMENT,
+  BLOCK_COMMENT,
+  WORD,
+  WHITESPACE,
+}
+
+interface Token {
+  type: TT;
+  value: string;
+  offset: number;
+}
+
+// ── Tokenizer ──
+
+function tokenize(src: string): Token[] {
+  const tokens: Token[] = [];
+  let i = 0;
+  while (i < src.length) {
+    const ch = src[i];
+
+    // Whitespace
+    if (ch === ' ' || ch === '\t' || ch === '\n' || ch === '\r') {
+      const start = i;
+      while (
+        i < src.length &&
+        (src[i] === ' ' || src[i] === '\t' || src[i] === '\n' || src[i] === '\r')
+      )
+        i++;
+      tokens.push({ type: TT.WHITESPACE, value: src.slice(start, i), offset: start });
+      continue;
+    }
+
+    // Block comment (; ... ;)
+    if (ch === '(' && src[i + 1] === ';') {
+      const start = i;
+      i += 2;
+      let depth = 1;
+      while (i < src.length && depth > 0) {
+        if (src[i] === '(' && src[i + 1] === ';') {
+          depth++;
+          i += 2;
+        } else if (src[i] === ';' && src[i + 1] === ')') {
+          depth--;
+          i += 2;
+        } else i++;
+      }
+      tokens.push({ type: TT.BLOCK_COMMENT, value: src.slice(start, i), offset: start });
+      continue;
+    }
+
+    // Line comment
+    if (ch === ';' && src[i + 1] === ';') {
+      const start = i;
+      while (i < src.length && src[i] !== '\n') i++;
+      tokens.push({ type: TT.LINE_COMMENT, value: src.slice(start, i), offset: start });
+      continue;
+    }
+
+    // Parentheses
+    if (ch === '(') {
+      tokens.push({ type: TT.LPAREN, value: '(', offset: i });
+      i++;
+      continue;
+    }
+    if (ch === ')') {
+      tokens.push({ type: TT.RPAREN, value: ')', offset: i });
+      i++;
+      continue;
+    }
+
+    // String
+    if (ch === '"') {
+      const start = i;
+      i++;
+      while (i < src.length && src[i] !== '"') {
+        if (src[i] === '\\') i++;
+        i++;
+      }
+      i++; // closing quote
+      tokens.push({ type: TT.STRING, value: src.slice(start, i), offset: start });
+      continue;
+    }
+
+    // Word (anything else non-whitespace, non-paren, non-string)
+    const start = i;
+    while (
+      i < src.length &&
+      src[i] !== ' ' &&
+      src[i] !== '\t' &&
+      src[i] !== '\n' &&
+      src[i] !== '\r' &&
+      src[i] !== '(' &&
+      src[i] !== ')' &&
+      src[i] !== '"' &&
+      !(src[i] === ';' && src[i + 1] === ';') &&
+      !(src[i] === '(' && src[i + 1] === ';')
+    ) {
+      i++;
+    }
+    if (i > start) {
+      tokens.push({ type: TT.WORD, value: src.slice(start, i), offset: start });
+    }
+  }
+  return tokens;
+}
+
+// ── S-expression AST ──
+
+export type SExpr =
+  | { type: 'list'; children: SExpr[]; head?: string }
+  | { type: 'atom'; value: string }
+  | { type: 'string'; value: string }
+  | { type: 'comment'; value: string; block: boolean };
+
+function parseSExprs(tokens: Token[]): SExpr[] {
+  let pos = 0;
+
+  function parseOne(): SExpr | null {
+    while (pos < tokens.length) {
+      const tok = tokens[pos];
+      if (tok.type === TT.WHITESPACE) {
+        pos++;
+        continue;
+      }
+
+      if (tok.type === TT.LINE_COMMENT) {
+        pos++;
+        return { type: 'comment', value: tok.value, block: false };
+      }
+      if (tok.type === TT.BLOCK_COMMENT) {
+        pos++;
+        return { type: 'comment', value: tok.value, block: true };
+      }
+      if (tok.type === TT.STRING) {
+        pos++;
+        return { type: 'string', value: tok.value };
+      }
+      if (tok.type === TT.WORD) {
+        pos++;
+        return { type: 'atom', value: tok.value };
+      }
+      if (tok.type === TT.RPAREN) {
+        return null; // end of list
+      }
+      if (tok.type === TT.LPAREN) {
+        pos++; // consume '('
+        const children: SExpr[] = [];
+        let head: string | undefined;
+        while (pos < tokens.length) {
+          const t = tokens[pos];
+          if (t.type === TT.WHITESPACE) {
+            pos++;
+            continue;
+          }
+          if (t.type === TT.RPAREN) {
+            pos++;
+            break;
+          }
+          const child = parseOne();
+          if (child === null) break;
+          if (head === undefined && child.type === 'atom') {
+            head = child.value;
+          }
+          children.push(child);
+        }
+        return { type: 'list', children, head };
+      }
+      pos++;
+    }
+    return null;
+  }
+
+  const results: SExpr[] = [];
+  while (pos < tokens.length) {
+    const expr = parseOne();
+    if (expr) results.push(expr);
+  }
+  return results;
+}
+
+// ── Instruction classification ──
+
+const DECLARATION_HEADS = new Set([
+  'module',
+  'func',
+  'param',
+  'result',
+  'local',
+  'global',
+  'table',
+  'memory',
+  'type',
+  'import',
+  'export',
+  'data',
+  'elem',
+  'start',
+  'then',
+  'else',
+  'mut',
+  'offset',
+  'item',
+  'declare',
+  'field',
+  'rec',
+  'sub',
+  'final',
+  'tag',
+]);
+
+const BARE_INSTRUCTION_KEYWORDS = new Set([
+  'block',
+  'loop',
+  'if',
+  'br',
+  'br_if',
+  'br_table',
+  'call',
+  'call_indirect',
+  'return',
+  'drop',
+  'select',
+  'unreachable',
+  'nop',
+  'return_call',
+  'return_call_indirect',
+  'return_call_ref',
+  'call_ref',
+  'throw',
+  'rethrow',
+  'try_table',
+  'throw_ref',
+]);
+
+function isInstruction(head: string): boolean {
+  if (DECLARATION_HEADS.has(head)) return false;
+  if (BARE_INSTRUCTION_KEYWORDS.has(head)) return true;
+  // Dot-prefixed instructions: i32.add, local.get, memory.grow, etc.
+  if (head.includes('.')) return true;
+  return false;
+}
+
+// ── Linearizer ──
+
+function exprToString(expr: SExpr): string {
+  if (expr.type === 'atom') return expr.value;
+  if (expr.type === 'string') return expr.value;
+  if (expr.type === 'comment') return expr.value;
+  if (expr.type === 'list') {
+    return '(' + expr.children.map(exprToString).join(' ') + ')';
+  }
+  return '';
+}
+
+interface LinearLine {
+  text: string;
+  indent: number;
+}
+
+function linearizeBody(exprs: SExpr[], baseIndent: number): LinearLine[] {
+  const lines: LinearLine[] = [];
+
+  for (const expr of exprs) {
+    if (expr.type === 'comment') {
+      lines.push({ text: expr.value, indent: baseIndent });
+      continue;
+    }
+
+    if (expr.type === 'atom' || expr.type === 'string') {
+      // Bare atom in instruction body — pass through
+      lines.push({ text: expr.value, indent: baseIndent });
+      continue;
+    }
+
+    if (expr.type !== 'list' || !expr.head) {
+      lines.push({ text: exprToString(expr), indent: baseIndent });
+      continue;
+    }
+
+    const head = expr.head;
+
+    // Non-instruction list — emit verbatim (e.g., (param ...), (result ...), (local ...))
+    if (!isInstruction(head)) {
+      lines.push({ text: exprToString(expr), indent: baseIndent });
+      continue;
+    }
+
+    // Control: block / loop
+    if (head === 'block' || head === 'loop') {
+      linearizeBlock(expr, head, baseIndent, lines);
+      continue;
+    }
+
+    // Control: if
+    if (head === 'if') {
+      linearizeIf(expr, baseIndent, lines);
+      continue;
+    }
+
+    // Regular instruction: linearize nested args first, then emit instruction
+    linearizeInstruction(expr, baseIndent, lines);
+  }
+
+  return lines;
+}
+
+function linearizeBlock(
+  expr: SExpr & { type: 'list' },
+  kind: string,
+  indent: number,
+  lines: LinearLine[],
+) {
+  const children = expr.children;
+  // children[0] is the head atom (block/loop)
+  // Collect header parts: label, type annotations
+  const headerParts: string[] = [kind];
+  let bodyStart = 1;
+  let label: string | undefined;
+
+  for (let i = 1; i < children.length; i++) {
+    const c = children[i];
+    if (c.type === 'atom' && c.value.startsWith('$')) {
+      headerParts.push(c.value);
+      label = c.value;
+      bodyStart = i + 1;
+    } else if (
+      c.type === 'list' &&
+      (c.head === 'result' || c.head === 'type' || c.head === 'param')
+    ) {
+      headerParts.push(exprToString(c));
+      bodyStart = i + 1;
+    } else {
+      bodyStart = i;
+      break;
+    }
+  }
+
+  lines.push({ text: headerParts.join(' '), indent });
+
+  const bodyExprs = children.slice(bodyStart);
+  const bodyLines = linearizeBody(bodyExprs, indent + 2);
+  lines.push(...bodyLines);
+
+  lines.push({ text: label ? `end ${label}` : 'end', indent });
+}
+
+function linearizeIf(expr: SExpr & { type: 'list' }, indent: number, lines: LinearLine[]) {
+  const children = expr.children;
+  // children[0] = 'if' atom
+  // Collect: optional label, optional (result ...), condition, (then ...), optional (else ...)
+  const headerParts: string[] = ['if'];
+  let idx = 1;
+  let label: string | undefined;
+
+  // Label
+  const maybeLabel = children[idx];
+  if (maybeLabel && maybeLabel.type === 'atom' && maybeLabel.value.startsWith('$')) {
+    label = maybeLabel.value;
+    headerParts.push(label);
+    idx++;
+  }
+
+  // Result / type annotations
+  while (idx < children.length) {
+    const c = children[idx];
+    if (c.type === 'list' && (c.head === 'result' || c.head === 'type' || c.head === 'param')) {
+      headerParts.push(exprToString(c));
+      idx++;
+    } else {
+      break;
+    }
+  }
+
+  // Condition: everything before (then ...) that is an instruction
+  const condExprs: SExpr[] = [];
+  while (idx < children.length) {
+    const c = children[idx];
+    if (c.type === 'list' && (c.head === 'then' || c.head === 'else')) break;
+    condExprs.push(c);
+    idx++;
+  }
+
+  // Emit condition instructions first
+  const condLines = linearizeBody(condExprs, indent);
+  lines.push(...condLines);
+
+  // Emit if header
+  lines.push({ text: headerParts.join(' '), indent });
+
+  // Then branch
+  const maybeThen = children[idx];
+  if (maybeThen && maybeThen.type === 'list' && maybeThen.head === 'then') {
+    const thenBody = maybeThen.children.slice(1); // skip 'then' atom
+    const thenLines = linearizeBody(thenBody, indent + 2);
+    lines.push(...thenLines);
+    idx++;
+  }
+
+  // Else branch
+  const maybeElse = children[idx];
+  if (maybeElse && maybeElse.type === 'list' && maybeElse.head === 'else') {
+    lines.push({ text: 'else', indent });
+    const elseBody = maybeElse.children.slice(1); // skip 'else' atom
+    const elseLines = linearizeBody(elseBody, indent + 2);
+    lines.push(...elseLines);
+    idx++;
+  }
+
+  lines.push({ text: label ? `end ${label}` : 'end', indent });
+}
+
+function linearizeInstruction(expr: SExpr & { type: 'list' }, indent: number, lines: LinearLine[]) {
+  const children = expr.children;
+  // children[0] = instruction name atom
+  const instrParts: string[] = [(children[0] as { type: 'atom'; value: string }).value];
+  const nestedArgs: SExpr[] = [];
+
+  for (let i = 1; i < children.length; i++) {
+    const c = children[i];
+    if (c.type === 'comment') {
+      // Comments in arg position: emit before instruction
+      nestedArgs.push(c);
+    } else if (c.type === 'atom') {
+      // Immediate argument (label, offset=N, align=N, numeric literal)
+      instrParts.push(c.value);
+    } else if (c.type === 'string') {
+      instrParts.push(c.value);
+    } else if (c.type === 'list' && c.head && isInstruction(c.head)) {
+      // Nested instruction — recursively linearize as argument
+      nestedArgs.push(c);
+    } else if (c.type === 'list' && c.head && !isInstruction(c.head)) {
+      // Non-instruction list in arg position (e.g., (type $t))
+      instrParts.push(exprToString(c));
+    } else {
+      instrParts.push(exprToString(c));
+    }
+  }
+
+  // Emit nested argument instructions first (stack order)
+  for (const arg of nestedArgs) {
+    if (arg.type === 'comment') {
+      lines.push({ text: arg.value, indent });
+    } else {
+      const argLines = linearizeBody([arg], indent);
+      lines.push(...argLines);
+    }
+  }
+
+  // Emit the instruction itself
+  lines.push({ text: instrParts.join(' '), indent });
+}
+
+function linearizeFunc(funcExpr: SExpr & { type: 'list' }): string {
+  const children = funcExpr.children;
+  // children[0] = 'func' atom
+  // Collect header: func name, (export ...), (import ...), (type ...), (param ...), (result ...), (local ...)
+  const headerParts: string[] = [];
+  const localDecls: string[] = [];
+  let bodyStart = 1;
+
+  for (let i = 1; i < children.length; i++) {
+    const c = children[i];
+    if (c.type === 'atom' && c.value.startsWith('$') && headerParts.length === 0) {
+      // Function name
+      headerParts.push(c.value);
+      bodyStart = i + 1;
+    } else if (
+      c.type === 'list' &&
+      c.head &&
+      (c.head === 'export' ||
+        c.head === 'import' ||
+        c.head === 'type' ||
+        c.head === 'param' ||
+        c.head === 'result')
+    ) {
+      headerParts.push(exprToString(c));
+      bodyStart = i + 1;
+    } else if (c.type === 'list' && c.head === 'local') {
+      localDecls.push(exprToString(c));
+      bodyStart = i + 1;
+    } else {
+      bodyStart = i;
+      break;
+    }
+  }
+
+  // Detect indent from original source structure — use 4 spaces for func body
+  const funcHeader = '(func' + (headerParts.length > 0 ? ' ' + headerParts.join(' ') : '');
+  const indent = 4;
+
+  const resultLines: string[] = [];
+  resultLines.push('  ' + funcHeader);
+
+  // Local declarations
+  for (const ld of localDecls) {
+    resultLines.push(' '.repeat(indent) + ld);
+  }
+
+  // Body instructions
+  const bodyExprs = children.slice(bodyStart);
+  const bodyLines = linearizeBody(bodyExprs, indent);
+  for (const bl of bodyLines) {
+    resultLines.push(' '.repeat(bl.indent) + bl.text);
+  }
+
+  resultLines.push('  )');
+
+  return resultLines.join('\n');
+}
+
+function hasFoldedInstructions(funcExpr: SExpr & { type: 'list' }): boolean {
+  const children = funcExpr.children;
+  for (let i = 1; i < children.length; i++) {
+    const c = children[i];
+    if (c.type === 'list' && c.head && isInstruction(c.head)) {
+      // Found an instruction form — this is already folded style
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Convert folded (S-expression) WAT to linear (stack) WAT format.
+ * Only transforms instruction bodies inside `(func ...)` forms.
+ * Module structure, types, imports, exports, etc. are preserved.
+ */
+export function foldedToLinear(source: string): string {
+  const tokens = tokenize(source);
+  const exprs = parseSExprs(tokens);
+
+  if (exprs.length === 0) return source;
+
+  // Process the top-level expression (usually a module)
+  return processTopLevel(exprs, source);
+}
+
+function processTopLevel(exprs: SExpr[], _source: string): string {
+  const lines: string[] = [];
+
+  for (const expr of exprs) {
+    if (expr.type === 'comment') {
+      lines.push(expr.value);
+      continue;
+    }
+    if (expr.type !== 'list') {
+      lines.push(exprToString(expr));
+      continue;
+    }
+
+    if (expr.head === 'module') {
+      lines.push(linearizeModule(expr));
+    } else if (expr.head === 'func') {
+      if (hasFoldedInstructions(expr)) {
+        lines.push(linearizeFunc(expr));
+      } else {
+        lines.push(exprToString(expr));
+      }
+    } else {
+      lines.push(exprToString(expr));
+    }
+  }
+
+  return lines.join('\n');
+}
+
+function linearizeModule(moduleExpr: SExpr & { type: 'list' }): string {
+  const children = moduleExpr.children;
+  const resultLines: string[] = [];
+
+  // Module header: (module or (module $name
+  let moduleHeader = '(module';
+  if (children.length > 1 && children[1].type === 'atom' && children[1].value.startsWith('$')) {
+    moduleHeader += ' ' + children[1].value;
+  }
+  resultLines.push(moduleHeader);
+
+  const startIdx = children[1]?.type === 'atom' && children[1].value.startsWith('$') ? 2 : 1;
+
+  for (let i = startIdx; i < children.length; i++) {
+    const child = children[i];
+
+    if (child.type === 'comment') {
+      resultLines.push('  ' + child.value);
+      continue;
+    }
+
+    if (child.type === 'list' && child.head === 'func' && hasFoldedInstructions(child)) {
+      resultLines.push(linearizeFunc(child));
+      continue;
+    }
+
+    // Non-func or non-folded: preserve as-is with 2-space indent
+    resultLines.push('  ' + exprToString(child));
+  }
+
+  resultLines.push(')');
+  return resultLines.join('\n');
+}

--- a/packages/docs/src/styles/custom.css
+++ b/packages/docs/src/styles/custom.css
@@ -14,3 +14,39 @@
   padding-top: 6rem;
   padding-bottom: 6rem;
 }
+
+/* Folded/Linear format toggle */
+.wat-format-toggle {
+  display: flex;
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  z-index: 10;
+  background: #2d2d2d;
+  border-radius: 4px;
+  padding: 2px;
+  gap: 1px;
+}
+
+.wat-format-btn {
+  all: unset;
+  cursor: pointer;
+  padding: 2px 8px;
+  font-size: 11px;
+  font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace;
+  color: #888;
+  border-radius: 3px;
+  line-height: 1.4;
+  transition:
+    background 0.15s,
+    color 0.15s;
+}
+
+.wat-format-btn:hover {
+  color: #bbb;
+}
+
+.wat-format-btn.active {
+  background: #3c3c3c;
+  color: #d4d4d4;
+}

--- a/packages/docs/tests/wat-linearizer.test.ts
+++ b/packages/docs/tests/wat-linearizer.test.ts
@@ -1,0 +1,321 @@
+import { describe, it, expect } from 'vitest';
+import { foldedToLinear } from '../src/lib/wat-linearizer';
+
+describe('foldedToLinear', () => {
+  describe('simple instructions', () => {
+    it('linearizes a simple binary op', () => {
+      const input = `(module
+  (func (result i32)
+    (i32.add (i32.const 1) (i32.const 2)))
+)`;
+      const output = foldedToLinear(input);
+      expect(output).toBe(`(module
+  (func (result i32)
+    i32.const 1
+    i32.const 2
+    i32.add
+  )
+)`);
+    });
+
+    it('linearizes nested binary ops', () => {
+      const input = `(module
+  (func (param $a i32) (param $b i32) (result i32)
+    (i32.add (i32.mul (local.get $a) (local.get $b)) (i32.const 1)))
+)`;
+      const output = foldedToLinear(input);
+      expect(output).toBe(`(module
+  (func (param $a i32) (param $b i32) (result i32)
+    local.get $a
+    local.get $b
+    i32.mul
+    i32.const 1
+    i32.add
+  )
+)`);
+    });
+  });
+
+  describe('block', () => {
+    it('linearizes a block with label', () => {
+      const input = `(module
+  (func (param $n i32) (result i32)
+    (block $out
+      (br_if $out (i32.eqz (local.get $n)))
+      (return (i32.const 42)))
+    (i32.const 0))
+)`;
+      const output = foldedToLinear(input);
+      expect(output).toBe(`(module
+  (func (param $n i32) (result i32)
+    block $out
+      local.get $n
+      i32.eqz
+      br_if $out
+      i32.const 42
+      return
+    end $out
+    i32.const 0
+  )
+)`);
+    });
+
+    it('linearizes a block with result type', () => {
+      const input = `(module
+  (func (result i32)
+    (block $b (result i32)
+      (i32.const 42)))
+)`;
+      const output = foldedToLinear(input);
+      expect(output).toBe(`(module
+  (func (result i32)
+    block $b (result i32)
+      i32.const 42
+    end $b
+  )
+)`);
+    });
+  });
+
+  describe('loop', () => {
+    it('linearizes a loop with label', () => {
+      const input = `(module
+  (func (param $n i32) (result i32)
+    (local $acc i32)
+    (block $done
+      (loop $again
+        (br_if $done (i32.eqz (local.get $n)))
+        (local.set $acc (i32.add (local.get $acc) (i32.const 1)))
+        (local.set $n (i32.sub (local.get $n) (i32.const 1)))
+        (br $again)))
+    (local.get $acc))
+)`;
+      const output = foldedToLinear(input);
+      expect(output).toBe(`(module
+  (func (param $n i32) (result i32)
+    (local $acc i32)
+    block $done
+      loop $again
+        local.get $n
+        i32.eqz
+        br_if $done
+        local.get $acc
+        i32.const 1
+        i32.add
+        local.set $acc
+        local.get $n
+        i32.const 1
+        i32.sub
+        local.set $n
+        br $again
+      end $again
+    end $done
+    local.get $acc
+  )
+)`);
+    });
+  });
+
+  describe('if/else', () => {
+    it('linearizes if with result type and else', () => {
+      const input = `(module
+  (func (param $x i32) (result i32)
+    (if (result i32) (i32.eqz (local.get $x))
+      (then (i32.const 1))
+      (else (i32.const 0))))
+)`;
+      const output = foldedToLinear(input);
+      expect(output).toBe(`(module
+  (func (param $x i32) (result i32)
+    local.get $x
+    i32.eqz
+    if (result i32)
+      i32.const 1
+    else
+      i32.const 0
+    end
+  )
+)`);
+    });
+
+    it('linearizes if with label', () => {
+      const input = `(module
+  (func (param $x i32) (result i32)
+    (if $lbl (result i32) (local.get $x)
+      (then (i32.const 1))
+      (else (i32.const 0))))
+)`;
+      const output = foldedToLinear(input);
+      expect(output).toBe(`(module
+  (func (param $x i32) (result i32)
+    local.get $x
+    if $lbl (result i32)
+      i32.const 1
+    else
+      i32.const 0
+    end $lbl
+  )
+)`);
+    });
+  });
+
+  describe('instructions with immediates', () => {
+    it('preserves offset and align on memory ops', () => {
+      const input = `(module
+  (memory 1)
+  (func (param $addr i32) (param $val i32)
+    (i32.store offset=4 align=4 (local.get $addr) (local.get $val)))
+)`;
+      const output = foldedToLinear(input);
+      expect(output).toBe(`(module
+  (memory 1)
+  (func (param $addr i32) (param $val i32)
+    local.get $addr
+    local.get $val
+    i32.store offset=4 align=4
+  )
+)`);
+    });
+  });
+
+  describe('call and call_indirect', () => {
+    it('linearizes function calls', () => {
+      const input = `(module
+  (func $double (param $x i32) (result i32)
+    (i32.mul (local.get $x) (i32.const 2)))
+  (func (export "main") (param $n i32) (result i32)
+    (call $double (local.get $n)))
+)`;
+      const output = foldedToLinear(input);
+      expect(output).toBe(`(module
+  (func $double (param $x i32) (result i32)
+    local.get $x
+    i32.const 2
+    i32.mul
+  )
+  (func (export "main") (param $n i32) (result i32)
+    local.get $n
+    call $double
+  )
+)`);
+    });
+  });
+
+  describe('already-linear code', () => {
+    it('passes through linear code unchanged', () => {
+      const input = `(module
+  (func (result i32)
+    i32.const 1
+    i32.const 2
+    i32.add)
+)`;
+      // No folded instructions — should preserve as-is
+      const output = foldedToLinear(input);
+      // The func body has no nested S-expressions, so it goes through exprToString
+      expect(output).toBe(`(module
+  (func (result i32) i32.const 1 i32.const 2 i32.add)
+)`);
+    });
+  });
+
+  describe('comments', () => {
+    it('preserves line comments', () => {
+      const input = `(module
+  (func (result i32)
+    ;; add two numbers
+    (i32.add (i32.const 1) (i32.const 2)))
+)`;
+      const output = foldedToLinear(input);
+      expect(output).toContain(';; add two numbers');
+      expect(output).toContain('i32.const 1');
+      expect(output).toContain('i32.add');
+    });
+  });
+
+  describe('module structure preservation', () => {
+    it('preserves non-func module elements', () => {
+      const input = `(module
+  (type $t (func (param i32) (result i32)))
+  (memory 1)
+  (global $g (mut i32) (i32.const 0))
+  (func (param i32) (result i32)
+    (i32.add (local.get 0) (i32.const 1)))
+)`;
+      const output = foldedToLinear(input);
+      expect(output).toContain('(type $t (func (param i32) (result i32)))');
+      expect(output).toContain('(memory 1)');
+      expect(output).toContain('(global $g (mut i32) (i32.const 0))');
+      expect(output).toContain('local.get 0');
+      expect(output).toContain('i32.const 1');
+      expect(output).toContain('i32.add');
+    });
+
+    it('preserves inline exports', () => {
+      const input = `(module
+  (func (export "add") (param $a i32) (param $b i32) (result i32)
+    (i32.add (local.get $a) (local.get $b)))
+)`;
+      const output = foldedToLinear(input);
+      expect(output).toContain('(func (export "add") (param $a i32) (param $b i32) (result i32)');
+    });
+  });
+
+  describe('select', () => {
+    it('linearizes select with nested args', () => {
+      const input = `(module
+  (func (param $a i32) (param $b i32) (param $c i32) (result i32)
+    (select (local.get $a) (local.get $b) (local.get $c)))
+)`;
+      const output = foldedToLinear(input);
+      expect(output).toBe(`(module
+  (func (param $a i32) (param $b i32) (param $c i32) (result i32)
+    local.get $a
+    local.get $b
+    local.get $c
+    select
+  )
+)`);
+    });
+  });
+
+  describe('drop', () => {
+    it('linearizes drop', () => {
+      const input = `(module
+  (func (param $x i32)
+    (drop (local.get $x)))
+)`;
+      const output = foldedToLinear(input);
+      expect(output).toBe(`(module
+  (func (param $x i32)
+    local.get $x
+    drop
+  )
+)`);
+    });
+  });
+
+  describe('deeply nested', () => {
+    it('handles triple nesting', () => {
+      const input = `(module
+  (func (result i32)
+    (i32.add
+      (i32.mul
+        (i32.sub (i32.const 10) (i32.const 3))
+        (i32.const 2))
+      (i32.const 1)))
+)`;
+      const output = foldedToLinear(input);
+      expect(output).toBe(`(module
+  (func (result i32)
+    i32.const 10
+    i32.const 3
+    i32.sub
+    i32.const 2
+    i32.mul
+    i32.const 1
+    i32.add
+  )
+)`);
+    });
+  });
+});

--- a/packages/docs/vitest.config.js
+++ b/packages/docs/vitest.config.js
@@ -3,6 +3,6 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     testTimeout: 30000,
-    include: ['tests/**/*.test.{js,mjs}'],
+    include: ['tests/**/*.test.{js,mjs,ts}'],
   },
 });


### PR DESCRIPTION
## Summary

- Add a pure-TypeScript folded → linear WAT converter (`wat-linearizer.ts`) with tokenizer, S-expression parser, and linearizer
- Add [Folded | Linear] segmented toggle to CodeMirror editors on docs pages
- 16 unit tests covering all conversion patterns (blocks, loops, if/else, nested ops, comments, etc.)
- Toggle skipped for instruction reference pages and non-folded code