### PR TITLE
feat: support wide-arithmetic and custom-page-sizes proposals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,9 +272,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A Language Server for WebAssembly Text Format (`.wat` files) written in Rust.
 
 Hover, completions, signature help, go to definition, find references, and rename.
 
-Supports WasmGC, Relaxed SIMD, Exception Handling, and Reference Types.
+Supports WasmGC, Relaxed SIMD, Exception Handling, Reference Types, Wide Arithmetic, and Custom Page Sizes.
 
 ## Install
 

--- a/grammars/tree-sitter-wat/grammar.js
+++ b/grammars/tree-sitter-wat/grammar.js
@@ -585,17 +585,18 @@ module.exports = grammar({
                   ),
                   new RegExp(
                     [
-                      "a(nd|dd)",
+                      // proposal: wide-arithmetic (add128, sub128, mul_wide_s/u)
+                      "a(nd|dd(128)?)",
                       "c[lt]z",
                       "(div|g[et]|l[et]|rem|shr)_[su]",
                       "e(qz?|xtend(_i32_[su]|(8|16|32)_s))",
-                      "mul",
+                      "mul(_wide_[su])?",
                       "ne",
                       "or",
                       "rot[lr]",
                       "popcnt",
                       "reinterpret_f64",
-                      "s(hl|ub)",
+                      "s(hl|ub(128)?)",
                       "trunc(_sat)?_f(32|64)_[su]",
                       "xor",
                     ].join("|"),
@@ -742,10 +743,15 @@ module.exports = grammar({
 
     // proposal: memory64
     // Memory type can optionally include 'i64' keyword for 64-bit addressing
-    memory_type: $ => seq(optional($.memory64_type), $.limits),
+    // proposal: custom-page-sizes
+    // Memory type can optionally end with a (pagesize N) clause
+    memory_type: $ => seq(optional($.memory64_type), $.limits, optional($.page_size)),
 
     // proposal: memory64
     memory64_type: $ => "i64",
+
+    // proposal: custom-page-sizes
+    page_size: $ => seq("(", "pagesize", $.nat, ")"),
 
     memory_use: $ => seq("(", "memory", $.index, ")"),
 

--- a/packages/docs/instructions.md
+++ b/packages/docs/instructions.md
@@ -603,6 +603,64 @@ Example:
 
 ---
 
+## i64.add128
+
+Add two 128-bit values, each represented as a pair of i64 halves (low, high). Returns the 128-bit result as two i64 values. Part of the wide-arithmetic proposal.
+
+Signature: `(param i64 i64 i64 i64) (result i64 i64)`
+
+Example:
+
+```wat
+;; (lhs_lo, lhs_hi) + (rhs_lo, rhs_hi) -> (lo, hi)
+(i64.add128 (i64.const 1) (i64.const 0) (i64.const 2) (i64.const 0))
+```
+
+---
+
+## i64.sub128
+
+Subtract two 128-bit values, each represented as a pair of i64 halves (low, high). Returns the 128-bit result as two i64 values. Part of the wide-arithmetic proposal.
+
+Signature: `(param i64 i64 i64 i64) (result i64 i64)`
+
+Example:
+
+```wat
+;; (lhs_lo, lhs_hi) - (rhs_lo, rhs_hi) -> (lo, hi)
+(i64.sub128 (i64.const 5) (i64.const 0) (i64.const 2) (i64.const 0))
+```
+
+---
+
+## i64.mul_wide_s
+
+Multiply two signed i64 values, producing the full 128-bit result as two i64 values (low, high). Part of the wide-arithmetic proposal.
+
+Signature: `(param i64 i64) (result i64 i64)`
+
+Example:
+
+```wat
+(i64.mul_wide_s (i64.const -2) (i64.const 3))
+```
+
+---
+
+## i64.mul_wide_u
+
+Multiply two unsigned i64 values, producing the full 128-bit result as two i64 values (low, high). Part of the wide-arithmetic proposal.
+
+Signature: `(param i64 i64) (result i64 i64)`
+
+Example:
+
+```wat
+(i64.mul_wide_u (i64.const 2) (i64.const 3))
+```
+
+---
+
 ## i64.const
 
 Create a constant i64 value.

--- a/src/bin/wat-hover.rs
+++ b/src/bin/wat-hover.rs
@@ -142,7 +142,7 @@ fn main() -> ExitCode {
                 eprintln!(
                     "  {} -> {:?}",
                     current.kind(),
-                    &source[current.byte_range()]
+                    source[current.byte_range()]
                         .chars()
                         .take(50)
                         .collect::<String>()
@@ -175,7 +175,7 @@ fn main() -> ExitCode {
             eprintln!(
                 "  {:?}: {:?}",
                 data.name,
-                &data.content.chars().take(20).collect::<String>()
+                data.content.chars().take(20).collect::<String>()
             );
         }
         eprintln!("Elem segments ({}):", symbols.elem_segments.len());

--- a/src/diagnostics_core/semantic.rs
+++ b/src/diagnostics_core/semantic.rs
@@ -1311,22 +1311,10 @@ fn derive_consumed_types_from_name(
         // br_on_null/br_on_non_null handled specially in process_instruction
 
         // Scalar binary operations — 2 operands of prefix type
-        name if is_binary_scalar(name) => {
-            if let Some(ty) = type_from_prefix(name) {
-                Some(Cow::Owned(vec![ty, ty]))
-            } else {
-                None
-            }
-        }
+        name if is_binary_scalar(name) => type_from_prefix(name).map(|ty| Cow::Owned(vec![ty, ty])),
 
         // Scalar unary operations — 1 operand of prefix type
-        name if is_unary_scalar(name) => {
-            if let Some(ty) = type_from_prefix(name) {
-                Some(Cow::Owned(vec![ty]))
-            } else {
-                None
-            }
-        }
+        name if is_unary_scalar(name) => type_from_prefix(name).map(|ty| Cow::Owned(vec![ty])),
 
         _ => None, // fall back to untyped count
     }
@@ -1537,13 +1525,7 @@ fn get_dynamic_operand_count(
             }
             0
         }
-        "br" | "br_if" => {
-            if instr_name == "br_if" {
-                1
-            } else {
-                0
-            }
-        }
+        "br_if" => 1,
         _ => 0,
     }
 }

--- a/src/docs.rs
+++ b/src/docs.rs
@@ -104,6 +104,14 @@ mod tests {
     }
 
     #[test]
+    fn test_get_instruction_doc_wide_arithmetic() {
+        assert!(get_instruction_doc("i64.add128").is_some());
+        assert!(get_instruction_doc("i64.sub128").is_some());
+        assert!(get_instruction_doc("i64.mul_wide_s").is_some());
+        assert!(get_instruction_doc("i64.mul_wide_u").is_some());
+    }
+
+    #[test]
     fn test_get_instruction_doc_not_exists() {
         // Test that non-existent instructions return None
         assert!(get_instruction_doc("not.an.instruction").is_none());

--- a/src/features/completion/mod.rs
+++ b/src/features/completion/mod.rs
@@ -517,6 +517,23 @@ fn get_type_completions(type_prefix: &str) -> Vec<CompletionItem> {
         for (name, desc) in int_ops {
             completions.push(make_completion(name, desc));
         }
+        if type_prefix.starts_with("i64") {
+            let wide_ops = vec![
+                ("add128", "128-bit addition (wide arithmetic)"),
+                ("sub128", "128-bit subtraction (wide arithmetic)"),
+                (
+                    "mul_wide_s",
+                    "Signed 64x64 to 128-bit multiply (wide arithmetic)",
+                ),
+                (
+                    "mul_wide_u",
+                    "Unsigned 64x64 to 128-bit multiply (wide arithmetic)",
+                ),
+            ];
+            for (name, desc) in wide_ops {
+                completions.push(make_completion(name, desc));
+            }
+        }
     } else {
         // Float-specific instructions
         let float_ops = vec![

--- a/src/features/completion/tests.rs
+++ b/src/features/completion/tests.rs
@@ -118,6 +118,22 @@ fn test_i32_instruction_completion() {
     assert!(completions.iter().any(|c| c.label == "sub"));
     assert!(completions.iter().any(|c| c.label == "mul"));
     assert!(completions.iter().any(|c| c.label == "const"));
+
+    // Wide arithmetic is i64-only, so it should not appear for i32.
+    assert!(!completions.iter().any(|c| c.label == "add128"));
+}
+
+#[test]
+fn test_i64_wide_arithmetic_completion() {
+    let document = "i64.";
+    let symbols = create_test_symbols();
+    let position = Position::new(0, 4);
+
+    let completions = provide_completion(document, &symbols, position);
+    assert!(completions.iter().any(|c| c.label == "add128"));
+    assert!(completions.iter().any(|c| c.label == "sub128"));
+    assert!(completions.iter().any(|c| c.label == "mul_wide_s"));
+    assert!(completions.iter().any(|c| c.label == "mul_wide_u"));
 }
 
 #[test]

--- a/src/features/hover/mod.rs
+++ b/src/features/hover/mod.rs
@@ -576,11 +576,7 @@ fn provide_annotation_hover(
             let after_prefix = &text[2..];
             let annotation_name = if let Some(stripped) = after_prefix.strip_prefix('"') {
                 // Quoted name: extract content between quotes
-                if let Some(end_quote) = stripped.find('"') {
-                    &stripped[..end_quote]
-                } else {
-                    return None;
-                }
+                &stripped[..stripped.find('"')?]
             } else {
                 // Unquoted name: read until whitespace or ')'
                 let end = after_prefix

--- a/src/instruction_metadata.rs
+++ b/src/instruction_metadata.rs
@@ -261,6 +261,11 @@ fn init_arity_table() -> Vec<(&'static str, InstructionArity)> {
         ("i64.shr_u", InstructionArity::binary_op()),
         ("i64.rotl", InstructionArity::binary_op()),
         ("i64.rotr", InstructionArity::binary_op()),
+        // i64 wide arithmetic (wide-arithmetic proposal)
+        ("i64.add128", InstructionArity::exact(0, "", 4, 2)),
+        ("i64.sub128", InstructionArity::exact(0, "", 4, 2)),
+        ("i64.mul_wide_s", InstructionArity::exact(0, "", 2, 2)),
+        ("i64.mul_wide_u", InstructionArity::exact(0, "", 2, 2)),
         // i64 comparison (binary)
         ("i64.eq", InstructionArity::binary_op()),
         ("i64.ne", InstructionArity::binary_op()),
@@ -1116,5 +1121,32 @@ mod tests {
         let notify = &map["memory.atomic.notify"];
         assert_eq!(notify.operand_mode, OperandMode::Fixed(2));
         assert_eq!(notify.produces, 1);
+    }
+
+    #[test]
+    fn test_wide_arithmetic_instruction_arity() {
+        let map = get_instruction_arity_map();
+
+        // add128/sub128: two 128-bit values as (lo, hi) i64 pairs → (lo, hi)
+        for instr in &["i64.add128", "i64.sub128"] {
+            let arity = &map[*instr];
+            assert_eq!(
+                arity.operand_mode,
+                OperandMode::Fixed(4),
+                "{instr} operands"
+            );
+            assert_eq!(arity.produces, 2, "{instr} produces");
+        }
+
+        // mul_wide: two i64 operands → full 128-bit product as (lo, hi)
+        for instr in &["i64.mul_wide_s", "i64.mul_wide_u"] {
+            let arity = &map[*instr];
+            assert_eq!(
+                arity.operand_mode,
+                OperandMode::Fixed(2),
+                "{instr} operands"
+            );
+            assert_eq!(arity.produces, 2, "{instr} produces");
+        }
     }
 }

--- a/tests/grammar_tests.rs
+++ b/tests/grammar_tests.rs
@@ -331,4 +331,62 @@ mod grammar_tests {
         let errors = check_syntax(source);
         assert!(errors.is_empty(), "extending loads failed: {:?}", errors);
     }
+
+    // ========================================================================
+    // proposal: wide-arithmetic
+    // ========================================================================
+
+    #[test]
+    fn test_wide_arithmetic_add128_sub128() {
+        let source = r#"
+            (module
+                (func (param $a i64) (param $b i64) (result i64 i64)
+                    local.get $a
+                    i64.const 0
+                    local.get $b
+                    i64.const 0
+                    i64.add128
+                )
+                (func (result i64 i64)
+                    (i64.sub128 (i64.const 5) (i64.const 0) (i64.const 2) (i64.const 0))
+                )
+            )
+        "#;
+        let errors = check_syntax(source);
+        assert!(errors.is_empty(), "wide arithmetic failed: {:?}", errors);
+    }
+
+    #[test]
+    fn test_wide_arithmetic_mul_wide() {
+        let source = r#"
+            (module
+                (func (param $a i64) (param $b i64) (result i64 i64)
+                    (i64.mul_wide_s (local.get $a) (local.get $b))
+                )
+                (func (param $a i64) (param $b i64) (result i64 i64)
+                    (i64.mul_wide_u (local.get $a) (local.get $b))
+                )
+            )
+        "#;
+        let errors = check_syntax(source);
+        assert!(errors.is_empty(), "mul_wide failed: {:?}", errors);
+    }
+
+    // ========================================================================
+    // proposal: custom-page-sizes
+    // ========================================================================
+
+    #[test]
+    fn test_custom_page_sizes() {
+        let source = r#"
+            (module
+                (memory $one_byte_pages 1 2 (pagesize 1))
+                (memory $default_pages 1 (pagesize 65536))
+                (memory $mem64 i64 1 (pagesize 1))
+                (import "env" "mem" (memory $imported 0 (pagesize 1)))
+            )
+        "#;
+        let errors = check_syntax(source);
+        assert!(errors.is_empty(), "custom page sizes failed: {:?}", errors);
+    }
 }


### PR DESCRIPTION
Adds LSP support for two phase-3 WebAssembly proposals already accepted by the bundled wast validator:

**Wide arithmetic** (`i64.add128`, `i64.sub128`, `i64.mul_wide_s`, `i64.mul_wide_u`)
- Tree-sitter grammar: extended the i64 opcode regex in `op_nullary`
- Instruction metadata: stack arities (add128/sub128: 4 operands → 2 results; mul_wide: 2 → 2) for stack-depth diagnostics and signature help
- Hover docs entries in `packages/docs/instructions.md`
- `i64.` prefix completions (correctly absent from `i32.`)

**Custom page sizes** (`(pagesize N)`)
- New `page_size` grammar rule as an optional trailing clause on `memory_type`, covering plain, memory64, and imported memories

Includes grammar, arity, docs-lookup, and completion tests; full suite passes and `wat-hover-coverage` is green. Malformed variants (`i64.mul_wide` without suffix, `(pagesize)` without a value) still produce errors.