### PR TITLE
feat: add semantic tokens for symbol-resolved syntax highlighting

### DIFF
--- a/grammars/tree-sitter-wat/queries/highlights.scm
+++ b/grammars/tree-sitter-wat/queries/highlights.scm
@@ -213,12 +213,8 @@
   (identifier) @variable)
 
 ; Annotations (@name, @producers, @custom, etc.)
-(annotation
-  (identifier_pattern) @attribute)
-(annotation_part
-  (identifier) @variable)
-(annotation_part
-  (string) @string)
+; The annotation node is an external scanner token with no children.
+(annotation) @attribute
 
 ; Brackets - let TextMate handle these
 ; ["(" ")"] @punctuation.bracket

--- a/packages/playground/src/components/Editor.vue
+++ b/packages/playground/src/components/Editor.vue
@@ -138,11 +138,33 @@ async function initMonaco() {
     },
   });
 
-  // Set up theme
+  // Set up theme. The rules cover both the TextMate token names produced by
+  // scopeToToken and the semantic token types from the LSP legend — semantic
+  // token styles are resolved against these same rules, and any type without
+  // a rule would render in the plain default foreground.
   monaco.editor.defineTheme('flexoki-dark', {
     base: 'vs-dark',
     inherit: true,
-    rules: [],
+    rules: [
+      { token: 'comment', foreground: '878580', fontStyle: 'italic' },
+      { token: 'string', foreground: '3aa99f' },
+      { token: 'string.escape', foreground: 'da702c' },
+      { token: 'number', foreground: '8b7ec8' },
+      { token: 'keyword', foreground: '879a39' },
+      { token: 'keyword.control', foreground: '879a39' },
+      { token: 'operator', foreground: '878580' },
+      { token: 'delimiter', foreground: '878580' },
+      { token: 'attribute', foreground: 'da702c' },
+      { token: 'type', foreground: 'd0a215' },
+      // Semantic token types (symbol-resolved)
+      { token: 'function', foreground: 'da702c' },
+      { token: 'variable', foreground: '4385be' },
+      { token: 'parameter', foreground: '4385be', fontStyle: 'italic' },
+      { token: 'property', foreground: 'ce5d97' },
+      { token: 'event', foreground: 'ce5d97' },
+      { token: 'namespace', foreground: 'd0a215' },
+      { token: 'label', foreground: 'd14d41' },
+    ],
     colors: {
       'editor.background': '#10100e',
       'editor.foreground': '#cecdc3',

--- a/packages/playground/src/components/Editor.vue
+++ b/packages/playground/src/components/Editor.vue
@@ -162,6 +162,7 @@ async function initMonaco() {
     tabSize: 2,
     scrollBeyondLastLine: false,
     lineNumbers: 'on',
+    'semanticHighlighting.enabled': true,
   });
 
   // Expose for Playwright tests
@@ -388,6 +389,19 @@ function registerLSPProviders() {
         )
       }));
     }
+  });
+
+  // Symbol-resolved highlighting layered over the TextMate base: functions,
+  // params, locals, globals, types, and labels each get their real
+  // classification instead of a generic identifier color.
+  const legend = watLSP.getSemanticTokensLegend();
+  monaco.languages.registerDocumentSemanticTokensProvider('wat', {
+    getLegend: () => legend,
+    provideDocumentSemanticTokens: (model) => {
+      watLSP.parse(model.getValue());
+      return { data: watLSP.provideSemanticTokens(), resultId: undefined };
+    },
+    releaseDocumentSemanticTokens: () => {},
   });
 
   monaco.languages.registerCompletionItemProvider('wat', {

--- a/packages/playground/src/components/Editor.vue
+++ b/packages/playground/src/components/Editor.vue
@@ -138,32 +138,44 @@ async function initMonaco() {
     },
   });
 
