### PR TITLE
refactor: consolidate module checks, optimize lookups, fix clippy lints

### DIFF
--- a/src/bin/wat-bench.rs
+++ b/src/bin/wat-bench.rs
@@ -293,7 +293,7 @@ fn benchmark_parse(
         times.push(start.elapsed());
     }
 
-    create_timing_result("parse", file_name, lines, times)
+    create_timing_result("parse", file_name, lines, &times)
 }
 
 fn benchmark_symbols(
@@ -310,7 +310,7 @@ fn benchmark_symbols(
         times.push(start.elapsed());
     }
 
-    create_timing_result("symbols", file_name, lines, times)
+    create_timing_result("symbols", file_name, lines, &times)
 }
 
 fn benchmark_diagnostics(
@@ -330,7 +330,7 @@ fn benchmark_diagnostics(
         times.push(start.elapsed());
     }
 
-    create_timing_result("diagnostics", file_name, lines, times)
+    create_timing_result("diagnostics", file_name, lines, &times)
 }
 
 fn benchmark_hover(
@@ -354,7 +354,7 @@ fn benchmark_hover(
         times.push(start.elapsed());
     }
 
-    create_timing_result("hover", file_name, lines, times)
+    create_timing_result("hover", file_name, lines, &times)
 }
 
 fn benchmark_completion(
@@ -380,7 +380,7 @@ fn benchmark_completion(
         times.push(start.elapsed());
     }
 
-    create_timing_result("completion", file_name, lines, times)
+    create_timing_result("completion", file_name, lines, &times)
 }
 
 fn benchmark_definition(
@@ -404,7 +404,7 @@ fn benchmark_definition(
         times.push(start.elapsed());
     }
 
-    create_timing_result("definition", file_name, lines, times)
+    create_timing_result("definition", file_name, lines, &times)
 }
 
 fn benchmark_references(
@@ -428,7 +428,7 @@ fn benchmark_references(
         times.push(start.elapsed());
     }
 
-    create_timing_result("references", file_name, lines, times)
+    create_timing_result("references", file_name, lines, &times)
 }
 
 fn generate_test_positions(lines: usize, count: usize) -> Vec<Position> {
@@ -443,12 +443,7 @@ fn generate_test_positions(lines: usize, count: usize) -> Vec<Position> {
     positions
 }
 
-fn create_timing_result(
-    name: &str,
-    file: &str,
-    lines: usize,
-    times: Vec<Duration>,
-) -> TimingResult {
+fn create_timing_result(name: &str, file: &str, lines: usize, times: &[Duration]) -> TimingResult {
     let total: Duration = times.iter().sum();
     let min = *times.iter().min().unwrap_or(&Duration::ZERO);
     let max = *times.iter().max().unwrap_or(&Duration::ZERO);

--- a/src/bin/wat-docs.rs
+++ b/src/bin/wat-docs.rs
@@ -350,7 +350,7 @@ fn main() -> ExitCode {
     let args = Args::parse();
 
     match args.command {
-        Command::List { filter } => cmd_list(filter),
+        Command::List { filter } => cmd_list(filter.as_deref()),
         Command::Show {
             instruction,
             raw,
@@ -368,8 +368,8 @@ fn main() -> ExitCode {
     }
 }
 
-fn cmd_list(filter: Option<String>) -> ExitCode {
-    let names = match &filter {
+fn cmd_list(filter: Option<&str>) -> ExitCode {
+    let names = match filter {
         Some(pattern) => docs::search_instruction_names(pattern),
         None => docs::instruction_names(),
     };

--- a/src/diagnostics_core/module_checks.rs
+++ b/src/diagnostics_core/module_checks.rs
@@ -306,14 +306,18 @@ fn check_export_name<'a>(
     seen: &mut HashMap<&'a str, Range>,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
+    use std::collections::hash_map::Entry;
     let range = node_to_range(node);
-    if seen.contains_key(name) {
-        diagnostics.push(Diagnostic::error(
-            range,
-            format!("Duplicate export name \"{}\"", name),
-        ));
-    } else {
-        seen.insert(name, range);
+    match seen.entry(name) {
+        Entry::Occupied(_) => {
+            diagnostics.push(Diagnostic::error(
+                range,
+                format!("Duplicate export name \"{}\"", name),
+            ));
+        }
+        Entry::Vacant(e) => {
+            e.insert(range);
+        }
     }
 }
 
@@ -390,65 +394,68 @@ pub(super) fn has_inline_import(node: &Node) -> bool {
 // 6. Duplicate identifiers
 // ============================================================================
 
+/// Tracks seen identifiers per index space for duplicate detection.
+struct IdentifierMaps<'a> {
+    func: HashMap<&'a str, Range>,
+    global: HashMap<&'a str, Range>,
+    table: HashMap<&'a str, Range>,
+    memory: HashMap<&'a str, Range>,
+    r#type: HashMap<&'a str, Range>,
+    tag: HashMap<&'a str, Range>,
+}
+
+impl<'a> IdentifierMaps<'a> {
+    fn new() -> Self {
+        Self {
+            func: HashMap::new(),
+            global: HashMap::new(),
+            table: HashMap::new(),
+            memory: HashMap::new(),
+            r#type: HashMap::new(),
+            tag: HashMap::new(),
+        }
+    }
+}
+
 fn check_duplicate_identifiers(module: &Node, source: &str, diagnostics: &mut Vec<Diagnostic>) {
-    let mut seen_func: HashMap<&str, Range> = HashMap::new();
-    let mut seen_global: HashMap<&str, Range> = HashMap::new();
-    let mut seen_table: HashMap<&str, Range> = HashMap::new();
-    let mut seen_memory: HashMap<&str, Range> = HashMap::new();
-    let mut seen_type: HashMap<&str, Range> = HashMap::new();
-    let mut seen_tag: HashMap<&str, Range> = HashMap::new();
+    let mut ids = IdentifierMaps::new();
 
     for_each_module_field(module, |field| {
         node_kind!(fk = field);
 
         match fk {
             "module_field_func" => {
-                check_identifier_dup(field, source, &mut seen_func, "func", diagnostics);
+                check_identifier_dup(field, source, &mut ids.func, "func", diagnostics);
             }
             "module_field_global" => {
-                check_identifier_dup(field, source, &mut seen_global, "global", diagnostics);
+                check_identifier_dup(field, source, &mut ids.global, "global", diagnostics);
             }
             "module_field_table" => {
-                check_identifier_dup(field, source, &mut seen_table, "table", diagnostics);
+                check_identifier_dup(field, source, &mut ids.table, "table", diagnostics);
             }
             "module_field_memory" => {
-                check_identifier_dup(field, source, &mut seen_memory, "memory", diagnostics);
+                check_identifier_dup(field, source, &mut ids.memory, "memory", diagnostics);
             }
             "module_field_type" => {
-                check_identifier_dup(field, source, &mut seen_type, "type", diagnostics);
+                check_identifier_dup(field, source, &mut ids.r#type, "type", diagnostics);
                 check_duplicate_struct_fields(field, source, diagnostics);
             }
             "module_field_tag" => {
-                check_identifier_dup(field, source, &mut seen_tag, "tag", diagnostics);
+                check_identifier_dup(field, source, &mut ids.tag, "tag", diagnostics);
                 check_tag_no_results(field, source, diagnostics);
             }
             "module_field_rec" => {
-                // Types inside rec groups share the type index space
                 let mut cursor = field.walk();
                 for child in field.children(&mut cursor) {
-                    // Inside rec, look for type definitions. The grammar defines rec as:
-                    // (rec (type $id? type_field) ...)
-                    // But the inner nodes are anonymous sequences, so we look for identifier
-                    // children or children that look like type definitions.
                     node_kind!(ck = child);
                     if ck == "module_field_type" {
-                        check_identifier_dup(&child, source, &mut seen_type, "type", diagnostics);
+                        check_identifier_dup(&child, source, &mut ids.r#type, "type", diagnostics);
                         check_duplicate_struct_fields(&child, source, diagnostics);
                     }
                 }
             }
             "module_field_import" => {
-                // Import descriptors declare identifiers in their respective namespaces
-                check_import_identifier_dup(
-                    field,
-                    source,
-                    &mut seen_func,
-                    &mut seen_global,
-                    &mut seen_table,
-                    &mut seen_memory,
-                    &mut seen_tag,
-                    diagnostics,
-                );
+                check_import_identifier_dup(field, source, &mut ids, diagnostics);
             }
             _ => {}
         }
@@ -462,31 +469,30 @@ fn check_identifier_dup<'a>(
     kind_name: &str,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
+    use std::collections::hash_map::Entry;
     if let Some(id_node) = crate::utils::find_child_by_kind(node, "identifier") {
         let name = node_text(&id_node, source);
         if name.starts_with('$') {
             let range = node_to_range(&id_node);
-            if seen.contains_key(name) {
-                diagnostics.push(Diagnostic::error(
-                    range,
-                    format!("Duplicate {} identifier {}", kind_name, name),
-                ));
-            } else {
-                seen.insert(name, range);
+            match seen.entry(name) {
+                Entry::Occupied(_) => {
+                    diagnostics.push(Diagnostic::error(
+                        range,
+                        format!("Duplicate {} identifier {}", kind_name, name),
+                    ));
+                }
+                Entry::Vacant(e) => {
+                    e.insert(range);
+                }
             }
         }
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 fn check_import_identifier_dup<'a>(
     import_node: &Node,
     source: &'a str,
-    seen_func: &mut HashMap<&'a str, Range>,
-    seen_global: &mut HashMap<&'a str, Range>,
-    seen_table: &mut HashMap<&'a str, Range>,
-    seen_memory: &mut HashMap<&'a str, Range>,
-    seen_tag: &mut HashMap<&'a str, Range>,
+    ids: &mut IdentifierMaps<'a>,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
     let mut cursor = import_node.walk();
@@ -498,19 +504,19 @@ fn check_import_identifier_dup<'a>(
                 node_kind!(dk = desc);
                 match dk {
                     "import_desc_func_type" | "import_desc_type_use" => {
-                        check_identifier_dup(&desc, source, seen_func, "func", diagnostics);
+                        check_identifier_dup(&desc, source, &mut ids.func, "func", diagnostics);
                     }
                     "import_desc_global_type" => {
-                        check_identifier_dup(&desc, source, seen_global, "global", diagnostics);
+                        check_identifier_dup(&desc, source, &mut ids.global, "global", diagnostics);
                     }
                     "import_desc_table_type" => {
-                        check_identifier_dup(&desc, source, seen_table, "table", diagnostics);
+                        check_identifier_dup(&desc, source, &mut ids.table, "table", diagnostics);
                     }
                     "import_desc_memory_type" => {
-                        check_identifier_dup(&desc, source, seen_memory, "memory", diagnostics);
+                        check_identifier_dup(&desc, source, &mut ids.memory, "memory", diagnostics);
                     }
                     "import_desc_tag_type" => {
-                        check_identifier_dup(&desc, source, seen_tag, "tag", diagnostics);
+                        check_identifier_dup(&desc, source, &mut ids.tag, "tag", diagnostics);
                         check_tag_no_results(&desc, source, diagnostics);
                     }
                     _ => {}
@@ -578,6 +584,7 @@ fn collect_struct_field_names<'a>(
     seen: &mut HashMap<&'a str, Range>,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
+    use std::collections::hash_map::Entry;
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         let kind = child.kind();
@@ -588,13 +595,16 @@ fn collect_struct_field_names<'a>(
                 if inner_child.kind() == "identifier" {
                     let name = node_text(&inner_child, source);
                     let range = node_to_range(&inner_child);
-                    if seen.contains_key(name) {
-                        diagnostics.push(Diagnostic::error(
-                            range,
-                            format!("duplicate field {}", name),
-                        ));
-                    } else {
-                        seen.insert(name, range);
+                    match seen.entry(name) {
+                        Entry::Occupied(_) => {
+                            diagnostics.push(Diagnostic::error(
+                                range,
+                                format!("duplicate field {}", name),
+                            ));
+                        }
+                        Entry::Vacant(e) => {
+                            e.insert(range);
+                        }
                     }
                 }
             }
@@ -712,34 +722,37 @@ fn resolve_type_use<'a>(
 // 8. Constant expression validation
 // ============================================================================
 
-const CONST_INSTRUCTIONS: &[&str] = &[
-    "i32.const",
-    "i64.const",
-    "f32.const",
-    "f64.const",
-    "v128.const",
-    "ref.null",
-    "ref.func",
-    "global.get",
-    // GC proposal const instructions
-    "struct.new",
-    "struct.new_default",
-    "array.new",
-    "array.new_default",
-    "array.new_fixed",
-    "any.convert_extern",
-    "extern.convert_any",
-    "ref.i31",
-    "i31.get_s",
-    "i31.get_u",
-    // Extended constant expressions proposal
-    "i32.add",
-    "i32.sub",
-    "i32.mul",
-    "i64.add",
-    "i64.sub",
-    "i64.mul",
-];
+fn is_const_instruction(name: &str) -> bool {
+    matches!(
+        name,
+        "i32.const"
+            | "i64.const"
+            | "f32.const"
+            | "f64.const"
+            | "v128.const"
+            | "ref.null"
+            | "ref.func"
+            | "global.get"
+            // GC proposal const instructions
+            | "struct.new"
+            | "struct.new_default"
+            | "array.new"
+            | "array.new_default"
+            | "array.new_fixed"
+            | "any.convert_extern"
+            | "extern.convert_any"
+            | "ref.i31"
+            | "i31.get_s"
+            | "i31.get_u"
+            // Extended constant expressions proposal
+            | "i32.add"
+            | "i32.sub"
+            | "i32.mul"
+            | "i64.add"
+            | "i64.sub"
+            | "i64.mul"
+    )
+}
 
 fn check_constant_expressions(
     module: &Node,
@@ -865,6 +878,27 @@ fn check_table_init_expr(
     }
 }
 
+/// Validate a single instr_plain node as a constant expression opcode.
+fn validate_const_instr(
+    instr_node: &Node,
+    report_node: &Node,
+    source: &str,
+    symbols: &SymbolTable,
+    max_allowed_global: usize,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let text = node_text(instr_node, source);
+    let first_token = text.split_whitespace().next().unwrap_or("");
+    if !is_const_instruction(first_token) {
+        diagnostics.push(Diagnostic::error(
+            node_to_range(report_node),
+            format!("Constant expression required, but found '{}'", first_token),
+        ));
+    } else if first_token == "global.get" {
+        check_global_get_in_const(instr_node, source, symbols, max_allowed_global, diagnostics);
+    }
+}
+
 /// Recursively check that all instructions in a tree are constant expressions.
 /// `max_allowed_global`: maximum global index that can be referenced by global.get.
 fn check_const_instruction_tree(
@@ -878,43 +912,23 @@ fn check_const_instruction_tree(
 
     match kind {
         "instr_plain" => {
-            // Linear-form instruction: check the opcode directly
-            let text = node_text(node, source);
-            let first_token = text.split_whitespace().next().unwrap_or("");
-            if !CONST_INSTRUCTIONS.contains(&first_token) {
-                diagnostics.push(Diagnostic::error(
-                    node_to_range(node),
-                    format!("Constant expression required, but found '{}'", first_token),
-                ));
-            } else if first_token == "global.get" {
-                check_global_get_in_const(node, source, symbols, max_allowed_global, diagnostics);
-            }
+            validate_const_instr(node, node, source, symbols, max_allowed_global, diagnostics);
             return;
         }
         "expr1_plain" => {
-            // Folded expression: first child is instr_plain, check its opcode
             let mut cursor = node.walk();
             for child in node.children(&mut cursor) {
                 node_kind!(ck = child);
                 if ck == "instr_plain" {
-                    let text = node_text(&child, source);
-                    let first_token = text.split_whitespace().next().unwrap_or("");
-                    if !CONST_INSTRUCTIONS.contains(&first_token) {
-                        diagnostics.push(Diagnostic::error(
-                            node_to_range(node),
-                            format!("Constant expression required, but found '{}'", first_token),
-                        ));
-                    } else if first_token == "global.get" {
-                        check_global_get_in_const(
-                            &child,
-                            source,
-                            symbols,
-                            max_allowed_global,
-                            diagnostics,
-                        );
-                    }
+                    validate_const_instr(
+                        &child,
+                        node,
+                        source,
+                        symbols,
+                        max_allowed_global,
+                        diagnostics,
+                    );
                 } else if ck == "expr" {
-                    // Check nested expressions for constness too
                     check_const_instruction_tree(
                         &child,
                         source,

--- a/src/features/references_core.rs
+++ b/src/features/references_core.rs
@@ -15,6 +15,9 @@ use tree_sitter::{Node, Tree};
 use crate::ts_facade::{Node, Tree};
 
 use crate::core::types::{Position, Range};
+use crate::symbol_lookup::{
+    find_block_in_function, find_local_in_function, find_param_in_function,
+};
 use crate::symbols::*;
 use crate::utils::{
     determine_context_from_line, determine_instruction_context_at_node, find_child_by_kind,
@@ -232,36 +235,30 @@ fn identify_named_symbol(
         }
         InstructionContext::Local => {
             if let Some(func) = find_containing_function(symbols, position) {
-                for param in &func.parameters {
-                    if param.name.as_deref() == Some(word) {
-                        return Some(ReferenceTarget::Parameter {
-                            name: Some(word.to_string()),
-                            index: param.index,
-                            function_start_byte: func.start_byte,
-                        });
-                    }
+                if let Some(param) = find_param_in_function(word, func) {
+                    return Some(ReferenceTarget::Parameter {
+                        name: Some(word.to_string()),
+                        index: param.index,
+                        function_start_byte: func.start_byte,
+                    });
                 }
-                for local in &func.locals {
-                    if local.name.as_deref() == Some(word) {
-                        return Some(ReferenceTarget::Local {
-                            name: Some(word.to_string()),
-                            index: local.index + func.parameters.len(),
-                            function_start_byte: func.start_byte,
-                        });
-                    }
+                if let Some(local) = find_local_in_function(word, func) {
+                    return Some(ReferenceTarget::Local {
+                        name: Some(word.to_string()),
+                        index: local.index + func.parameters.len(),
+                        function_start_byte: func.start_byte,
+                    });
                 }
             }
         }
         InstructionContext::Branch | InstructionContext::Block => {
             if let Some(func) = find_containing_function(symbols, position) {
-                for block in &func.blocks {
-                    if block.label == word {
-                        return Some(ReferenceTarget::BlockLabel {
-                            label: word.to_string(),
-                            function_start_byte: func.start_byte,
-                            line: block.line,
-                        });
-                    }
+                if let Some(block) = find_block_in_function(word, func) {
+                    return Some(ReferenceTarget::BlockLabel {
+                        label: word.to_string(),
+                        function_start_byte: func.start_byte,
+                        line: block.line,
+                    });
                 }
             }
         }
@@ -274,33 +271,26 @@ fn identify_named_symbol(
             }
 
             if let Some(func) = find_containing_function(symbols, position) {
-                for param in &func.parameters {
-                    if param.name.as_deref() == Some(word) {
-                        return Some(ReferenceTarget::Parameter {
-                            name: Some(word.to_string()),
-                            index: param.index,
-                            function_start_byte: func.start_byte,
-                        });
-                    }
+                if let Some(param) = find_param_in_function(word, func) {
+                    return Some(ReferenceTarget::Parameter {
+                        name: Some(word.to_string()),
+                        index: param.index,
+                        function_start_byte: func.start_byte,
+                    });
                 }
-                for local in &func.locals {
-                    if local.name.as_deref() == Some(word) {
-                        return Some(ReferenceTarget::Local {
-                            name: Some(word.to_string()),
-                            index: local.index + func.parameters.len(),
-                            function_start_byte: func.start_byte,
-                        });
-                    }
+                if let Some(local) = find_local_in_function(word, func) {
+                    return Some(ReferenceTarget::Local {
+                        name: Some(word.to_string()),
+                        index: local.index + func.parameters.len(),
+                        function_start_byte: func.start_byte,
+                    });
                 }
-
-                for block in &func.blocks {
-                    if block.label == word {
-                        return Some(ReferenceTarget::BlockLabel {
-                            label: word.to_string(),
-                            function_start_byte: func.start_byte,
-                            line: block.line,
-                        });
-                    }
+                if let Some(block) = find_block_in_function(word, func) {
+                    return Some(ReferenceTarget::BlockLabel {
+                        label: word.to_string(),
+                        function_start_byte: func.start_byte,
+                        line: block.line,
+                    });
                 }
             }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,8 +1,6 @@
 use crate::core::types::Range;
 use crate::symbols::*;
-use crate::utils::{
-    block_type_from_kind, node_text, node_to_range, BLOCK_KINDS_EXPR, BLOCK_KINDS_STATEMENT,
-};
+use crate::utils::{block_type_from_kind, node_text, node_to_range};
 
 // Use the appropriate tree-sitter types based on feature
 #[cfg(feature = "native")]
@@ -1165,7 +1163,19 @@ fn visit_node_for_blocks(node: &Node, source: &str, blocks: &mut Vec<BlockLabel>
     node_kind!(kind_str = node);
 
     // Check both statement form (block_block) and expression form (expr1_block)
-    if BLOCK_KINDS_STATEMENT.contains(&kind_str) || BLOCK_KINDS_EXPR.contains(&kind_str) {
+    if matches!(
+        kind_str,
+        "block_block"
+            | "block_loop"
+            | "block_if"
+            | "block_try"
+            | "block_try_table"
+            | "expr1_block"
+            | "expr1_loop"
+            | "expr1_if"
+            | "expr1_try"
+            | "expr1_try_table"
+    ) {
         // Check if it has a label
         if let Some(id_node) = crate::utils::find_child_by_kind(node, "identifier") {
             let label = normalize_identifier(node_text(&id_node, source));

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -9,31 +9,6 @@ use tree_sitter::{Node, Tree};
 use crate::ts_facade::{Node, Tree};
 
 // ============================================================================
-// Block type constants - centralized to prevent sync issues
-// ============================================================================
-
-/// All block-related node kinds (statement form)
-pub const BLOCK_KINDS_STATEMENT: &[&str] = &[
-    "block_block",
-    "block_loop",
-    "block_if",
-    "block_try",
-    "block_try_table",
-];
-
-/// All block-related node kinds (expression form)
-pub const BLOCK_KINDS_EXPR: &[&str] = &[
-    "expr1_block",
-    "expr1_loop",
-    "expr1_if",
-    "expr1_try",
-    "expr1_try_table",
-];
-
-/// All block-related node kinds (instruction form used in some contexts)
-pub const BLOCK_KINDS_INSTR: &[&str] = &["instr_block", "instr_loop"];
-
-// ============================================================================
 // Struct operation constants - used for hover and diagnostics
 // ============================================================================
 
@@ -42,9 +17,21 @@ pub const STRUCT_OPS: &[&str] = &["struct.get", "struct.set", "struct.get_s", "s
 
 /// Check if a kind represents any block structure (statement, expression, or instruction form)
 pub fn is_block_kind(kind: &str) -> bool {
-    BLOCK_KINDS_STATEMENT.contains(&kind)
-        || BLOCK_KINDS_EXPR.contains(&kind)
-        || BLOCK_KINDS_INSTR.contains(&kind)
+    matches!(
+        kind,
+        "block_block"
+            | "block_loop"
+            | "block_if"
+            | "block_try"
+            | "block_try_table"
+            | "expr1_block"
+            | "expr1_loop"
+            | "expr1_if"
+            | "expr1_try"
+            | "expr1_try_table"
+            | "instr_block"
+            | "instr_loop"
+    )
 }
 
 /// Check if a kind represents a labeled block structure (block, loop, if - not try)


### PR DESCRIPTION
## Summary

- Replace `CONST_INSTRUCTIONS` linear scan with `matches!()` for O(1) const expression validation
- Extract `validate_const_instr()` helper to de-duplicate instr_plain/expr1_plain validation
- Use HashMap `entry` API instead of `contains_key` + `insert` (3 call sites)
- Bundle 6 identifier HashMaps into `IdentifierMaps` struct, removing `too_many_arguments` lint
- Replace `BLOCK_KINDS_*` array lookups with `matches!()` and remove unused constants
- Use `find_param_in_function`/`find_local_in_function`/`find_block_in_function` helpers in references_core
- Fix clippy needless-pass-by-value in wat-bench and wat-docs