### PR TITLE
fix linearizer and grammar bugs, add linearization CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,11 @@ jobs:
           fi
           echo "All examples validated correctly"
 
+      - name: Validate linearized examples
+        shell: bash
+        run: |
+          npx tsx scripts/check-linearized-examples.ts
+
   validate-wasm-tools:
     name: Validate Examples (wasm-tools)
     needs: changes

--- a/grammars/tree-sitter-wat/grammar.js
+++ b/grammars/tree-sitter-wat/grammar.js
@@ -260,14 +260,14 @@ module.exports = grammar({
     instr_block: $ => choice($.block_block, $.block_loop, $.block_if, $.block_try, $.block_try_table),
 
     instr_call: $ =>
-      seq(choice("call_indirect", "return_call_indirect"), optional($.type_use), repeat($.func_type_params_many), repeat($.func_type_results), $.instr),
+      seq(choice("call_indirect", "return_call_indirect"), optional($.index), optional($.type_use), repeat($.func_type_params_many), repeat($.func_type_results), $.instr),
 
     // NOTE: this must be wrapped in "optional"
     instr_list: $ => repeat1(choice($.instr_list_call, $.instr)),
 
     instr_list_call: $ =>
       prec.right(
-        seq(choice("call_indirect", "return_call_indirect"), optional($.type_use), repeat($.func_type_params_many), repeat($.func_type_results)),
+        seq(choice("call_indirect", "return_call_indirect"), optional($.index), optional($.type_use), repeat($.func_type_params_many), repeat($.func_type_results)),
       ),
 
     instr_plain: $ =>

--- a/packages/docs/src/lib/wat-linearizer.ts
+++ b/packages/docs/src/lib/wat-linearizer.ts
@@ -256,7 +256,17 @@ function exprToString(expr: SExpr): string {
   if (expr.type === 'string') return expr.value;
   if (expr.type === 'comment') return expr.value;
   if (expr.type === 'list') {
-    return '(' + expr.children.map(exprToString).join(' ') + ')';
+    const parts = expr.children.map(exprToString);
+    let result = '(';
+    for (let i = 0; i < parts.length; i++) {
+      if (i > 0) {
+        // After a line comment, use newline so the comment doesn't eat subsequent code
+        const prev = expr.children[i - 1];
+        result += prev.type === 'comment' && !prev.block ? '\n' : ' ';
+      }
+      result += parts[i];
+    }
+    return result + ')';
   }
   return '';
 }
@@ -303,6 +313,12 @@ function linearizeBody(exprs: SExpr[], baseIndent: number): LinearLine[] {
     // Control: if
     if (head === 'if') {
       linearizeIf(expr, baseIndent, lines);
+      continue;
+    }
+
+    // Control: try_table
+    if (head === 'try_table') {
+      linearizeTryTable(expr, baseIndent, lines);
       continue;
     }
 
@@ -405,6 +421,15 @@ function linearizeIf(expr: SExpr & { type: 'list' }, indent: number, lines: Line
     idx++;
   }
 
+  // Skip comments between then and else
+  while (idx < children.length && children[idx].type === 'comment') {
+    lines.push({
+      text: (children[idx] as { type: 'comment'; value: string }).value,
+      indent: indent + 2,
+    });
+    idx++;
+  }
+
   // Else branch
   const maybeElse = children[idx];
   if (maybeElse && maybeElse.type === 'list' && maybeElse.head === 'else') {
@@ -414,6 +439,45 @@ function linearizeIf(expr: SExpr & { type: 'list' }, indent: number, lines: Line
     lines.push(...elseLines);
     idx++;
   }
+
+  lines.push({ text: label ? `end ${label}` : 'end', indent });
+}
+
+const CATCH_HEADS = new Set(['catch', 'catch_ref', 'catch_all', 'catch_all_ref']);
+
+function linearizeTryTable(expr: SExpr & { type: 'list' }, indent: number, lines: LinearLine[]) {
+  const children = expr.children;
+  // children[0] = 'try_table' atom
+  const headerParts: string[] = ['try_table'];
+  let bodyStart = 1;
+  let label: string | undefined;
+
+  for (let i = 1; i < children.length; i++) {
+    const c = children[i];
+    if (c.type === 'atom' && c.value.startsWith('$')) {
+      headerParts.push(c.value);
+      label = c.value;
+      bodyStart = i + 1;
+    } else if (
+      c.type === 'list' &&
+      (c.head === 'result' || c.head === 'type' || c.head === 'param')
+    ) {
+      headerParts.push(exprToString(c));
+      bodyStart = i + 1;
+    } else if (c.type === 'list' && c.head && CATCH_HEADS.has(c.head)) {
+      headerParts.push(exprToString(c));
+      bodyStart = i + 1;
+    } else {
+      bodyStart = i;
+      break;
+    }
+  }
+
+  lines.push({ text: headerParts.join(' '), indent });
+
+  const bodyExprs = children.slice(bodyStart);
+  const bodyLines = linearizeBody(bodyExprs, indent + 2);
+  lines.push(...bodyLines);
 
   lines.push({ text: label ? `end ${label}` : 'end', indent });
 }

--- a/packages/docs/tests/wat-linearizer.test.ts
+++ b/packages/docs/tests/wat-linearizer.test.ts
@@ -318,4 +318,82 @@ describe('foldedToLinear', () => {
 )`);
     });
   });
+
+  describe('try_table', () => {
+    it('linearizes try_table as a block', () => {
+      const input = `(module
+  (tag $e (param i32))
+  (func (result i32)
+    (block $handler (result i32)
+      (try_table (result i32) (catch $e $handler)
+        (i32.const 42)
+        (throw $e (i32.const 1)))
+      (i32.const 0)))
+)`;
+      const output = foldedToLinear(input);
+      expect(output).toBe(`(module
+  (tag $e (param i32))
+  (func (result i32)
+    block $handler (result i32)
+      try_table (result i32) (catch $e $handler)
+        i32.const 42
+        i32.const 1
+        throw $e
+      end
+      i32.const 0
+    end $handler
+  )
+)`);
+    });
+
+    it('linearizes try_table with catch_all', () => {
+      const input = `(module
+  (func $may_throw)
+  (func
+    (block $fallback
+      (try_table (catch_all $fallback)
+        (call $may_throw))))
+)`;
+      const output = foldedToLinear(input);
+      expect(output).toBe(`(module
+  (func $may_throw)
+  (func
+    block $fallback
+      try_table (catch_all $fallback)
+        call $may_throw
+      end
+    end $fallback
+  )
+)`);
+    });
+  });
+
+  describe('if with comments between branches', () => {
+    it('preserves else when comment separates then and else', () => {
+      const input = `(module
+  (func (param $a i32) (param $b i32) (result i32)
+    (if (result i32) (i32.eqz (local.get $b))
+      (then (i32.const 0)) ;; zero case
+      (else (i32.div_s (local.get $a) (local.get $b)))))
+)`;
+      const output = foldedToLinear(input);
+      expect(output).toContain('else');
+      expect(output).toContain('i32.div_s');
+    });
+  });
+
+  describe('line comments in non-folded code', () => {
+    it('preserves code after line comments', () => {
+      const input = `(module
+  (func (param $a i32) (param $b i32) (result i32)
+    (i32.add
+      (local.get $a) ;; first operand
+      (local.get $b)))
+)`;
+      const output = foldedToLinear(input);
+      expect(output).toContain('local.get $a');
+      expect(output).toContain('local.get $b');
+      expect(output).toContain('i32.add');
+    });
+  });
 });

--- a/scripts/check-linearized-examples.ts
+++ b/scripts/check-linearized-examples.ts
@@ -1,0 +1,86 @@
+#!/usr/bin/env npx tsx
+// Validates that linearized (stack-form) WAT examples produce no new errors.
+// Converts each playground example from folded to linear form using the
+// docs linearizer, then runs wat-check on both versions and compares.
+
+import { foldedToLinear } from '../packages/docs/src/lib/wat-linearizer';
+import { readFileSync, writeFileSync, mkdirSync, readdirSync } from 'fs';
+import { join, basename } from 'path';
+import { execSync } from 'child_process';
+
+const WAT_CHECK = process.env.WAT_CHECK ?? join(__dirname, '..', 'target', 'release', 'wat-check');
+const EXAMPLES_DIR = join(__dirname, '..', 'packages', 'playground', 'examples');
+const OUT_DIR = join(__dirname, '..', 'target', 'linearized-examples');
+
+mkdirSync(OUT_DIR, { recursive: true });
+
+function runWatCheck(filePath: string): string[] {
+  try {
+    const output = execSync(`"${WAT_CHECK}" "${filePath}" --format compact --errors-only 2>&1`, {
+      encoding: 'utf-8',
+      timeout: 10000,
+    });
+    return output.trim().split('\n').filter(l => l.trim().length > 0);
+  } catch (e: any) {
+    const output = ((e.stdout ?? '') + (e.stderr ?? '')).trim();
+    return output.split('\n').filter(l => l.trim().length > 0);
+  }
+}
+
+function normalizeMessage(diag: string): string {
+  // Strip file path and line:col, keep just the severity and message
+  return diag.replace(/^[^:]+:\d+:\d+:/, 'X:');
+}
+
+const exampleFiles = readdirSync(EXAMPLES_DIR)
+  .filter(f => f.endsWith('.wat'))
+  .sort();
+
+let failures = 0;
+
+for (const file of exampleFiles) {
+  const origPath = join(EXAMPLES_DIR, file);
+  const origSource = readFileSync(origPath, 'utf-8');
+
+  let linearSource: string;
+  try {
+    linearSource = foldedToLinear(origSource);
+  } catch (e: any) {
+    console.log(`  FAIL  ${file}: linearizer error: ${e.message}`);
+    failures++;
+    continue;
+  }
+
+  if (linearSource === origSource) {
+    console.log(`  skip  ${file} (unchanged)`);
+    continue;
+  }
+
+  const linearPath = join(OUT_DIR, file);
+  writeFileSync(linearPath, linearSource);
+
+  const origErrors = runWatCheck(origPath);
+  const linearErrors = runWatCheck(linearPath);
+
+  // Normalize: strip paths/positions, compare error messages only
+  const origMessages = new Set(origErrors.map(normalizeMessage));
+  const newErrors = linearErrors.filter(d => !origMessages.has(normalizeMessage(d)));
+
+  if (newErrors.length > 0) {
+    console.log(`  FAIL  ${file}: ${newErrors.length} new error(s) after linearization`);
+    for (const e of newErrors) {
+      console.log(`        ${e}`);
+    }
+    failures++;
+  } else {
+    console.log(`  ok    ${file}`);
+  }
+}
+
+console.log('');
+if (failures > 0) {
+  console.log(`${failures} file(s) failed linearization check`);
+  process.exit(1);
+} else {
+  console.log(`All ${exampleFiles.length} examples pass linearization check`);
+}


### PR DESCRIPTION
## Summary
- Fix WAT linearizer: handle `try_table` as a block-structured instruction (was incorrectly emitting body before the block)
- Fix WAT linearizer: prevent line comments from eating subsequent code when collapsed to one line
- Fix WAT linearizer: preserve `else` branch when comments appear between `then` and `else`
- Fix tree-sitter grammar: add table index support for `call_indirect` in linear form (`instr_call`, `instr_list_call`)
- Add CI step that linearizes all playground examples and validates no new errors are introduced