-  // Set up theme. The rules cover both the TextMate token names produced by
-  // scopeToToken and the semantic token types from the LSP legend — semantic
-  // token styles are resolved against these same rules, and any type without
-  // a rule would render in the plain default foreground.
+  // Set up theme, pulling colors from the design tokens in design-tokens.css
+  // so the editor matches the rest of the site. The rules cover both the
+  // TextMate token names produced by scopeToToken and the semantic token types
+  // from the LSP legend — semantic token styles are resolved against these
+  // same rules, and any type without a rule would render in the plain default
+  // foreground.
+  const css = getComputedStyle(document.documentElement);
+  const token = (name: string, fallback: string) =>
+    (css.getPropertyValue(name).trim() || fallback).replace('#', '');
+  const fg = token('--fg-color', '#cecdc3');
+  const fgMuted = token('--fg-muted', '#878580');
+  const primary = token('--primary-color', '#654ff0');
+  const info = token('--info-color', '#519fdf');
+  const warning = token('--warning-color', '#d0a215');
+  const error = token('--error-color', '#d14d41');
+
   monaco.editor.defineTheme('flexoki-dark', {
     base: 'vs-dark',
     inherit: true,
     rules: [
-      { token: 'comment', foreground: '878580', fontStyle: 'italic' },
-      { token: 'string', foreground: '3aa99f' },
-      { token: 'string.escape', foreground: 'da702c' },
-      { token: 'number', foreground: '8b7ec8' },
-      { token: 'keyword', foreground: '879a39' },
-      { token: 'keyword.control', foreground: '879a39' },
-      { token: 'operator', foreground: '878580' },
-      { token: 'delimiter', foreground: '878580' },
-      { token: 'attribute', foreground: 'da702c' },
-      { token: 'type', foreground: 'd0a215' },
+      { token: 'comment', foreground: fgMuted, fontStyle: 'italic' },
+      { token: 'string', foreground: warning },
+      { token: 'string.escape', foreground: info },
+      { token: 'number', foreground: fg },
+      { token: 'keyword', foreground: info },
+      { token: 'keyword.control', foreground: info },
+      { token: 'operator', foreground: fgMuted },
+      { token: 'delimiter', foreground: fgMuted },
+      { token: 'attribute', foreground: fgMuted, fontStyle: 'italic' },
+      { token: 'type', foreground: warning },
       // Semantic token types (symbol-resolved)
-      { token: 'function', foreground: 'da702c' },
-      { token: 'variable', foreground: '4385be' },
-      { token: 'parameter', foreground: '4385be', fontStyle: 'italic' },
-      { token: 'property', foreground: 'ce5d97' },
-      { token: 'event', foreground: 'ce5d97' },
-      { token: 'namespace', foreground: 'd0a215' },
-      { token: 'label', foreground: 'd14d41' },
+      { token: 'function', foreground: primary },
+      { token: 'variable', foreground: fg },
+      { token: 'parameter', foreground: fg, fontStyle: 'italic' },
+      { token: 'property', foreground: warning },
+      { token: 'event', foreground: warning },
+      { token: 'namespace', foreground: fg, fontStyle: 'bold' },
+      { token: 'label', foreground: error },
     ],
     colors: {
       'editor.background': '#10100e',

--- a/src/features/mod.rs
+++ b/src/features/mod.rs
@@ -41,6 +41,10 @@ pub mod references_core;
 #[cfg(feature = "native")]
 pub mod references;
 
+// Semantic tokens - server-driven syntax highlighting classification
+#[cfg(any(feature = "native", feature = "wasm"))]
+pub mod semantic_tokens;
+
 // Signature - signature help for function calls
 // The call_info submodule is shared; the LSP wrapper is native-only
 #[cfg(any(feature = "native", feature = "wasm"))]

--- a/src/features/semantic_tokens/mod.rs
+++ b/src/features/semantic_tokens/mod.rs
@@ -1,0 +1,625 @@
+//! Semantic tokens — server-side classification of identifiers and indices
+//! for syntax highlighting.
+//!
+//! Walks the tree once and classifies every `$identifier` and numeric index
+//! using the same symbol tables and context detection that hover, definition,
+//! and references already use. Keywords, strings, and literals are left to the
+//! client's base grammar; only resolved symbols get tokens, so unresolved
+//! references simply stay uncolored.
+//!
+//! Shared core logic for native and WASM builds. The native LSP wrapper at the
+//! bottom converts to the LSP delta-encoded wire format.
+
+// Allow needless_borrow/borrow_deref_ref: &kind and &*kind are required for WASM
+// (String -> &str) but appear unnecessary on native (&str -> &str).
+#![allow(clippy::needless_borrow, clippy::borrow_deref_ref)]
+
+#[cfg(feature = "native")]
+use tree_sitter::{Node, Tree};
+
+#[cfg(all(feature = "wasm", not(feature = "native")))]
+use crate::ts_facade::{Node, Tree};
+
+use crate::core::types::Position;
+use crate::parser::ModuleInfo;
+use crate::symbol_lookup::{
+    find_block_in_function, find_local_in_function, find_param_in_function,
+};
+use crate::symbols::{SymbolTable, TypeKind};
+use crate::utils::{
+    context_from_instruction_text, determine_catch_clause_context, find_containing_function,
+    is_block_kind, InstructionContext,
+};
+
+#[cfg(all(test, feature = "native"))]
+mod tests;
+
+/// Semantic classification of a single token.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SemanticTokenKind {
+    Function,
+    Parameter,
+    Local,
+    Global,
+    Table,
+    Memory,
+    Type,
+    Tag,
+    Data,
+    Elem,
+    Label,
+    /// Struct field name
+    Property,
+    /// Module name in `(module $name ...)`
+    Module,
+}
+
+/// A classified token with absolute document coordinates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SemanticTokenInfo {
+    pub line: u32,
+    pub start_char: u32,
+    pub length: u32,
+    pub kind: SemanticTokenKind,
+    pub is_declaration: bool,
+    pub is_readonly: bool,
+}
+
+/// Reference context for a token, derived from its enclosing syntax.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RefContext {
+    Function,
+    Global,
+    Local,
+    Label,
+    Table,
+    Memory,
+    Type,
+    Tag,
+    Data,
+    Elem,
+    /// No specific context — attempt name-based resolution (identifiers only)
+    General,
+    /// Definitely not a symbol reference (e.g. an i32.const operand)
+    Literal,
+}
+
+/// Main entry point: classify every identifier and index in the document.
+/// Returns tokens in document order with absolute positions.
+pub fn provide_semantic_tokens(
+    document: &str,
+    modules: &[ModuleInfo],
+    tree: &Tree,
+) -> Vec<SemanticTokenInfo> {
+    let mut tokens = Vec::new();
+    walk_node(tree.root_node(), document, modules, &mut tokens);
+    tokens.sort_by_key(|t| (t.line, t.start_char));
+    tokens
+}
+
+fn walk_node(
+    node: Node,
+    document: &str,
+    modules: &[ModuleInfo],
+    tokens: &mut Vec<SemanticTokenInfo>,
+) {
+    let kind = node.kind();
+
+    match &*kind {
+        "identifier" => {
+            classify_identifier(&node, document, modules, tokens);
+            return;
+        }
+        // `nat` may wrap `dec_nat`/`hex_nat`; classify at the outermost numeric
+        // node and don't recurse, so each number is considered exactly once.
+        "nat" | "dec_nat" | "hex_nat" => {
+            classify_nat(&node, document, modules, tokens);
+            return;
+        }
+        "comment_block"
+        | "comment_line"
+        | "comment_block_annot"
+        | "comment_line_annot"
+        | "string" => return,
+        _ => {}
+    }
+
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        walk_node(child, document, modules, tokens);
+    }
+}
+
+/// Find the SymbolTable for the module containing the given line.
+fn symbols_for_line(modules: &[ModuleInfo], line: u32) -> Option<&SymbolTable> {
+    modules
+        .iter()
+        .find(|m| line >= m.range.start.line && line <= m.range.end.line)
+        .or_else(|| modules.first())
+        .map(|m| &m.symbols)
+}
+
+fn push_token(
+    tokens: &mut Vec<SemanticTokenInfo>,
+    node: &Node,
+    kind: SemanticTokenKind,
+    is_declaration: bool,
+    is_readonly: bool,
+) {
+    let start = node.start_position();
+    tokens.push(SemanticTokenInfo {
+        line: start.row as u32,
+        start_char: start.column as u32,
+        length: (node.end_byte() - node.start_byte()) as u32,
+        kind,
+        is_declaration,
+        is_readonly,
+    });
+}
+
+/// Map a declaration site (identifier as direct child of its defining form)
+/// to a token kind. Returns None if the parent is not a declaration site.
+fn declaration_kind(
+    parent_kind: &str,
+    text: &str,
+    modules: &[ModuleInfo],
+    line: u32,
+) -> Option<(SemanticTokenKind, bool)> {
+    let kind = match parent_kind {
+        "module" => SemanticTokenKind::Module,
+        "module_field_func" | "import_desc_func_type" | "import_desc_type_use" => {
+            SemanticTokenKind::Function
+        }
+        "module_field_global" | "import_desc_global_type" => {
+            let readonly = symbols_for_line(modules, line)
+                .and_then(|s| s.get_global_by_name(text))
+                .is_some_and(|g| !g.is_mutable);
+            return Some((SemanticTokenKind::Global, readonly));
+        }
+        "module_field_table" | "import_desc_table_type" => SemanticTokenKind::Table,
+        "module_field_memory" | "import_desc_memory_type" => SemanticTokenKind::Memory,
+        "module_field_type" | "module_field_rec" => SemanticTokenKind::Type,
+        "module_field_tag" | "import_desc_tag_type" => SemanticTokenKind::Tag,
+        "module_field_data" => SemanticTokenKind::Data,
+        "module_field_elem" => SemanticTokenKind::Elem,
+        "func_locals_one" => SemanticTokenKind::Local,
+        "func_type_params_one" => SemanticTokenKind::Parameter,
+        "field_type" => SemanticTokenKind::Property,
+        k if is_block_kind(k) => SemanticTokenKind::Label,
+        _ => return None,
+    };
+    Some((kind, false))
+}
+
+/// Determine the reference context for an identifier or index by walking up
+/// the tree. Unlike `determine_instruction_context`, this stops at the first
+/// enclosing plain instruction: an operand of `i32.const` must not inherit the
+/// context of an outer `call` expression.
+fn reference_context(node: &Node, document: &str) -> RefContext {
+    // Catch clauses need positional disambiguation (first index is the tag,
+    // the rest are branch labels).
+    if let Some(ctx) = determine_catch_clause_context(node, document) {
+        return match ctx {
+            InstructionContext::Tag => RefContext::Tag,
+            _ => RefContext::Label,
+        };
+    }
+
+    let original_start = node.start_byte();
+    let mut current = node_copy!(node);
+
+    loop {
+        node_kind!(kind = current);
+        match kind {
+            // The nearest plain instruction decides; if it takes no symbolic
+            // operand (e.g. i32.const), the token is a literal.
+            "instr_plain" | "expr1_plain" => {
+                return context_from_instruction_text(&document[current.byte_range()])
+                    .map_or(RefContext::Literal, instruction_ref_context);
+            }
+            // call_indirect / return_call_indirect: a direct index child is the
+            // table; the type is wrapped in type_use (matched before we get here).
+            "instr_call" | "expr1_call" | "instr_list_call" => return RefContext::Table,
+            "type_use" | "ref_type_ref" | "ref_type_concrete" | "module_field_type"
+            | "module_field_rec" => return RefContext::Type,
+            "export_desc_func" | "module_field_start" => return RefContext::Function,
+            "export_desc_global" => return RefContext::Global,
+            "export_desc_table" | "table_use" => return RefContext::Table,
+            "export_desc_memory" | "memory_use" => return RefContext::Memory,
+            "export_desc_tag" => return RefContext::Tag,
+            // (elem func $f1 $f2 ...) — indexes are function references
+            "elem_list" => {
+                if crate::utils::find_child_by_kind(&current, "elem_kind").is_some() {
+                    return RefContext::Function;
+                }
+            }
+            // Bare indexes after the offset in (elem (i32.const 0) $f) are
+            // function references; anything else in the elem field is not.
+            "module_field_elem" => {
+                let mut cursor = current.walk();
+                let mut past_offset = false;
+                for child in current.children(&mut cursor) {
+                    node_kind!(ck = child);
+                    if ck == "offset" {
+                        past_offset = true;
+                    } else if ck == "index" && past_offset {
+                        let cr = child.byte_range();
+                        if cr.start <= original_start && original_start < cr.end {
+                            return RefContext::Function;
+                        }
+                    }
+                }
+                return RefContext::Literal;
+            }
+            _ => {}
+        }
+
+        match current.parent() {
+            Some(parent) => current = parent,
+            None => break,
+        }
+    }
+
+    RefContext::General
+}
+
+fn instruction_ref_context(ctx: InstructionContext) -> RefContext {
+    match ctx {
+        InstructionContext::Call => RefContext::Function,
+        InstructionContext::Global => RefContext::Global,
+        InstructionContext::Local => RefContext::Local,
+        InstructionContext::Branch | InstructionContext::Block => RefContext::Label,
+        InstructionContext::Table => RefContext::Table,
+        InstructionContext::Memory => RefContext::Memory,
+        InstructionContext::Type => RefContext::Type,
+        InstructionContext::Tag => RefContext::Tag,
+        InstructionContext::Data => RefContext::Data,
+        InstructionContext::Elem => RefContext::Elem,
+        InstructionContext::Function | InstructionContext::General => RefContext::General,
+    }
+}
+
+/// True if any struct type in the module has a field with this name.
+fn is_struct_field_name(symbols: &SymbolTable, name: &str) -> bool {
+    symbols.types.iter().any(|t| {
+        matches!(&t.kind, TypeKind::Struct { fields }
+            if fields.iter().any(|(n, _, _)| n.as_deref() == Some(name)))
+    })
+}
+
+fn classify_identifier(
+    node: &Node,
+    document: &str,
+    modules: &[ModuleInfo],
+    tokens: &mut Vec<SemanticTokenInfo>,
+) {
+    let text = &document[node.byte_range()];
+    let line = node.start_position().row as u32;
+
+    // Declaration sites: the identifier is a direct child of its defining form.
+    if let Some(parent) = node.parent() {
+        node_kind!(pk = parent);
+        if let Some((kind, readonly)) = declaration_kind(pk, text, modules, line) {
+            push_token(tokens, node, kind, true, readonly);
+            return;
+        }
+    }
+
+    let Some(symbols) = symbols_for_line(modules, line) else {
+        return;
+    };
+    let position = Position::new(line, node.start_position().column as u32);
+
+    let token = match reference_context(node, document) {
+        RefContext::Function => symbols
+            .get_function_by_name(text)
+            .map(|_| (SemanticTokenKind::Function, false)),
+        RefContext::Global => symbols
+            .get_global_by_name(text)
+            .map(|g| (SemanticTokenKind::Global, !g.is_mutable)),
+        RefContext::Local => resolve_local_name(symbols, position, text),
+        RefContext::Label => find_containing_function(symbols, position)
+            .and_then(|f| find_block_in_function(text, f))
+            .map(|_| (SemanticTokenKind::Label, false)),
+        RefContext::Table => symbols
+            .get_table_by_name(text)
+            .map(|_| (SemanticTokenKind::Table, false)),
+        RefContext::Memory => symbols
+            .get_memory_by_name(text)
+            .map(|_| (SemanticTokenKind::Memory, false)),
+        RefContext::Type => resolve_type_context_name(symbols, position, text),
+        RefContext::Tag => symbols
+            .get_tag_by_name(text)
+            .map(|_| (SemanticTokenKind::Tag, false)),
+        RefContext::Data => symbols
+            .get_data_by_name(text)
+            .map(|_| (SemanticTokenKind::Data, false))
+            .or_else(|| {
+                // memory.init $mem $data — first index is the memory
+                symbols
+                    .get_memory_by_name(text)
+                    .map(|_| (SemanticTokenKind::Memory, false))
+            }),
+        RefContext::Elem => symbols
+            .get_elem_by_name(text)
+            .map(|_| (SemanticTokenKind::Elem, false))
+            .or_else(|| {
+                // table.init $table $elem — first index is the table
+                symbols
+                    .get_table_by_name(text)
+                    .map(|_| (SemanticTokenKind::Table, false))
+            }),
+        RefContext::General => resolve_general_name(symbols, position, text),
+        RefContext::Literal => None,
+    };
+
+    if let Some((kind, readonly)) = token {
+        push_token(tokens, node, kind, false, readonly);
+    }
+}
+
+/// Resolve a named local-context reference to a parameter or local.
+fn resolve_local_name(
+    symbols: &SymbolTable,
+    position: Position,
+    text: &str,
+) -> Option<(SemanticTokenKind, bool)> {
+    let func = find_containing_function(symbols, position)?;
+    if find_param_in_function(text, func).is_some() {
+        Some((SemanticTokenKind::Parameter, false))
+    } else {
+        find_local_in_function(text, func).map(|_| (SemanticTokenKind::Local, false))
+    }
+}
+
+/// Resolve a Type-context identifier: type name, struct field, or (for
+/// br_on_cast-style instructions whose first index is a label) a block label.
+fn resolve_type_context_name(
+    symbols: &SymbolTable,
+    position: Position,
+    text: &str,
+) -> Option<(SemanticTokenKind, bool)> {
+    if symbols.get_type_by_name(text).is_some() {
+        return Some((SemanticTokenKind::Type, false));
+    }
+    if is_struct_field_name(symbols, text) {
+        return Some((SemanticTokenKind::Property, false));
+    }
+    find_containing_function(symbols, position)
+        .and_then(|f| find_block_in_function(text, f))
+        .map(|_| (SemanticTokenKind::Label, false))
+}
+
+/// Fallback resolution when no syntactic context was found, mirroring the
+/// lookup order used by references' General context.
+fn resolve_general_name(
+    symbols: &SymbolTable,
+    position: Position,
+    text: &str,
+) -> Option<(SemanticTokenKind, bool)> {
+    if symbols.get_function_by_name(text).is_some() {
+        return Some((SemanticTokenKind::Function, false));
+    }
+    if let Some(func) = find_containing_function(symbols, position) {
+        if find_param_in_function(text, func).is_some() {
+            return Some((SemanticTokenKind::Parameter, false));
+        }
+        if find_local_in_function(text, func).is_some() {
+            return Some((SemanticTokenKind::Local, false));
+        }
+        if find_block_in_function(text, func).is_some() {
+            return Some((SemanticTokenKind::Label, false));
+        }
+    }
+    if let Some(global) = symbols.get_global_by_name(text) {
+        return Some((SemanticTokenKind::Global, !global.is_mutable));
+    }
+    if symbols.get_table_by_name(text).is_some() {
+        return Some((SemanticTokenKind::Table, false));
+    }
+    if symbols.get_memory_by_name(text).is_some() {
+        return Some((SemanticTokenKind::Memory, false));
+    }
+    if symbols.get_type_by_name(text).is_some() {
+        return Some((SemanticTokenKind::Type, false));
+    }
+    if symbols.get_tag_by_name(text).is_some() {
+        return Some((SemanticTokenKind::Tag, false));
+    }
+    if symbols.get_data_by_name(text).is_some() {
+        return Some((SemanticTokenKind::Data, false));
+    }
+    if symbols.get_elem_by_name(text).is_some() {
+        return Some((SemanticTokenKind::Elem, false));
+    }
+    if is_struct_field_name(symbols, text) {
+        return Some((SemanticTokenKind::Property, false));
+    }
+    None
+}
+
+fn classify_nat(
+    node: &Node,
+    document: &str,
+    modules: &[ModuleInfo],
+    tokens: &mut Vec<SemanticTokenInfo>,
+) {
+    let text = &document[node.byte_range()];
+    let Some(index) = crate::parser::parse_wat_nat(text).map(|v| v as usize) else {
+        return;
+    };
+
+    let line = node.start_position().row as u32;
+    let Some(symbols) = symbols_for_line(modules, line) else {
+        return;
+    };
+    let position = Position::new(line, node.start_position().column as u32);
+
+    let token = match reference_context(node, document) {
+        RefContext::Function => symbols
+            .get_function_by_index(index)
+            .map(|_| (SemanticTokenKind::Function, false)),
+        RefContext::Global => symbols
+            .get_global_by_index(index)
+            .map(|g| (SemanticTokenKind::Global, !g.is_mutable)),
+        RefContext::Local => find_containing_function(symbols, position).and_then(|func| {
+            if index < func.parameters.len() {
+                Some((SemanticTokenKind::Parameter, false))
+            } else {
+                func.locals
+                    .get(index - func.parameters.len())
+                    .map(|_| (SemanticTokenKind::Local, false))
+            }
+        }),
+        // Numeric branch targets are relative depths; color them as labels
+        // whenever they appear inside a function.
+        RefContext::Label => {
+            find_containing_function(symbols, position).map(|_| (SemanticTokenKind::Label, false))
+        }
+        RefContext::Table => symbols
+            .get_table_by_index(index)
+            .map(|_| (SemanticTokenKind::Table, false)),
+        RefContext::Memory => symbols
+            .get_memory_by_index(index)
+            .map(|_| (SemanticTokenKind::Memory, false)),
+        RefContext::Type => symbols
+            .get_type_by_index(index)
+            .map(|_| (SemanticTokenKind::Type, false)),
+        RefContext::Tag => symbols
+            .get_tag_by_index(index)
+            .map(|_| (SemanticTokenKind::Tag, false)),
+        RefContext::Data => symbols
+            .get_data_by_index(index)
+            .map(|_| (SemanticTokenKind::Data, false)),
+        RefContext::Elem => symbols
+            .get_elem_by_index(index)
+            .map(|_| (SemanticTokenKind::Elem, false)),
+        // Bare numbers with no symbolic context are literals.
+        RefContext::General | RefContext::Literal => None,
+    };
+
+    if let Some((kind, readonly)) = token {
+        push_token(tokens, node, kind, false, readonly);
+    }
+}
+
+// ============================================================================
+// Native LSP wrapper — legend and delta encoding
+// ============================================================================
+
+#[cfg(feature = "native")]
+use tower_lsp::lsp_types::{Range, SemanticToken, SemanticTokenModifier, SemanticTokenType};
+
+/// Token types legend. Index into this array = `token_type` on the wire.
+#[cfg(feature = "native")]
+pub const TOKEN_TYPES: [SemanticTokenType; 8] = [
+    SemanticTokenType::FUNCTION,     // 0
+    SemanticTokenType::PARAMETER,    // 1
+    SemanticTokenType::VARIABLE,     // 2: locals, globals, tables, memories, data, elems
+    SemanticTokenType::TYPE,         // 3
+    SemanticTokenType::PROPERTY,     // 4: struct fields
+    SemanticTokenType::EVENT,        // 5: exception tags
+    SemanticTokenType::NAMESPACE,    // 6: module names
+    SemanticTokenType::new("label"), // 7: block labels (rust-analyzer precedent)
+];
+
+/// Token modifiers legend. Bit position in this array = bit in the wire bitset.
+#[cfg(feature = "native")]
+pub const TOKEN_MODIFIERS: [SemanticTokenModifier; 3] = [
+    SemanticTokenModifier::DECLARATION, // 1 << 0
+    SemanticTokenModifier::READONLY,    // 1 << 1
+    SemanticTokenModifier::STATIC,      // 1 << 2: module-level entities
+];
+
+#[cfg(feature = "native")]
+fn token_type_index(kind: SemanticTokenKind) -> u32 {
+    match kind {
+        SemanticTokenKind::Function => 0,
+        SemanticTokenKind::Parameter => 1,
+        SemanticTokenKind::Local
+        | SemanticTokenKind::Global
+        | SemanticTokenKind::Table
+        | SemanticTokenKind::Memory
+        | SemanticTokenKind::Data
+        | SemanticTokenKind::Elem => 2,
+        SemanticTokenKind::Type => 3,
+        SemanticTokenKind::Property => 4,
+        SemanticTokenKind::Tag => 5,
+        SemanticTokenKind::Module => 6,
+        SemanticTokenKind::Label => 7,
+    }
+}
+
+#[cfg(feature = "native")]
+fn token_modifier_bitset(token: &SemanticTokenInfo) -> u32 {
+    let mut bits = 0;
+    if token.is_declaration {
+        bits |= 1 << 0;
+    }
+    if token.is_readonly {
+        bits |= 1 << 1;
+    }
+    if matches!(
+        token.kind,
+        SemanticTokenKind::Global
+            | SemanticTokenKind::Table
+            | SemanticTokenKind::Memory
+            | SemanticTokenKind::Data
+            | SemanticTokenKind::Elem
+    ) {
+        bits |= 1 << 2;
+    }
+    bits
+}
+
+/// Delta-encode absolute tokens into the LSP wire format.
+#[cfg(feature = "native")]
+fn encode_tokens(tokens: &[SemanticTokenInfo]) -> Vec<SemanticToken> {
+    let mut prev_line = 0u32;
+    let mut prev_start = 0u32;
+    tokens
+        .iter()
+        .map(|t| {
+            let delta_line = t.line - prev_line;
+            let delta_start = if delta_line == 0 {
+                t.start_char - prev_start
+            } else {
+                t.start_char
+            };
+            prev_line = t.line;
+            prev_start = t.start_char;
+            SemanticToken {
+                delta_line,
+                delta_start,
+                length: t.length,
+                token_type: token_type_index(t.kind),
+                token_modifiers_bitset: token_modifier_bitset(t),
+            }
+        })
+        .collect()
+}
+
+/// Full-document semantic tokens in LSP wire format (native wrapper).
+#[cfg(feature = "native")]
+pub fn provide_semantic_tokens_lsp(
+    document: &str,
+    modules: &[ModuleInfo],
+    tree: &Tree,
+) -> Vec<SemanticToken> {
+    encode_tokens(&provide_semantic_tokens(document, modules, tree))
+}
+
+/// Semantic tokens for a document range in LSP wire format (native wrapper).
+#[cfg(feature = "native")]
+pub fn provide_semantic_tokens_range_lsp(
+    document: &str,
+    modules: &[ModuleInfo],
+    tree: &Tree,
+    range: Range,
+) -> Vec<SemanticToken> {
+    let tokens: Vec<SemanticTokenInfo> = provide_semantic_tokens(document, modules, tree)
+        .into_iter()
+        .filter(|t| t.line >= range.start.line && t.line <= range.end.line)
+        .collect();
+    encode_tokens(&tokens)
+}

--- a/src/features/semantic_tokens/tests.rs
+++ b/src/features/semantic_tokens/tests.rs
@@ -1,0 +1,339 @@
+use super::*;
+use crate::parser::parse_modules_from_tree;
+use crate::tree_sitter_bindings::create_parser;
+
+/// Parse a document and produce semantic tokens.
+fn tokens_for(source: &str) -> Vec<SemanticTokenInfo> {
+    let mut parser = create_parser();
+    let tree = parser.parse(source, None).unwrap();
+    let modules = parse_modules_from_tree(&tree, source).unwrap();
+    provide_semantic_tokens(source, &modules, &tree)
+}
+
+/// Find the (line, character) of the nth occurrence of `needle` in `source`.
+fn pos_of(source: &str, needle: &str, occurrence: usize) -> (u32, u32) {
+    let mut seen = 0;
+    for (line_num, line) in source.lines().enumerate() {
+        let mut from = 0;
+        while let Some(col) = line[from..].find(needle) {
+            if seen == occurrence {
+                return (line_num as u32, (from + col) as u32);
+            }
+            seen += 1;
+            from += col + 1;
+        }
+    }
+    panic!("occurrence {} of {:?} not found", occurrence, needle);
+}
+
+/// Find the token covering a given position, if any.
+fn token_at(tokens: &[SemanticTokenInfo], line: u32, ch: u32) -> Option<&SemanticTokenInfo> {
+    tokens
+        .iter()
+        .find(|t| t.line == line && t.start_char <= ch && ch < t.start_char + t.length)
+}
+
+/// Assert a token exists `offset` characters into the nth occurrence of
+/// `needle` (the offset points at the identifier/index inside the needle).
+fn expect_token<'a>(
+    tokens: &'a [SemanticTokenInfo],
+    source: &str,
+    needle: &str,
+    occurrence: usize,
+    offset: u32,
+) -> &'a SemanticTokenInfo {
+    let (line, ch) = pos_of(source, needle, occurrence);
+    token_at(tokens, line, ch + offset).unwrap_or_else(|| {
+        panic!(
+            "no token at occurrence {} of {:?} + {} (line {}, char {})",
+            occurrence,
+            needle,
+            offset,
+            line,
+            ch + offset
+        )
+    })
+}
+
+const SAMPLE: &str = r#"(module
+  (type $point (struct (field $x (mut f64)) (field $y (mut f64))))
+  (import "env" "ext" (func $ext (param i32)))
+  (global $counter (mut i32) (i32.const 0))
+  (global $limit i32 (i32.const 10))
+  (memory $mem 1)
+  (table $tbl 1 funcref)
+  (tag $err (param i32))
+  (func $add (param $a i32) (param $b i32) (result i32)
+    (local $sum i32)
+    local.get $a
+    local.get $b
+    i32.add
+    local.set $sum
+    global.get $limit
+    drop
+    local.get $sum)
+  (func $main
+    (block $exit
+      (loop $top
+        global.get $counter
+        drop
+        br $top))
+    (call $add (i32.const 1) (i32.const 2))
+    drop)
+  (start $main)
+  (export "add" (func $add))
+)"#;
+
+#[test]
+fn test_function_declaration_and_references() {
+    let tokens = tokens_for(SAMPLE);
+
+    let decl = expect_token(&tokens, SAMPLE, "func $add", 0, 5);
+    assert_eq!(decl.kind, SemanticTokenKind::Function);
+    assert!(decl.is_declaration);
+    assert_eq!(decl.length, 4);
+
+    let call_ref = expect_token(&tokens, SAMPLE, "call $add", 0, 5);
+    assert_eq!(call_ref.kind, SemanticTokenKind::Function);
+    assert!(!call_ref.is_declaration);
+
+    // (export "add" (func $add)) — second occurrence of "func $add"
+    let export_ref = expect_token(&tokens, SAMPLE, "func $add", 1, 5);
+    assert_eq!(export_ref.kind, SemanticTokenKind::Function);
+    assert!(!export_ref.is_declaration);
+}
+
+#[test]
+fn test_imported_function_declaration() {
+    let tokens = tokens_for(SAMPLE);
+    let decl = expect_token(&tokens, SAMPLE, "func $ext", 0, 5);
+    assert_eq!(decl.kind, SemanticTokenKind::Function);
+    assert!(decl.is_declaration);
+}
+
+#[test]
+fn test_params_and_locals() {
+    let tokens = tokens_for(SAMPLE);
+
+    let param_decl = expect_token(&tokens, SAMPLE, "param $a", 0, 6);
+    assert_eq!(param_decl.kind, SemanticTokenKind::Parameter);
+    assert!(param_decl.is_declaration);
+
+    let param_ref = expect_token(&tokens, SAMPLE, "local.get $a", 0, 10);
+    assert_eq!(param_ref.kind, SemanticTokenKind::Parameter);
+    assert!(!param_ref.is_declaration);
+
+    let local_decl = expect_token(&tokens, SAMPLE, "local $sum", 0, 7);
+    assert_eq!(local_decl.kind, SemanticTokenKind::Local);
+    assert!(local_decl.is_declaration);
+
+    let local_ref = expect_token(&tokens, SAMPLE, "local.set $sum", 0, 10);
+    assert_eq!(local_ref.kind, SemanticTokenKind::Local);
+    assert!(!local_ref.is_declaration);
+}
+
+#[test]
+fn test_globals_readonly_modifier() {
+    let tokens = tokens_for(SAMPLE);
+
+    let mutable_decl = expect_token(&tokens, SAMPLE, "global $counter", 0, 7);
+    assert_eq!(mutable_decl.kind, SemanticTokenKind::Global);
+    assert!(mutable_decl.is_declaration);
+    assert!(!mutable_decl.is_readonly);
+
+    let immutable_decl = expect_token(&tokens, SAMPLE, "global $limit", 0, 7);
+    assert_eq!(immutable_decl.kind, SemanticTokenKind::Global);
+    assert!(immutable_decl.is_readonly);
+
+    let immutable_ref = expect_token(&tokens, SAMPLE, "global.get $limit", 0, 11);
+    assert_eq!(immutable_ref.kind, SemanticTokenKind::Global);
+    assert!(!immutable_ref.is_declaration);
+    assert!(immutable_ref.is_readonly);
+
+    let mutable_ref = expect_token(&tokens, SAMPLE, "global.get $counter", 0, 11);
+    assert_eq!(mutable_ref.kind, SemanticTokenKind::Global);
+    assert!(!mutable_ref.is_readonly);
+}
+
+#[test]
+fn test_block_labels() {
+    let tokens = tokens_for(SAMPLE);
+
+    let block_decl = expect_token(&tokens, SAMPLE, "block $exit", 0, 6);
+    assert_eq!(block_decl.kind, SemanticTokenKind::Label);
+    assert!(block_decl.is_declaration);
+
+    let loop_decl = expect_token(&tokens, SAMPLE, "loop $top", 0, 5);
+    assert_eq!(loop_decl.kind, SemanticTokenKind::Label);
+    assert!(loop_decl.is_declaration);
+
+    let br_ref = expect_token(&tokens, SAMPLE, "br $top", 0, 3);
+    assert_eq!(br_ref.kind, SemanticTokenKind::Label);
+    assert!(!br_ref.is_declaration);
+}
+
+#[test]
+fn test_type_and_struct_fields() {
+    let tokens = tokens_for(SAMPLE);
+
+    let type_decl = expect_token(&tokens, SAMPLE, "type $point", 0, 5);
+    assert_eq!(type_decl.kind, SemanticTokenKind::Type);
+    assert!(type_decl.is_declaration);
+
+    let field_decl = expect_token(&tokens, SAMPLE, "field $x", 0, 6);
+    assert_eq!(field_decl.kind, SemanticTokenKind::Property);
+    assert!(field_decl.is_declaration);
+}
+
+#[test]
+fn test_module_level_entities() {
+    let tokens = tokens_for(SAMPLE);
+
+    let mem = expect_token(&tokens, SAMPLE, "memory $mem", 0, 7);
+    assert_eq!(mem.kind, SemanticTokenKind::Memory);
+
+    let tbl = expect_token(&tokens, SAMPLE, "table $tbl", 0, 6);
+    assert_eq!(tbl.kind, SemanticTokenKind::Table);
+
+    let tag = expect_token(&tokens, SAMPLE, "tag $err", 0, 4);
+    assert_eq!(tag.kind, SemanticTokenKind::Tag);
+}
+
+#[test]
+fn test_start_references_function() {
+    let tokens = tokens_for(SAMPLE);
+    let start_ref = expect_token(&tokens, SAMPLE, "start $main", 0, 6);
+    assert_eq!(start_ref.kind, SemanticTokenKind::Function);
+    assert!(!start_ref.is_declaration);
+}
+
+#[test]
+fn test_numeric_indices() {
+    let source = r#"(module
+  (global $g (mut i32) (i32.const 0))
+  (func $f (param i32) (result i32)
+    (local i32)
+    local.get 0
+    local.set 1
+    global.get 0
+    drop
+    call 0)
+)"#;
+    let tokens = tokens_for(source);
+
+    let param_ref = expect_token(&tokens, source, "local.get 0", 0, 10);
+    assert_eq!(param_ref.kind, SemanticTokenKind::Parameter);
+
+    let local_ref = expect_token(&tokens, source, "local.set 1", 0, 10);
+    assert_eq!(local_ref.kind, SemanticTokenKind::Local);
+
+    let global_ref = expect_token(&tokens, source, "global.get 0", 0, 11);
+    assert_eq!(global_ref.kind, SemanticTokenKind::Global);
+
+    let call_ref = expect_token(&tokens, source, "call 0", 0, 5);
+    assert_eq!(call_ref.kind, SemanticTokenKind::Function);
+}
+
+#[test]
+fn test_const_operands_are_not_tokens() {
+    let source = r#"(module
+  (func $f (result i32)
+    i32.const 0
+    (i32.add (i32.const 1) (i32.const 2)))
+)"#;
+    let tokens = tokens_for(source);
+
+    // None of the i32.const operands should produce a token, even though a
+    // function with index 0 exists.
+    for occurrence in 0..3 {
+        let (line, ch) = pos_of(source, "i32.const ", occurrence);
+        assert!(
+            token_at(&tokens, line, ch + 10).is_none(),
+            "i32.const operand {} should not be classified",
+            occurrence
+        );
+    }
+}
+
+#[test]
+fn test_unresolved_reference_gets_no_token() {
+    let source = r#"(module
+  (func $f
+    call $undefined)
+)"#;
+    let tokens = tokens_for(source);
+    let (line, ch) = pos_of(source, "$undefined", 0);
+    assert!(token_at(&tokens, line, ch).is_none());
+}
+
+#[test]
+fn test_multi_module_resolution() {
+    let source = r#"(module
+  (func $f (result i32) (i32.const 1))
+)
+(module
+  (global $g i32 (i32.const 2))
+  (func $f (result i32)
+    global.get $g)
+)"#;
+    let tokens = tokens_for(source);
+
+    // $f declared in both modules
+    let decl_a = expect_token(&tokens, source, "func $f", 0, 5);
+    assert_eq!(decl_a.kind, SemanticTokenKind::Function);
+    assert!(decl_a.is_declaration);
+    let decl_b = expect_token(&tokens, source, "func $f", 1, 5);
+    assert_eq!(decl_b.kind, SemanticTokenKind::Function);
+    assert!(decl_b.is_declaration);
+
+    // $g reference resolves against the second module's symbols
+    let g_ref = expect_token(&tokens, source, "global.get $g", 0, 11);
+    assert_eq!(g_ref.kind, SemanticTokenKind::Global);
+    assert!(g_ref.is_readonly);
+}
+
+#[test]
+fn test_tokens_sorted_by_position() {
+    let tokens = tokens_for(SAMPLE);
+    assert!(!tokens.is_empty());
+    for pair in tokens.windows(2) {
+        assert!(
+            (pair[0].line, pair[0].start_char) <= (pair[1].line, pair[1].start_char),
+            "tokens must be sorted by document position"
+        );
+    }
+}
+
+#[test]
+fn test_delta_encoding() {
+    let source = "(module (func $f) (start $f))";
+    let mut parser = create_parser();
+    let tree = parser.parse(source, None).unwrap();
+    let modules = parse_modules_from_tree(&tree, source).unwrap();
+
+    let absolute = provide_semantic_tokens(source, &modules, &tree);
+    let encoded = provide_semantic_tokens_lsp(source, &modules, &tree);
+    assert_eq!(absolute.len(), encoded.len());
+
+    // Reconstruct absolute positions from the deltas and compare.
+    let mut line = 0u32;
+    let mut ch = 0u32;
+    for (abs, enc) in absolute.iter().zip(encoded.iter()) {
+        line += enc.delta_line;
+        if enc.delta_line > 0 {
+            ch = enc.delta_start;
+        } else {
+            ch += enc.delta_start;
+        }
+        assert_eq!(
+            (line, ch, enc.length),
+            (abs.line, abs.start_char, abs.length)
+        );
+    }
+
+    // $f decl and $f start-reference must both be functions
+    assert_eq!(encoded[0].token_type, 0);
+    assert_eq!(encoded[0].token_modifiers_bitset & 1, 1); // declaration
+    assert_eq!(encoded[1].token_type, 0);
+    assert_eq!(encoded[1].token_modifiers_bitset & 1, 0);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,9 @@ pub use features::document_symbols;
 pub use features::references;
 
 #[cfg(any(feature = "native", feature = "wasm"))]
+pub use features::semantic_tokens;
+
+#[cfg(any(feature = "native", feature = "wasm"))]
 pub use features::signature;
 
 #[cfg(any(feature = "native", feature = "wasm"))]

--- a/src/native/server.rs
+++ b/src/native/server.rs
@@ -6,7 +6,7 @@
 use crate::parser::ModuleInfo;
 use crate::{
     completion, definition, diagnostics, document_symbols, folding, hover, parser, references,
-    signature, symbols, tree_sitter_bindings, utils,
+    semantic_tokens, signature, symbols, tree_sitter_bindings, utils,
 };
 
 use dashmap::DashMap;
@@ -277,6 +277,19 @@ impl LanguageServer for Backend {
                     work_done_progress_options: WorkDoneProgressOptions::default(),
                 })),
                 folding_range_provider: Some(FoldingRangeProviderCapability::Simple(true)),
+                semantic_tokens_provider: Some(
+                    SemanticTokensServerCapabilities::SemanticTokensOptions(
+                        SemanticTokensOptions {
+                            legend: SemanticTokensLegend {
+                                token_types: semantic_tokens::TOKEN_TYPES.to_vec(),
+                                token_modifiers: semantic_tokens::TOKEN_MODIFIERS.to_vec(),
+                            },
+                            full: Some(SemanticTokensFullOptions::Bool(true)),
+                            range: Some(true),
+                            work_done_progress_options: WorkDoneProgressOptions::default(),
+                        },
+                    ),
+                ),
                 ..Default::default()
             },
         })
@@ -679,6 +692,45 @@ impl LanguageServer for Backend {
                     .show_message(MessageType::WARNING, "No symbol found at position")
                     .await;
             }
+        }
+
+        Ok(None)
+    }
+
+    async fn semantic_tokens_full(
+        &self,
+        params: SemanticTokensParams,
+    ) -> Result<Option<SemanticTokensResult>> {
+        let uri = params.text_document.uri.to_string();
+
+        if let Some((doc, modules, tree)) = self.get_document_context(&uri) {
+            let data = semantic_tokens::provide_semantic_tokens_lsp(&doc, &modules, &tree);
+            return Ok(Some(SemanticTokensResult::Tokens(SemanticTokens {
+                result_id: None,
+                data,
+            })));
+        }
+
+        Ok(None)
+    }
+
+    async fn semantic_tokens_range(
+        &self,
+        params: SemanticTokensRangeParams,
+    ) -> Result<Option<SemanticTokensRangeResult>> {
+        let uri = params.text_document.uri.to_string();
+
+        if let Some((doc, modules, tree)) = self.get_document_context(&uri) {
+            let data = semantic_tokens::provide_semantic_tokens_range_lsp(
+                &doc,
+                &modules,
+                &tree,
+                params.range,
+            );
+            return Ok(Some(SemanticTokensRangeResult::Tokens(SemanticTokens {
+                result_id: None,
+                data,
+            })));
         }
 
         Ok(None)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -224,7 +224,7 @@ pub fn determine_instruction_context_at_node(node: &Node, document: &str) -> Ins
 
 /// Classify instruction text into an InstructionContext using first-word matching.
 /// Avoids repeated `.contains()` scans over the full text.
-fn context_from_instruction_text(instr_text: &str) -> Option<InstructionContext> {
+pub(crate) fn context_from_instruction_text(instr_text: &str) -> Option<InstructionContext> {
     let first_token = instr_text.split_whitespace().next().unwrap_or("");
 
     // Check data/elem segment operations BEFORE general memory/table
@@ -273,7 +273,10 @@ fn context_from_instruction_text(instr_text: &str) -> Option<InstructionContext>
 /// Determine the context for a node inside a catch_clause.
 /// For (catch $tag $label): first index is Tag, second is Branch
 /// For (catch_all $label): single index is Branch
-fn determine_catch_clause_context(node: &Node, document: &str) -> Option<InstructionContext> {
+pub(crate) fn determine_catch_clause_context(
+    node: &Node,
+    document: &str,
+) -> Option<InstructionContext> {
     // Walk up to find the catch_clause and track our position
     let mut current = node_copy!(node);
     let mut index_node: Option<Node> = None;

--- a/src/wasm/api.rs
+++ b/src/wasm/api.rs
@@ -908,15 +908,18 @@ fn capture_name_to_token(name: &str) -> (u32, u32) {
 
         // Types
         "type" | "type.builtin" => (3, 0b10), // builtin modifier
+        "type.definition" => (3, 0b01),       // definition modifier
 
-        // Keywords
+        // Keywords, including instructions (i32.add, local.get, ...): they read
+        // as keywords visually, and mapping them to `function` would repaint
+        // every instruction in the function color.
         "keyword" => (4, 0),
-        "keyword.control" => (4, 0b100000), // control modifier
+        "keyword.control" => (4, 0b100000),   // control modifier
+        "function.instruction" => (4, 0b100), // instruction modifier
 
-        // Functions/Instructions
+        // Functions
         "function" => (5, 0),
         "function.definition" => (5, 0b01), // definition modifier
-        "function.instruction" => (5, 0b100), // instruction modifier
 
         // Variables
         "variable" => (6, 0),

--- a/src/wasm/api.rs
+++ b/src/wasm/api.rs
@@ -12,6 +12,9 @@ use crate::core::types::{
 use crate::folding::{provide_folding_ranges, FoldingRangeKind};
 use crate::hover::provide_hover_core;
 use crate::parser::{parse_document_from_tree, parse_modules_from_tree, ModuleInfo};
+use crate::semantic_tokens::{
+    provide_semantic_tokens as provide_semantic_tokens_core, SemanticTokenInfo, SemanticTokenKind,
+};
 use crate::signature::call_info::{find_function_call, find_function_call_ast, CallType};
 use crate::signature::signature_core::{
     provide_call_ref_signature_core, provide_direct_call_signature_core,
@@ -498,6 +501,10 @@ impl WatLSP {
     /// Provide semantic tokens for syntax highlighting
     /// Returns a flat array of u32 values in Monaco's delta-encoded format:
     /// [deltaLine, deltaStartChar, length, tokenType, tokenModifiers, ...]
+    ///
+    /// Combines the syntactic base (highlights.scm query captures) with
+    /// symbol-resolved semantic classification of identifiers and indices.
+    /// Semantic tokens take precedence where both cover the same position.
     #[wasm_bindgen(js_name = provideSemanticTokens)]
     pub fn provide_semantic_tokens(&self) -> js_sys::Uint32Array {
         let empty = js_sys::Uint32Array::new_with_length(0);
@@ -507,44 +514,69 @@ impl WatLSP {
             None => return empty,
         };
 
-        let query = match &self.highlight_query {
-            Some(q) => q,
-            None => return empty,
-        };
-
-        // Run the query on the root node
-        let root = tree.root_node();
-        let captures = query.captures(&root);
-
-        // Collect all tokens with their positions
+        // Collect all tokens with their positions. Semantic tokens are pushed
+        // FIRST so the stable sort keeps them ahead of query captures at the
+        // same position, and the overlap-skip below drops the capture.
         let mut tokens: Vec<(u32, u32, u32, u32, u32)> = Vec::new();
 
-        for capture in captures {
-            let name = capture.name();
-            let node = capture.node();
-
-            let start_pos = node.start_position();
-            let end_pos = node.end_position();
-
-            // Calculate length (handle multi-line tokens)
-            let length = if start_pos.row == end_pos.row {
-                (end_pos.column - start_pos.column) as u32
-            } else {
-                // For multi-line tokens, just use the first line length
-                // This is a simplification; proper handling would split tokens
-                (node.end_byte() - node.start_byte()) as u32
-            };
-
-            // Map capture name to token type index
-            let (token_type, token_modifiers) = capture_name_to_token(&name);
-
+        // Symbol-resolved tokens; fall back to a synthetic whole-document
+        // module when per-module extraction failed but symbols exist.
+        let synthesized;
+        let modules: &[ModuleInfo] = if !self.modules.is_empty() {
+            &self.modules
+        } else if let Some(symbols) = &self.symbols {
+            let end_line = self.document.lines().count() as u32;
+            synthesized = [ModuleInfo {
+                range: Range::from_coords(0, 0, end_line, 0),
+                symbols: symbols.clone(),
+            }];
+            &synthesized
+        } else {
+            &[]
+        };
+        for token in provide_semantic_tokens_core(&self.document, modules, tree) {
+            let (token_type, token_modifiers) = semantic_token_to_legend(&token);
             tokens.push((
-                start_pos.row as u32,
-                start_pos.column as u32,
-                length,
+                token.line,
+                token.start_char,
+                token.length,
                 token_type,
                 token_modifiers,
             ));
+        }
+
+        // Syntactic base from the highlights.scm query
+        if let Some(query) = &self.highlight_query {
+            let root = tree.root_node();
+            let captures = query.captures(&root);
+
+            for capture in captures {
+                let name = capture.name();
+                let node = capture.node();
+
+                let start_pos = node.start_position();
+                let end_pos = node.end_position();
+
+                // Calculate length (handle multi-line tokens)
+                let length = if start_pos.row == end_pos.row {
+                    (end_pos.column - start_pos.column) as u32
+                } else {
+                    // For multi-line tokens, just use the first line length
+                    // This is a simplification; proper handling would split tokens
+                    (node.end_byte() - node.start_byte()) as u32
+                };
+
+                // Map capture name to token type index
+                let (token_type, token_modifiers) = capture_name_to_token(&name);
+
+                tokens.push((
+                    start_pos.row as u32,
+                    start_pos.column as u32,
+                    length,
+                    token_type,
+                    token_modifiers,
+                ));
+            }
         }
 
         // Sort tokens by position (line, then column)
@@ -617,6 +649,7 @@ impl WatLSP {
         let obj = js_sys::Object::new();
 
         // Token types - must match the indices used in capture_name_to_token
+        // and semantic_token_to_legend
         let types = js_sys::Array::new();
         types.push(&"comment".into()); // 0
         types.push(&"string".into()); // 1
@@ -626,6 +659,11 @@ impl WatLSP {
         types.push(&"function".into()); // 5
         types.push(&"variable".into()); // 6
         types.push(&"operator".into()); // 7
+        types.push(&"parameter".into()); // 8
+        types.push(&"property".into()); // 9: struct fields
+        types.push(&"event".into()); // 10: exception tags
+        types.push(&"namespace".into()); // 11: module names
+        types.push(&"label".into()); // 12: block labels
 
         // Token modifiers - bit flags
         let modifiers = js_sys::Array::new();
@@ -635,6 +673,8 @@ impl WatLSP {
         modifiers.push(&"parameter".into()); // bit 3
         modifiers.push(&"local".into()); // bit 4
         modifiers.push(&"control".into()); // bit 5
+        modifiers.push(&"readonly".into()); // bit 6: immutable globals
+        modifiers.push(&"static".into()); // bit 7: module-level entities
 
         js_sys::Reflect::set(&obj, &"tokenTypes".into(), &types).ok();
         js_sys::Reflect::set(&obj, &"tokenModifiers".into(), &modifiers).ok();
@@ -887,6 +927,46 @@ fn capture_name_to_token(name: &str) -> (u32, u32) {
         // Default to keyword for unknown captures
         _ => (4, 0),
     }
+}
+
+/// Map a symbol-resolved semantic token to (tokenType index, tokenModifiers
+/// bitmask) in the legend defined by get_semantic_tokens_legend.
+fn semantic_token_to_legend(token: &SemanticTokenInfo) -> (u32, u32) {
+    let token_type = match token.kind {
+        SemanticTokenKind::Function => 5,
+        SemanticTokenKind::Type => 3,
+        SemanticTokenKind::Local
+        | SemanticTokenKind::Global
+        | SemanticTokenKind::Table
+        | SemanticTokenKind::Memory
+        | SemanticTokenKind::Data
+        | SemanticTokenKind::Elem => 6,
+        SemanticTokenKind::Parameter => 8,
+        SemanticTokenKind::Property => 9,
+        SemanticTokenKind::Tag => 10,
+        SemanticTokenKind::Module => 11,
+        SemanticTokenKind::Label => 12,
+    };
+
+    let mut modifiers = 0u32;
+    if token.is_declaration {
+        modifiers |= 1 << 0; // definition
+    }
+    if token.is_readonly {
+        modifiers |= 1 << 6; // readonly
+    }
+    if matches!(
+        token.kind,
+        SemanticTokenKind::Global
+            | SemanticTokenKind::Table
+            | SemanticTokenKind::Memory
+            | SemanticTokenKind::Data
+            | SemanticTokenKind::Elem
+    ) {
+        modifiers |= 1 << 7; // static
+    }
+
+    (token_type, modifiers)
 }
 
 impl Default for WatLSP {

--- a/tests/lsp_protocol.rs
+++ b/tests/lsp_protocol.rs
@@ -165,6 +165,7 @@ async fn lifecycle_initialize_shutdown() {
     assert!(caps.get("referencesProvider").is_some());
     assert!(caps.get("renameProvider").is_some());
     assert!(caps.get("foldingRangeProvider").is_some());
+    assert!(caps.get("semanticTokensProvider").is_some());
 
     // Initialized notification
     let notif = Request::build("initialized")
@@ -487,4 +488,38 @@ async fn did_close_clears_diagnostics() {
         last.diagnostics.is_empty(),
         "closing document should clear diagnostics"
     );
+}
+
+#[tokio::test]
+async fn semantic_tokens_full() {
+    let (mut svc, _notifs) = create_service();
+    initialize(&mut svc).await;
+    open_document(&mut svc, TEST_URI, TEST_DOC).await;
+
+    let result = send_request(
+        &mut svc,
+        "textDocument/semanticTokens/full",
+        2,
+        json!({ "textDocument": { "uri": TEST_URI } }),
+    )
+    .await;
+
+    let data = result
+        .get("data")
+        .and_then(Value::as_array)
+        .expect("semantic tokens response should contain a data array");
+    assert!(
+        !data.is_empty() && data.len() % 5 == 0,
+        "token data must be non-empty groups of 5, got {} entries",
+        data.len()
+    );
+
+    // First token in TEST_DOC is the `$add` declaration on line 1, char 8:
+    // deltaLine=1, deltaStart=8, length=4, type=0 (function), modifiers has
+    // the declaration bit set.
+    assert_eq!(data[0].as_u64(), Some(1));
+    assert_eq!(data[1].as_u64(), Some(8));
+    assert_eq!(data[2].as_u64(), Some(4));
+    assert_eq!(data[3].as_u64(), Some(0));
+    assert_eq!(data[4].as_u64().unwrap() & 1, 1);
 }


### PR DESCRIPTION
Implements LSP semantic tokens so editors get symbol-resolved highlighting on top of their base grammar: functions, parameters, locals, globals, types, tags, memories, tables, data/elem segments, struct fields, module names, and block labels each get their true classification, for both `$named` identifiers and numeric indices (`call 0`, `local.get 1`).

## Native LSP

- New shared `features/semantic_tokens` core module (compiles for native and wasm) that walks the tree once and classifies every identifier/index using the existing symbol tables and instruction-context detection.
- Registers `semanticTokensProvider` (full + range) in the server with a legend of standard LSP token types plus a custom `label` type (rust-analyzer precedent), and `declaration`/`readonly`/`static` modifiers (immutable globals get `readonly`).
- Context resolution stops at the first enclosing plain instruction, so literals like the `1` in `(call $f (i32.const 1))` don't inherit the outer call's context. Unresolved references emit no token and stay uncolored.
- Multi-module WAST documents resolve each token against the module containing it.

## WASM API + playground

- `provideSemanticTokens` now merges symbol-resolved tokens (taking precedence) with the syntactic `highlights.scm` base; the legend is extended append-only to keep existing indices stable.
- Fixes a pre-existing bug where `highlights.scm` referenced nonexistent `identifier_pattern`/`annotation_part` nodes, so the query never compiled and `provideSemanticTokens` silently returned an empty array in every deployed build.
- The playground registers a Monaco `DocumentSemanticTokensProvider` and enables semantic highlighting, layered over the existing TextMate base.

Includes 14 unit tests, an end-to-end JSON-RPC protocol test, and was verified headlessly in Node against the compiled wasm bundle.